### PR TITLE
Remove sleep in the deployment locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ response*.GET.html
 .DS_Store
 .m2
 AMW_openshift_deploy/deployments
+AMW_angular/io/node/node

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentService.java
@@ -20,6 +20,49 @@
 
 package ch.puzzle.itc.mobiliar.business.deploy.boundary;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.OptimisticLockException;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.apache.commons.lang.StringUtils;
+
 import ch.puzzle.itc.mobiliar.business.database.control.SequencesService;
 import ch.puzzle.itc.mobiliar.business.deploy.control.DeploymentNotificationService;
 import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity;
@@ -29,8 +72,6 @@ import ch.puzzle.itc.mobiliar.business.deploy.entity.NodeJobEntity;
 import ch.puzzle.itc.mobiliar.business.deploy.entity.NodeJobEntity.NodeJobStatus;
 import ch.puzzle.itc.mobiliar.business.deploy.event.DeploymentEvent;
 import ch.puzzle.itc.mobiliar.business.deploy.event.DeploymentEvent.DeploymentEventType;
-import ch.puzzle.itc.mobiliar.business.deploymentparameter.control.DeploymentParameterRepository;
-import ch.puzzle.itc.mobiliar.business.deploymentparameter.control.KeyRepository;
 import ch.puzzle.itc.mobiliar.business.deploymentparameter.entity.DeploymentParameter;
 import ch.puzzle.itc.mobiliar.business.domain.commons.CommonFilterService;
 import ch.puzzle.itc.mobiliar.business.environment.control.ContextDomainService;
@@ -49,7 +90,12 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.shakedown.control.ShakedownTestService;
-import ch.puzzle.itc.mobiliar.common.exception.*;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import ch.puzzle.itc.mobiliar.common.exception.AMWRuntimeException;
+import ch.puzzle.itc.mobiliar.common.exception.DeploymentStateException;
+import ch.puzzle.itc.mobiliar.common.exception.MultipleVersionsForApplicationException;
+import ch.puzzle.itc.mobiliar.common.exception.NotFoundExcption;
+import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
 import ch.puzzle.itc.mobiliar.common.util.ConfigurationService;
 import ch.puzzle.itc.mobiliar.common.util.ConfigurationService.ConfigKey;
 import ch.puzzle.itc.mobiliar.common.util.CustomFilter;
@@ -57,29 +103,6 @@ import ch.puzzle.itc.mobiliar.common.util.CustomFilter.ComperatorFilterOption;
 import ch.puzzle.itc.mobiliar.common.util.CustomFilter.FilterType;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import ch.puzzle.itc.mobiliar.common.util.Tuple;
