### PR TITLE
addRelation.xhtml: remove check if a resource is provided twice

### DIFF
--- a/AMW_web/src/main/webapp/resources/mobi/addRelation.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/addRelation.xhtml
@@ -147,7 +147,7 @@
                                                 oncomplete="updateElements();hideLoader();refreshChanges();refreshSubChanges();"/>
                                 </h:commandLink></td>
                                 <td><h:commandLink value="Add as provided Resource"
-                                                   rendered="#{editResourceView.editResource and relationDataProvider.canAddAsProvidedRelation(selectableItem) and relationDataProvider.canBeAddedAsProvidedResource(selectableItem)}"
+                                                   rendered="#{editResourceView.editResource and relationDataProvider.canAddAsProvidedRelation(selectableItem)}"
                                                    onclick="if(confirmLeave(event) &amp;&amp; confirmMatchingRelease(#{editResourceView.existsForThisRelease(selectableItem)})){#{rich:component('addRelationPopup')}.hide();showLoader();}else{return false;}">
                                     <a4j:ajax
                                             listener="#{relationDataProvider.addProvidedResource(selectableItem)}"


### PR DESCRIPTION
With the check some resources with a lot of instances are still slow. Because provided resources is a rarely used feature it is enough to check only after the user has clicked the add the resource link.

Before:
![before](https://user-images.githubusercontent.com/15231595/29811851-1f20f37a-8ca5-11e7-87f1-1258e37be6f5.JPG)

After:
![after](https://user-images.githubusercontent.com/15231595/29811858-27c8c304-8ca5-11e7-9b8c-c73718dbcfd5.JPG)
