### PR TITLE
Bugfix 251 covered properties problem

### DIFF
--- a/AMW_web/src/main/webapp/stylesheets/customized-screen.css
+++ b/AMW_web/src/main/webapp/stylesheets/customized-screen.css
@@ -1764,6 +1764,11 @@ a.expandable:before {
     color: #8b8b8a !important;
 }
 
+/* chrome: avoid a horizontal scroll-bar by changing the zoom level */
+table.propertyTable textarea.propertyInputField {
+    overflow: hidden;
+}
+
 .btn.primary.red {
     background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ff0000), color-stop(100%, #770000));
     background: -webkit-linear-gradient(#ff0000, #770000);


### PR DESCRIPTION
fixes #251 

* No suspicious changes found in the css files nor the xhtml files:
`git diff v1.14.0..v1.15.1 -- \*.css ./AMW_web/src/main/webapp/resources/mobi/editPropertiesTable.xhtml ./AMW_web/src/main/webapp/resources/mobi/propertyEditor.xhtml ./AMW_web/src/main/webapp/pages/editResourceView.xhtml`
* could reproduce it on my chromium 62.0.3202.89 when the zoom is set to 90%.

I suggest to set the overflow to hidden for the properties. I think the horizontal scrollbar is not wished in any zoom level.