### PR TITLE
Distinguish old from new permissions

### DIFF
--- a/AMW_angular/io/src/app/permission/restriction.component.html
+++ b/AMW_angular/io/src/app/permission/restriction.component.html
@@ -8,7 +8,7 @@
         <select id="selectPermission" class="form-control input-sm" [(ngModel)]="restriction.permission.name"
                 (change)="setOld()">
           <option [ngValue]="permission.name" *ngFor="let permission of permissions">{{permission.name}}
-            <span *ngIf="permission.old"> (OLD)</span>
+            <ng-container *ngIf="permission.old"> (OLD)</ng-container>
           </option>
         </select>
       </div>


### PR DESCRIPTION
Distinguish old from new permissions in permissions dropdown (Fixes display issue 1.2)