### PR TITLE
Don't lock on nodejob update, backoff if lock fails

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentEntity.java
@@ -123,6 +123,11 @@ public class DeploymentEntity implements Serializable {
             return null;
         }
 
+		@Override
+		public String toString() {
+			return displayName;
+		}
+
     }
 
     // TODO: Redundant to deploymentState?
@@ -428,4 +433,30 @@ public class DeploymentEntity implements Serializable {
         deploymentParameters.add(deploymentParameter);
     }
 
+	public boolean isPredeploymentFinished() {
+		for (NodeJobEntity job : this.getNodeJobs()) {
+			if (NodeJobEntity.NodeJobStatus.RUNNING.equals(job.getStatus())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public boolean isPredeploymentSuccessful() {
+		for (NodeJobEntity job : this.getNodeJobs()) {
+			if (!NodeJobEntity.NodeJobStatus.SUCCESS.equals(job.getStatus())) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public NodeJobEntity findNodeJobEntity(Integer nodeJobId) {
+		for (NodeJobEntity nodeJob : this.getNodeJobs()) {
+			if (nodeJobId.equals(nodeJob.getId())) {
+				return nodeJob;
+			}
+		}
+		return null;
+	}
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/event/DeploymentEvent.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/event/DeploymentEvent.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 public class DeploymentEvent {
 	
 	public enum DeploymentEventType {
-		NEW, UPDATE;
+		NEW, UPDATE, NODE_JOB_UPDATE;
 	}
 	
 	private DeploymentEventType eventType;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/scheduler/DeploymentScheduler.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/scheduler/DeploymentScheduler.java
@@ -128,7 +128,6 @@ public class DeploymentScheduler {
 			executeSimulation();
 			executePreDeployments();
 			break;
-
 		case UPDATE:
 			switch(event.getNewState()) {
 			case READY_FOR_DEPLOYMENT:
@@ -139,9 +138,10 @@ public class DeploymentScheduler {
 				else{
 					executeDeployments();
 				}
-				
 				break;
 			}
+		case NODE_JOB_UPDATE:
+			deploymentService.handleNodeJobUpdate(event.getDeploymentId());
 		}
 	}
 	
@@ -209,7 +209,7 @@ public class DeploymentScheduler {
 		if (!deployments.isEmpty()) {
 			log.log(logLevel, deployments.size() + " deployments inProgress reached timeout");
 			int timeout = ConfigurationService.getPropertyAsInt(ConfigKey.DEPLOYMENT_IN_PROGRESS_TIMEOUT);
-			handleDeploymentsInProgress(deployments, GenerationModus.DEPLOY, timeout);
+			handleDeploymentsTimeout(deployments, GenerationModus.DEPLOY, timeout);
 		}
 		else {
 			log.log(Level.FINE, "No deployments inProgress have reached the timeout");
@@ -222,14 +222,14 @@ public class DeploymentScheduler {
 		if (!deployments.isEmpty()) {
 			log.log(logLevel, deployments.size() + " preDeployments inProgress reached timeout");
 			int timeout = ConfigurationService.getPropertyAsInt(ConfigKey.PREDEPLOYMENT_IN_PROGRESS_TIMEOUT);;
-			handleDeploymentsInProgress(deployments, GenerationModus.PREDEPLOY, timeout);
+			handleDeploymentsTimeout(deployments, GenerationModus.PREDEPLOY, timeout);
 		}
 		else {
 			log.log(Level.FINE, "No preDeployments inProgress have reached the timeout");
 		}
 	}
 
-	protected void handleDeploymentsInProgress(List<DeploymentEntity> deployments, GenerationModus generationModus, int timeout) {
+	protected void handleDeploymentsTimeout(List<DeploymentEntity> deployments, GenerationModus generationModus, int timeout) {
 		for (DeploymentEntity deployment : deployments) {
 			log.log(logLevel, "Deployment (" + deployment.getId()
 					+ ") was marked as failed because it reached the deplyoment timeout");

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestExecuterService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestExecuterService.java
@@ -66,7 +66,7 @@ public class ShakedownTestExecuterService {
 
 		if(shakedownTest != null){
 			// lock ShakedownTest
-			boolean lockSuccessful = lockingService.lockShakedownTestForTesting(shakeDownTestId);
+			boolean lockSuccessful = lockingService.markShakedownTestAsRunning(shakeDownTestId);
 			if (lockSuccessful) {
 				log.info("Locking of ShakedownTest " + shakedownTest.getId() + " successful");
 

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/deploy/control/DeploymentExecuterServiceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/deploy/control/DeploymentExecuterServiceTest.java
@@ -127,7 +127,6 @@ public class DeploymentExecuterServiceTest {
 	@Test
 	public void test_executeDeployment_No_DeploymentFound() {
 		// given
-
 		when(deploymentService.getDeploymentById(Integer.valueOf(1))).thenReturn(null);
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenReturn(null);
@@ -136,13 +135,10 @@ public class DeploymentExecuterServiceTest {
 		deploymentExecuterService.generateConfigurationAndExecuteDeployment(Integer.valueOf(1), GenerationModus.DEPLOY);
 
 		// then
-		verify(deploymentService, times(1)).getDeploymentById(Integer.valueOf(1));
 		verify(generatorDomainServiceWithAppServerRelations, times(0)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(0))
 		.executeDeployment(any(GenerationResult.class), any(DeploymentEntity.class), any(GenerationModus.class));
-		verify(locking, times(0)).lockDeploymentForExecution(any(Integer.class), any(GenerationModus.class));
-		verify(log, times(1)).log(any(Level.class), anyString());
-
+		verify(locking, times(1)).markDeploymentAsRunning(any(Integer.class), any(GenerationModus.class));
 	}
 
 	@Test
@@ -150,17 +146,17 @@ public class DeploymentExecuterServiceTest {
 		// given
 		when(deploymentService.getDeploymentById(deployment.getId())).thenReturn(deployment);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(false);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(false);
 
 		// when
 		deploymentExecuterService.generateConfigurationAndExecuteDeployment(deployment.getId(), GenerationModus.DEPLOY);
 
 		// then
-		verify(deploymentService, times(1)).getDeploymentById(deployment.getId());
+		verify(deploymentService, times(0)).getDeploymentById(deployment.getId());
 		verify(generatorDomainServiceWithAppServerRelations, times(0)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(0))
 		.executeDeployment(any(GenerationResult.class), any(DeploymentEntity.class), any(GenerationModus.class));
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY);
 		verify(log, times(0)).log(any(Level.class), anyString());
 
 	}
@@ -172,7 +168,7 @@ public class DeploymentExecuterServiceTest {
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenReturn(null);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
 		when(entityManager.find(DeploymentEntity.class, deployment.getId())).thenReturn(deployment);
 
 		// when
@@ -184,7 +180,7 @@ public class DeploymentExecuterServiceTest {
 		verify(generatorDomainServiceWithAppServerRelations, times(1)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(0))
 		.executeDeployment(any(GenerationResult.class), any(DeploymentEntity.class), any(GenerationModus.class));
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY);
 		verify(log, times(0)).log(any(Level.class), anyString());
 
 	}
@@ -197,7 +193,7 @@ public class DeploymentExecuterServiceTest {
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenReturn(result);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
 		when(entityManager.find(DeploymentEntity.class, deployment.getId())).thenReturn(deployment);
 
 		// when
@@ -207,7 +203,7 @@ public class DeploymentExecuterServiceTest {
 		verify(deploymentService, times(1)).getDeploymentById(deployment.getId());
 		verify(generatorDomainServiceWithAppServerRelations, times(1)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(1)).executeDeployment(result, deployment, GenerationModus.DEPLOY);
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY);
 		verify(log, times(0)).log(any(Level.class), anyString());
 	}
 
@@ -219,7 +215,7 @@ public class DeploymentExecuterServiceTest {
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenThrow(e);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY)).thenReturn(true);
 		when(entityManager.find(DeploymentEntity.class, deployment.getId())).thenReturn(deployment);
 
 		// when
@@ -230,7 +226,7 @@ public class DeploymentExecuterServiceTest {
 		verify(generatorDomainServiceWithAppServerRelations, times(1)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(0)).executeDeployment(any(GenerationResult.class), any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentExecutionResultHandler, times(1)).handleUnSuccessfulDeployment(GenerationModus.DEPLOY, deployment,null, e);
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.DEPLOY);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.DEPLOY);
 	}
 
 	@Test
@@ -242,7 +238,7 @@ public class DeploymentExecuterServiceTest {
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenReturn(result);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.SIMULATE)).thenReturn(true);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.SIMULATE)).thenReturn(true);
 		when(entityManager.find(DeploymentEntity.class, deployment.getId())).thenReturn(deployment);
 
 		// when
@@ -252,7 +248,7 @@ public class DeploymentExecuterServiceTest {
 		verify(deploymentService, times(1)).getDeploymentById(deployment.getId());
 		verify(generatorDomainServiceWithAppServerRelations, times(1)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(1)).executeDeployment(result, deployment, GenerationModus.SIMULATE);
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.SIMULATE);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.SIMULATE);
 		verify(log, times(0)).log(any(Level.class), anyString());
 	}
 
@@ -266,7 +262,7 @@ public class DeploymentExecuterServiceTest {
 
 		when(generatorDomainServiceWithAppServerRelations.generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class))).thenReturn(result);
 
-		when(locking.lockDeploymentForExecution(deployment.getId(), GenerationModus.SIMULATE)).thenReturn(true);
+		when(locking.markDeploymentAsRunning(deployment.getId(), GenerationModus.SIMULATE)).thenReturn(true);
 		when(entityManager.find(DeploymentEntity.class, deployment.getId())).thenReturn(deployment);
 
 		// when
@@ -276,7 +272,7 @@ public class DeploymentExecuterServiceTest {
 		verify(deploymentService, times(1)).getDeploymentById(deployment.getId());
 		verify(generatorDomainServiceWithAppServerRelations, times(1)).generateConfigurationForDeployment(any(DeploymentEntity.class), any(GenerationModus.class));
 		verify(deploymentAsynchronousExecuter, times(0)).executeDeployment(result, deployment, GenerationModus.SIMULATE);
-		verify(locking, times(1)).lockDeploymentForExecution(deployment.getId(), GenerationModus.SIMULATE);
+		verify(locking, times(1)).markDeploymentAsRunning(deployment.getId(), GenerationModus.SIMULATE);
 		verify(log, times(0)).log(any(Level.class), anyString());
 	}
 }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestExecuterServiceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestExecuterServiceTest.java
@@ -100,7 +100,7 @@ public class ShakedownTestExecuterServiceTest {
 		ShakedownTestGenerationResult generationResult = ShakedownTestGenerationResultBuilder.buildGenerationResultSuccess(resultShakedownTestEntity, null);
 
 		when(shakedownTestService.getShakedownTestById(test.getId())).thenReturn(test);
-		when(locking.lockShakedownTestForTesting(test.getId())).thenReturn(true);
+		when(locking.markShakedownTestAsRunning(test.getId())).thenReturn(true);
 		when(entityManager.find(ShakedownTestEntity.class, test.getId())).thenReturn(test);
 		when(shakedownTestGeneratorDomainService.generateConfigurationForShakedownTest(test)).thenReturn(generationResult);
 
@@ -122,7 +122,7 @@ public class ShakedownTestExecuterServiceTest {
 		ShakedownTestGenerationResult generationResult = ShakedownTestGenerationResultBuilder.mockGenerationResultWithErrors(test, null);
 
 		when(shakedownTestService.getShakedownTestById(test.getId())).thenReturn(test);
-		when(locking.lockShakedownTestForTesting(test.getId())).thenReturn(true);
+		when(locking.markShakedownTestAsRunning(test.getId())).thenReturn(true);
 		when(entityManager.find(ShakedownTestEntity.class, test.getId())).thenReturn(test);
 		when(shakedownTestGeneratorDomainService.generateConfigurationForShakedownTest(test)).thenReturn(generationResult);
 
@@ -142,7 +142,7 @@ public class ShakedownTestExecuterServiceTest {
 		test.setContext(contextEntity);
 
 		when(shakedownTestService.getShakedownTestById(test.getId())).thenReturn(test);
-		when(locking.lockShakedownTestForTesting(test.getId())).thenReturn(true);
+		when(locking.markShakedownTestAsRunning(test.getId())).thenReturn(true);
 		when(entityManager.find(ShakedownTestEntity.class, test.getId())).thenReturn(test);
 		when(shakedownTestGeneratorDomainService.generateConfigurationForShakedownTest(test)).thenReturn(null);
 


### PR DESCRIPTION
Reduces the locks of a deployment dramatically and also reduces the load on the DB when locks happen.
Fixes a bug where locking constantly failed with deployments with more than 8 nodes.
We also had a problem with locks, when the DB was slow.