-import org.apache.commons.lang.StringUtils;
-
-import javax.ejb.Stateless;
-import javax.ejb.TransactionAttribute;
-import javax.ejb.TransactionAttributeType;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
-import javax.persistence.LockModeType;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import java.io.*;
-import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributeView;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Stateless
 public class DeploymentService {
@@ -201,12 +224,6 @@ public class DeploymentService {
 
     @Inject
     private LockingService lockingService;
-
-    @Inject
-    private KeyRepository keyRepository;
-
-    @Inject
-    private DeploymentParameterRepository deploymentParameterRepository;
 
     private PropertyDescriptorEntity mavenVersionProperty = null;
 
@@ -541,28 +558,37 @@ public class DeploymentService {
 
     public void handleNodeJobUpdate(Integer deploymentId) {
 		DeploymentEntity deployment = getDeploymentById(deploymentId);
-		DeploymentState previousState = deployment.getDeploymentState();
+		log.fine("handleNodeJobUpdate called state: " + deployment.getDeploymentState());
 
 		if (!deployment.isPredeploymentFinished()) {
 			return;
 		}
-		deployment = lockingService.lockDeployment(deploymentId);
-		if (deployment == null) {
+		if (!DeploymentState.PRE_DEPLOYMENT.equals(deployment.getDeploymentState())) {
 			return;
 		}
 
-        if (deployment.isPredeploymentSuccessful()) {
-            deployment.setDeploymentState(DeploymentState.READY_FOR_DEPLOYMENT);
-            deployment.appendStateMessage("All NodeJobs successful, updated deployment state from " + previousState + " to " + deployment.getDeploymentState() + " at " + new Date());
-            log.info("All NodeJobs of deployment " + deployment.getId() + " successful, updated deployment state from " + previousState + " to " + deployment.getDeploymentState().name());
-        }
+		if (deployment.isPredeploymentSuccessful()) {
+			try {
+				handlePreDeploymentSuccessful(deployment);
+			} catch (OptimisticLockException e) {
+				// If it fails the deployment will be retried by the scheduler
+				return;
+			}
+		}
         else {
-            deployment.setDeploymentState(DeploymentState.failed);
-            deployment.appendStateMessage("Deployment (previous state : " + previousState + ") failed due to NodeJob failing at " + new Date());
-            log.info("Deployment " + deployment.getId() + " (previous state : " + previousState + ") failed due to NodeJob failing");
+            updateDeploymentInfoAndSendNotification(GenerationModus.PREDEPLOY, deploymentId, "Deployment (previous state : " + deployment.getDeploymentState() + ") failed due to NodeJob failing at " + new Date(), deployment.getResource().getId(), null);
+            log.info("Deployment " + deployment.getId() + " (previous state : " + deployment.getDeploymentState() + ") failed due to NodeJob failing");
         }
-        em.persist(deployment);
-        deploymentEvent.fire(new DeploymentEvent(DeploymentEventType.UPDATE, deploymentId, deployment.getDeploymentState()));
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    private void handlePreDeploymentSuccessful(DeploymentEntity deployment) {
+		DeploymentState previousState = deployment.getDeploymentState();
+
+        deployment.setDeploymentState(DeploymentState.READY_FOR_DEPLOYMENT);
+        deployment.appendStateMessage("All NodeJobs successful, updated deployment state from " + previousState + " to " + deployment.getDeploymentState() + " at " + new Date());
+        log.info("All NodeJobs of deployment " + deployment.getId() + " successful, updated deployment state from " + previousState + " to " + deployment.getDeploymentState().name());
+        deploymentEvent.fire(new DeploymentEvent(DeploymentEventType.UPDATE, deployment.getId(), deployment.getDeploymentState()));
     }
 
     // TODO test
@@ -786,6 +812,24 @@ public class DeploymentService {
         return query.getResultList();
     }
 
+    /**
+     * Get Deployments that are in PRE_DEPLOYMENT but all of it's nodeJobs finished.
+     *
+     * @return List of DeploymentEntity
+     */
+    public List<DeploymentEntity> getFinishedPreDeployments() {
+        TypedQuery<DeploymentEntity> query = em.createQuery(
+                "select "+ DEPLOYMENT_QL_ALIAS +" from "+ DEPLOYMENT_ENTITY_NAME + " " + DEPLOYMENT_QL_ALIAS
+                + " where " + DEPLOYMENT_QL_ALIAS + ".deploymentState = :deploymentState"
+                + " AND 0 != (select count(id) from " + DEPLOYMENT_QL_ALIAS + ".nodeJobs where deploymentState = :deploymentState)"
+                + " AND (select count(id) from " + DEPLOYMENT_QL_ALIAS + ".nodeJobs where status!=:running and deploymentState = :deploymentState)"
+                + " = (select count(id) from " + DEPLOYMENT_QL_ALIAS + ".nodeJobs where deploymentState = :deploymentState)",
+                		DeploymentEntity.class)
+                .setParameter("deploymentState", DeploymentState.PRE_DEPLOYMENT)
+                .setParameter("running", NodeJobStatus.RUNNING);
+
+        return query.getResultList();
+    }
 
     /**
      * Returns all Deployment to be simulated
@@ -861,7 +905,13 @@ public class DeploymentService {
     @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
     public DeploymentEntity updateDeploymentInfo(GenerationModus generationModus, final Integer deploymentId, final String errorMessage, final Integer resourceId,
                                                  final GenerationResult generationResult) {
-        DeploymentEntity deployment = em.find(DeploymentEntity.class, deploymentId, LockModeType.PESSIMISTIC_FORCE_INCREMENT);
+		// don't lock a deployment for predeployment as there is no need to update the deployment.
+		if (GenerationModus.PREDEPLOY.equals(generationModus) && errorMessage == null) {
+			log.fine("Predeploy script finished at " + new Date());
+			return em.find(DeploymentEntity.class, deploymentId);
+		}
+		DeploymentEntity deployment = em.find(DeploymentEntity.class, deploymentId,
+				LockModeType.PESSIMISTIC_FORCE_INCREMENT);
 
         // set as used for deployment
         if (resourceId != null) {
@@ -879,12 +929,8 @@ public class DeploymentService {
                 deployment.setDeploymentState(DeploymentState.failed);
             }
         } else if (GenerationModus.PREDEPLOY.equals(generationModus)) {
-            if (errorMessage == null) {
-                log.fine("Predeploy script finished at " + new Date());
-            } else {
-                deployment.appendStateMessage(errorMessage);
-                deployment.setDeploymentState(DeploymentState.failed);
-            }
+            deployment.appendStateMessage(errorMessage);
+            deployment.setDeploymentState(DeploymentState.failed);
         } else {
             if (errorMessage == null) {
                 String nodeInfo = getNodeInfoForDeployment(generationResult);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentService.java
@@ -818,15 +818,14 @@ public class DeploymentService {
      * @return List of DeploymentEntity
      */
     public List<DeploymentEntity> getFinishedPreDeployments() {
-        // throws a "Hexadecimal string with odd number of characters" if 'RUNNING' is set via parameter
         TypedQuery<DeploymentEntity> query = em.createQuery(
                 "select "+ DEPLOYMENT_QL_ALIAS +" from "+ DEPLOYMENT_ENTITY_NAME + " " + DEPLOYMENT_QL_ALIAS
-                + " join " + DEPLOYMENT_QL_ALIAS + ".nodeJobs nj"
-                + " where " + DEPLOYMENT_QL_ALIAS + ".deploymentState = :deploymentState and nj.deploymentState = :deploymentState"
-                + " group by " + DEPLOYMENT_QL_ALIAS + ".id "
-                + " having count(case nj.status when 'RUNNING' then 1 else null end) = 0",
+                + " where " + DEPLOYMENT_QL_ALIAS + ".deploymentState = :deploymentState"
+                + " and exists (select 1 from " + DEPLOYMENT_QL_ALIAS + ".nodeJobs where deploymentState = :deploymentState)"
+                + " and not exists (select 1 from " + DEPLOYMENT_QL_ALIAS + ".nodeJobs where status = :running and deploymentState = :deploymentState)",
                 		DeploymentEntity.class)
-                .setParameter("deploymentState", DeploymentState.PRE_DEPLOYMENT);
+                .setParameter("deploymentState", DeploymentState.PRE_DEPLOYMENT)
+                .setParameter("running", NodeJobStatus.RUNNING);
         return query.getResultList();
     }
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentEntity.java
@@ -323,11 +323,11 @@ public class DeploymentEntity implements Serializable {
         setDeploymentCancelDate(new Date());
     }
 
-    public void setDeploymentState(DeploymentState newDeploymentState) {
-        if (deploymentState != null && !deploymentState.isTransitionAllowed(newDeploymentState)) {
-            throw new DeploymentStateException("Can't set status: " + newDeploymentState + ". Allowed states: "
-                    + deploymentState.allowedTransitions);
-        }
+	public void setDeploymentState(DeploymentState newDeploymentState) {
+		if (deploymentState != null && !deploymentState.isTransitionAllowed(newDeploymentState)) {
+			throw new DeploymentStateException("Can't set status from " + deploymentState + " to " + newDeploymentState
+					+ " of deployment " + getId() + ". Allowed transitions: " + deploymentState.allowedTransitions);
+		}
 
         deploymentState = newDeploymentState;
     }
@@ -434,6 +434,9 @@ public class DeploymentEntity implements Serializable {
     }
 
 	public boolean isPredeploymentFinished() {
+		if (this.getNodeJobs().size() == 0) {
+			return false;
+		}
 		for (NodeJobEntity job : this.getNodeJobs()) {
 			if (NodeJobEntity.NodeJobStatus.RUNNING.equals(job.getStatus())) {
 				return false;
@@ -443,6 +446,9 @@ public class DeploymentEntity implements Serializable {
 	}
 
 	public boolean isPredeploymentSuccessful() {
+		if (this.getNodeJobs().size() == 0) {
+			return false;
+		}
 		for (NodeJobEntity job : this.getNodeJobs()) {
 			if (!NodeJobEntity.NodeJobStatus.SUCCESS.equals(job.getStatus())) {
 				return false;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/LockingService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/LockingService.java
@@ -29,13 +29,13 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
 import javax.persistence.LockTimeoutException;
+import javax.persistence.OptimisticLockException;
 
 import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity;
 import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity.DeploymentState;
 import ch.puzzle.itc.mobiliar.business.generator.control.extracted.GenerationModus;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestEntity;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestEntity.shakedownTest_state;
-import ch.puzzle.itc.mobiliar.common.exception.AMWRuntimeException;
 
 @Stateless
 public class LockingService
@@ -47,38 +47,7 @@ public class LockingService
 	@Inject
 	Logger log;
 	
-	private int lockRetries = 3;
-	
-	
-	/**
-	 * Lock a deployment. Must be called in a transaction.
-	 * 
-	 * @param id Deployment id to lock
-	 * @return The locked Deployment entity or null if not possible
-	 */
-	public DeploymentEntity lockDeployment(Integer id) {
-		int count = 0;
-		int backoff = 300;
-		
-		log.fine("Locking deployment " + id);
-		for(; count <= lockRetries; count++) {
-			try {
-				return entityManager.find(DeploymentEntity.class, id, LockModeType.PESSIMISTIC_FORCE_INCREMENT);
-			} catch (LockTimeoutException e) {
-				backoff = getBackoff(backoff);
-				log.info("Retring to lock deployment " + id + " in " + backoff + " ms");
-				try {
-					Thread.sleep(backoff);
-				} catch (InterruptedException e1) {
-					throw new AMWRuntimeException("Exception while waiting to lock deployment " + id, e1);
-				}
-			}
-		}
 
-		log.warning("Locking of deployments " + id + " not possible!");
-		return null;
-	}
-	
 	/**
 	 * Locks the deployment entity and updates it's status to make sure that the deployment is only executed once.
 	 * It requires a new transaction so the changes are committed to the database at the end of the method.
@@ -89,9 +58,13 @@ public class LockingService
 	 */
 	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 	public boolean markDeploymentAsRunning(Integer id, GenerationModus generationModus){
-		DeploymentEntity d = lockDeployment(id);
+		DeploymentEntity d;
 		
-		if(d == null) {
+		log.fine("Locking deployment " + id);
+		try {
+			d = entityManager.find(DeploymentEntity.class, id, LockModeType.PESSIMISTIC_FORCE_INCREMENT);
+		} catch (LockTimeoutException e) {
+			log.warning("Locking of deployments " + id + " not possible!");
 			return false;
 		}
 		
@@ -126,34 +99,24 @@ public class LockingService
 	 */
 	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 	public boolean markShakedownTestAsRunning(Integer id){
-		if (id != null) {
-			try {
-				boolean success = false;
-				ShakedownTestEntity s = entityManager.find(ShakedownTestEntity.class, id, LockModeType.PESSIMISTIC_FORCE_INCREMENT);
-				
-				if (!s.isExecuted()) {
-					log.info("Test of ShakedownTest " + s.getId() + "...");
-					s.setExecuted(true);
-					s.setShakedownTestStateDisplayName(shakedownTest_state.inprogress);
-					entityManager.persist(s);
-					success=true;	
-				} else {
-					log.info("Test " + s.getId() + " was already executed.");
-				}
-				return success;
-			} catch (Exception e) {
-				log.info("Test " + id + " could not be locked.");
-			}
+		ShakedownTestEntity s;
+		log.fine("Locking ShakedownTest " + id);
+		try{
+			s = entityManager.find(ShakedownTestEntity.class, id, LockModeType.PESSIMISTIC_FORCE_INCREMENT);
 		}
-		return false;
+		catch (LockTimeoutException e) {
+			log.warning("Locking of ShakedownTest " + id + " not possible!");
+			return false;
+		}
+
+		if (s.isExecuted()) {
+			log.info("Test " + s.getId() + " was already executed.");
+			return false;
+		}
+		
+		s.setExecuted(true);
+		s.setShakedownTestStateDisplayName(shakedownTest_state.inprogress);
+		entityManager.persist(s);
+		return true;	
 	}
-	
-	/**
-	 * Calculates a new backoff based on the previous backoff. Loosely based on
-	 * a logarithmic algorithm.
-	 */
-	private int getBackoff(int currentBackofflMillis) {
-	    double delta = 0.3d * currentBackofflMillis;
-	    return (int) (1.5 * currentBackofflMillis + (Math.random() * (delta + 1)));
-	  }
 }


### PR DESCRIPTION
Removes the pessimistic lock when updating NodeJobs and eliminates the sleep in the locking service.
Changes:
* Nodejob updates don't update the deployment with a state message anymore. The deployment doesn't have be locked.
* The update of a nodejob and the deployment state change from pre_deployment to progress happens in separate transactions.
* Added scheduler that advances a deployment with nodejobs that are all finished: `checkForFinishedPredeploymentDeployments`. This is only needed if the update via event fails.