### PR TITLE
Don't pass proxy vars to yarn

### DIFF
--- a/AMW_angular/pom.xml
+++ b/AMW_angular/pom.xml
@@ -68,6 +68,7 @@
                         </goals>
                         <configuration>
                             <arguments>run build</arguments>
+                            <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Yarn passes the proxy vars to webpack, which doesn't support these vars:

```
[INFO] --- frontend-maven-plugin:1.6:yarn (yarn build) @ AMW_angular ---
[INFO] Found proxies: [proxy{protocol='https', host='proxy', port=80, with username/passport authentication}]
[INFO] Running 'yarn build --https-proxy=http://proxy:80 --proxy=http://proxy:80' in C:\scm\liima\AMW_angular\io
[INFO] yarn run v1.3.2
[INFO] $ yarn run build:prod --https-proxy=http://proxy:80 --proxy=http://proxy:80
[INFO] $ yarn run clean:dist
[INFO] $ yarn run rimraf dist
[INFO] $ rimraf dist
[INFO] $ webpack --config config/webpack.prod.js  --progress --profile --bail --https-proxy=http://proxy:80 --proxy=http://proxy:80
[ERROR] webpack 2.6.1
[ERROR] Usage: https://webpack.js.org/api/cli/
[ERROR] Usage without config file: webpack <entry> [<entry>] <output>
[ERROR] Usage with config file: webpack
[ERROR]
[ERROR] Config options: ...
```
See also: https://github.com/eirslett/frontend-maven-plugin/issues/660

Whit this change the proxy vars are no longer passed from the maven plugin to `yarn run build`.