### PR TITLE
Set cache max-age of one hour for non static content

### DIFF
--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,0 +1,2 @@
+not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
+not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')


### PR DESCRIPTION
Fixes #255 for EAP7+ and WildFly8+. The bundles created by webpack must be reloaded after 1 hour (3600s)
