### PR TITLE
REST: reload permissions & delete role

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -428,9 +428,11 @@ public class PermissionBoundary implements Serializable {
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_PROPERTY_DECRYPT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEMPLATE.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_RELEASE_COPY_FROM_RESOURCE.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
-            createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
-            createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION_RESULT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
-            createAutoAssignedRestriction(getUserName(), Permission.DEPLOYMENT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
+            if (resource.getResourceType().isApplicationServerResourceType()) {
+                createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
+                createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION_RESULT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
+                createAutoAssignedRestriction(getUserName(), Permission.DEPLOYMENT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
+            }
             reloadCache();
         }
     }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -456,11 +456,12 @@ public class PermissionBoundary implements Serializable {
             throws AMWException {
         if (!delegated || canDelegateThisPermission(permissionName, resourceGroupId, resourceTypeName, contextName, action)) {
             RestrictionEntity restriction = new RestrictionEntity();
+            Integer id = createRestriction(roleName, userName, permissionName, resourceGroupId, resourceTypeName,
+                    resourceTypePermission, contextName, action, restriction);
             if (reload) {
                 reloadCache();
             }
-            return createRestriction(roleName, userName, permissionName, resourceGroupId, resourceTypeName, resourceTypePermission,
-                    contextName, action, restriction);
+            return id;
         }
         throw new AMWException("No permission to create this permission");
     }
@@ -487,16 +488,16 @@ public class PermissionBoundary implements Serializable {
             throw new AMWException("Only ResourceGroupId(s) OR ResourceTypeName(s) must be set");
         }
         if (userNames == null) {
-            userNames = new ArrayList();
+            userNames = new ArrayList<>();
         }
         if (resourceGroupIds == null) {
-            resourceGroupIds = new ArrayList();
+            resourceGroupIds = new ArrayList<>();
         }
         if (resourceTypeNames == null) {
-            resourceTypeNames = new ArrayList();
+            resourceTypeNames = new ArrayList<>();
         }
         if (contextNames == null || contextNames.isEmpty()) {
-            contextNames = new ArrayList();
+            contextNames = new ArrayList<>();
             contextNames.add(null);
         }
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -702,6 +702,19 @@ public class PermissionBoundary implements Serializable {
     }
 
     /**
+     * Removes a role with all it's permissions
+     *
+     * @return List<RoleEntity>
+     */
+    @HasPermission(permission = Permission.ASSIGN_REMOVE_PERMISSION)
+    public void deleteRole(String roleName, boolean reload) {
+        permissionRepository.deleteRole(roleName);
+        if (reload) {
+            reloadCache();
+        }
+    }
+
+    /**
      * Returns a list of all PermissionEntities (used by REST)
      *
      * @return List<PermissionEntity>

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -431,6 +431,7 @@ public class PermissionBoundary implements Serializable {
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION_RESULT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.DEPLOYMENT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
+            permissionRepository.forceReloadingOfLists();
         }
     }
 
@@ -449,10 +450,13 @@ public class PermissionBoundary implements Serializable {
      */
     @HasPermission(oneOfPermission = { Permission.ASSIGN_REMOVE_PERMISSION, Permission.PERMISSION_DELEGATION }, action = Action.CREATE)
     public Integer createRestriction(String roleName, String userName, String permissionName, Integer resourceGroupId, String resourceTypeName,
-                                     ResourceTypePermission resourceTypePermission, String contextName, Action action, boolean delegated)
+                                     ResourceTypePermission resourceTypePermission, String contextName, Action action, boolean delegated, boolean reload)
             throws AMWException {
         if (!delegated || canDelegateThisPermission(permissionName, resourceGroupId, resourceTypeName, contextName, action)) {
             RestrictionEntity restriction = new RestrictionEntity();
+            if (reload) {
+                permissionRepository.forceReloadingOfLists();
+            }
             return createRestriction(roleName, userName, permissionName, resourceGroupId, resourceTypeName, resourceTypePermission,
                     contextName, action, restriction);
         }
@@ -475,7 +479,7 @@ public class PermissionBoundary implements Serializable {
      */
     @HasPermission(oneOfPermission = { Permission.ASSIGN_REMOVE_PERMISSION, Permission.PERMISSION_DELEGATION }, action = Action.CREATE)
     public int createMultipleRestrictions(String roleName, List<String> userNames, List<String> permissionNames, List<Integer> resourceGroupIds, List<String> resourceTypeNames,
-                                              ResourceTypePermission resourceTypePermission, List<String> contextNames, List<Action> actions, boolean delegated) throws AMWException {
+                                              ResourceTypePermission resourceTypePermission, List<String> contextNames, List<Action> actions, boolean delegated, boolean reload) throws AMWException {
         int count = 0;
         if (resourceGroupIds != null && !resourceGroupIds.isEmpty() && resourceTypeNames != null && !resourceTypeNames.isEmpty()) {
             throw new AMWException("Only ResourceGroupId(s) OR ResourceTypeName(s) must be set");
@@ -522,6 +526,9 @@ public class PermissionBoundary implements Serializable {
                 }
             }
         }
+        if (reload) {
+            permissionRepository.forceReloadingOfLists();
+        }
         return count;
     }
 
@@ -562,9 +569,7 @@ public class PermissionBoundary implements Serializable {
         if (permissionService.identicalOrMoreGeneralRestrictionExists(restriction)) {
             return null;
         }
-        final Integer id = restrictionRepository.create(restriction);
-        permissionRepository.forceReloadingOfLists();
-        return id;
+        return restrictionRepository.create(restriction);
     }
 
     private Integer createAutoAssignedRestriction(String userName, String permissionName, Integer resourceGroupId, Action action, RestrictionEntity restriction)
@@ -574,7 +579,6 @@ public class PermissionBoundary implements Serializable {
             return null;
         }
         final Integer id = restrictionRepository.create(restriction);
-        permissionRepository.forceReloadingOfLists();
         return id;
     }
 
@@ -592,7 +596,7 @@ public class PermissionBoundary implements Serializable {
     @HasPermission(permission = Permission.ASSIGN_REMOVE_PERMISSION, action = Action.UPDATE)
     public boolean updateRestriction(Integer id, String roleName, String userName, String permissionName, Integer resourceId,
                                   String resourceTypeName, ResourceTypePermission resourceTypePermission,
-                                  String contextName, Action action) throws AMWException {
+                                  String contextName, Action action, boolean reload) throws AMWException {
         if (id == null) {
             throw new AMWException("Id must not be null");
         }
@@ -606,17 +610,21 @@ public class PermissionBoundary implements Serializable {
             return false;
         }
         restrictionRepository.merge(restriction);
-        permissionRepository.forceReloadingOfLists();
+        if (reload) {
+            permissionRepository.forceReloadingOfLists();
+        }
         return true;
     }
 
     @HasPermission(permission = Permission.ASSIGN_REMOVE_PERMISSION, action = Action.DELETE)
-    public void removeRestriction(Integer id) throws AMWException {
+    public void removeRestriction(Integer id, boolean reload) throws AMWException {
         if (restrictionRepository.find(id) == null) {
             throw new AMWException("Restriction not found");
         }
         restrictionRepository.deleteRestrictionById(id);
-        permissionRepository.forceReloadingOfLists();
+        if (reload) {
+            permissionRepository.forceReloadingOfLists();
+        }
     }
 
     /**

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -431,7 +431,7 @@ public class PermissionBoundary implements Serializable {
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.RESOURCE_TEST_GENERATION_RESULT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
             createAutoAssignedRestriction(getUserName(), Permission.DEPLOYMENT.name(), resourceGroupId, Action.ALL, new RestrictionEntity());
-            permissionRepository.forceReloadingOfLists();
+            reloadCache();
         }
     }
 
@@ -455,7 +455,7 @@ public class PermissionBoundary implements Serializable {
         if (!delegated || canDelegateThisPermission(permissionName, resourceGroupId, resourceTypeName, contextName, action)) {
             RestrictionEntity restriction = new RestrictionEntity();
             if (reload) {
-                permissionRepository.forceReloadingOfLists();
+                reloadCache();
             }
             return createRestriction(roleName, userName, permissionName, resourceGroupId, resourceTypeName, resourceTypePermission,
                     contextName, action, restriction);
@@ -527,7 +527,7 @@ public class PermissionBoundary implements Serializable {
             }
         }
         if (reload) {
-            permissionRepository.forceReloadingOfLists();
+            reloadCache();
         }
         return count;
     }
@@ -611,7 +611,7 @@ public class PermissionBoundary implements Serializable {
         }
         restrictionRepository.merge(restriction);
         if (reload) {
-            permissionRepository.forceReloadingOfLists();
+            reloadCache();
         }
         return true;
     }
@@ -623,7 +623,7 @@ public class PermissionBoundary implements Serializable {
         }
         restrictionRepository.deleteRestrictionById(id);
         if (reload) {
-            permissionRepository.forceReloadingOfLists();
+            reloadCache();
         }
     }
 
@@ -845,4 +845,8 @@ public class PermissionBoundary implements Serializable {
         return false;
     }
 
+    @HasPermission(permission = Permission.ASSIGN_REMOVE_PERMISSION)
+    public void reloadCache() {
+        permissionRepository.forceReloadingOfLists();
+    }
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRepository.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRepository.java
@@ -124,6 +124,18 @@ public class PermissionRepository {
 		return roleEntity;
 	}
 
+	public void deleteRole(String roleName) {
+		RoleEntity role = getRoleByName(roleName);
+		if (role == null) {
+			throw new IllegalArgumentException("Role " + roleName + " doesn't exist!");
+		}
+		if (!role.isDeletable()) {
+			throw new IllegalArgumentException("Role " + roleName + " is not deletable!");
+		}
+		// leads to a cascade delete of the restrictions
+		entityManager.remove(role);
+	}
+
 	public boolean isReloadDeployableRoleList() {
 		return reloadDeployableRoleList;
 	}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
@@ -115,7 +115,7 @@ public class PermissionBoundaryTest {
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnUpdateIfIdIsNull() throws AMWException {
         // given // when // then
-        permissionBoundary.updateRestriction(null,null, null, null, null, null, null, null, null);
+        permissionBoundary.updateRestriction(null,null, null, null, null, null, null, null, null, true);
     }
 
     @Test(expected=AMWException.class)
@@ -123,7 +123,7 @@ public class PermissionBoundaryTest {
         // given
         when(restrictionRepository.find(1)).thenReturn(null);
         // when // then
-        permissionBoundary.updateRestriction(1, null, null, null, null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, null, null, null, null, null, null, null, null, true);
     }
 
     @Test(expected=AMWException.class)
@@ -131,7 +131,7 @@ public class PermissionBoundaryTest {
         // given
         when(restrictionRepository.find(1)).thenReturn(new RestrictionEntity());
         // when // then
-        permissionBoundary.updateRestriction(1, null, null, null, null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, null, null, null, null, null, null, null, null, true);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("newRole")).thenReturn(null);
         when(permissionRepository.getPermissionByName("valid")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.updateRestriction(1, "newRole", null, "valid", null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, "newRole", null, "valid", null, null, null, null, null, true);
         // then
         verify(permissionRepository).createRole("newRole");
     }
@@ -152,7 +152,7 @@ public class PermissionBoundaryTest {
         when(restrictionRepository.find(1)).thenReturn(new RestrictionEntity());
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         // when // then
-        permissionBoundary.updateRestriction(1, "existing", null, null, null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, "existing", null, null, null, null, null, null, null, true);
     }
 
     @Test(expected=AMWException.class)
@@ -162,7 +162,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("invalid")).thenReturn(null);
         // when // then
-        permissionBoundary.updateRestriction(1, "existing", null, "invalid", null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, "existing", null, "invalid", null, null, null, null, null, true);
     }
 
     @Test(expected=AMWException.class)
@@ -173,7 +173,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         when(contextLocator.getContextByName("bad")).thenThrow(new NoResultException());
         // when // then
-        permissionBoundary.updateRestriction(1, "existing", null, "good", null, null, null, "bad", null);
+        permissionBoundary.updateRestriction(1, "existing", null, "good", null, null, null, "bad", null, true);
     }
 
     @Test(expected=AMWException.class)
@@ -184,7 +184,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         when(resourceTypeRepository.getByName("bad")).thenReturn(null);
         // when // then
-        permissionBoundary.updateRestriction(1, "existing", null, "good", null, "bad", null, null, null);
+        permissionBoundary.updateRestriction(1, "existing", null, "good", null, "bad", null, null, null, true);
     }
 
     @Test
@@ -194,7 +194,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.updateRestriction(1, "existing", null, "good", null, null, null, null, null);
+        permissionBoundary.updateRestriction(1, "existing", null, "good", null, null, null, null, null, true);
         // then
         verify(restrictionRepository).merge(any(RestrictionEntity.class));
         verify(permissionRepository).forceReloadingOfLists();
@@ -203,43 +203,43 @@ public class PermissionBoundaryTest {
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfRoleNameAndUserNameAreNull() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(null, null, null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, null, null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfUserNameIsEmpty() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(null, "", null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, "", null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfTrimmedUserNameIsEmpty() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(null, " ", null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, " ", null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfUserNameHasLeadingSpaces() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(null, " invalid", null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, " invalid", null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfRoleNameHasTrailingSpaces() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction("invalid ", null, null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction("invalid ", null, null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfRoleNameHasLeadingSpaces() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(" invalid", null, null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(" invalid", null, null, null, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionOnCreateIfUserNameHasTrailingSpaces() throws AMWException {
         // given // when // then
-        permissionBoundary.createRestriction(null, "invalid ", null, null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, "invalid ", null, null, null, null, null, null, false, true);
     }
 
 
@@ -249,7 +249,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("newRole")).thenReturn(null);
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.createRestriction("newRole", null, "good", null, null, null, null, null, false);
+        permissionBoundary.createRestriction("newRole", null, "good", null, null, null, null, null, false, true);
         // then
         verify(permissionRepository).createRole("newRole");
         verify(restrictionRepository).create(any(RestrictionEntity.class));
@@ -260,7 +260,7 @@ public class PermissionBoundaryTest {
         // given
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.createRestriction(null, "hans", "good", null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, "hans", "good", null, null, null, null, null, false, true);
         // then
         verify(permissionRepository).getUserRestrictionByName("hans");
         verify(permissionRepository).createUserRestriciton("hans");
@@ -273,7 +273,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         when(permissionRepository.getUserRestrictionByName("fritz")).thenReturn(new UserRestrictionEntity());
         // when
-        permissionBoundary.createRestriction(null, "fritz", "good", null, null, null, null, null, false);
+        permissionBoundary.createRestriction(null, "fritz", "good", null, null, null, null, null, false, true);
         // then
         verify(permissionRepository, never()).createUserRestriciton(anyString());
         verify(restrictionRepository).create(any(RestrictionEntity.class));
@@ -285,7 +285,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.createRestriction("existing", null, "good", null, null, null, null, CREATE, false);
+        permissionBoundary.createRestriction("existing", null, "good", null, null, null, null, CREATE, false, true);
         // then
         verify(restrictionRepository).create(any(RestrictionEntity.class));
     }
@@ -296,7 +296,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when
-        permissionBoundary.createRestriction("existing", null, "good", null, null, null, null, null, false);
+        permissionBoundary.createRestriction("existing", null, "good", null, null, null, null, null, false, true);
         // then
         verify(restrictionRepository).create(any(RestrictionEntity.class));
         verify(permissionRepository).forceReloadingOfLists();
@@ -309,7 +309,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getUserRestrictionByName("fed")).thenReturn(new UserRestrictionEntity());
         when(permissionRepository.getPermissionByName(anyString())).thenReturn(resourcePermission);
         // when
-        permissionBoundary.createRestriction(null, "fred", "SHAKEDOWNTEST", null, null, null, null, CREATE, true);
+        permissionBoundary.createRestriction(null, "fred", "SHAKEDOWNTEST", null, null, null, null, CREATE, true, true);
         // then
         verify(permissionService).hasPermissionToDelegatePermission(Permission.SHAKEDOWNTEST, null, null, null, CREATE);
         verify(restrictionRepository).create(any(RestrictionEntity.class));
@@ -321,7 +321,7 @@ public class PermissionBoundaryTest {
         when(permissionService.hasPermissionToDelegatePermission(Permission.SHAKEDOWNTEST, null, null, null, CREATE)).thenReturn(false);
         when(permissionRepository.getUserRestrictionByName("fed")).thenReturn(new UserRestrictionEntity());
         // when
-        permissionBoundary.createRestriction(null, "fred", "SHAKEDOWNTEST", null, null, null, null, CREATE, true);
+        permissionBoundary.createRestriction(null, "fred", "SHAKEDOWNTEST", null, null, null, null, CREATE, true, true);
         // then
         verify(permissionService).hasPermissionToDelegatePermission(Permission.SHAKEDOWNTEST, null, null, null, CREATE);
         verify(restrictionRepository, never()).create(any(RestrictionEntity.class));
@@ -334,7 +334,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         when(resourceGroupRepository.find(7)).thenReturn(null);
         // when // then
-        permissionBoundary.createRestriction("existing", null, "good", 7, null, null, null, null, false);
+        permissionBoundary.createRestriction("existing", null, "good", 7, null, null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
@@ -343,7 +343,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when // then
-        permissionBoundary.createRestriction("existing", null, "good", 7, "bad", null, null, null, false);
+        permissionBoundary.createRestriction("existing", null, "good", 7, "bad", null, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
@@ -352,7 +352,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when // then
-        permissionBoundary.createRestriction("existing", null, "good", 7, null, DEFAULT_ONLY, null, null, false);
+        permissionBoundary.createRestriction("existing", null, "good", 7, null, DEFAULT_ONLY, null, null, false, true);
     }
 
     @Test(expected=AMWException.class)
@@ -361,7 +361,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getRoleByName("existing")).thenReturn(new RoleEntity());
         when(permissionRepository.getPermissionByName("good")).thenReturn(resourcePermission);
         // when // then
-        permissionBoundary.createRestriction("existing", null, "good", null, "bad", NON_DEFAULT_ONLY, null, null, false);
+        permissionBoundary.createRestriction("existing", null, "good", null, "bad", NON_DEFAULT_ONLY, null, null, false, true);
     }
 
     @Test
@@ -404,7 +404,7 @@ public class PermissionBoundaryTest {
     @Test(expected=AMWException.class)
     public void shouldThrowAMWExceptionIfRestrictionToBeDeletedCanNotBeFound() throws AMWException {
         // given // when // then
-        permissionBoundary.removeRestriction(21);
+        permissionBoundary.removeRestriction(21, true);
     }
 
     @Test
@@ -412,7 +412,7 @@ public class PermissionBoundaryTest {
         // given
         when(restrictionRepository.find(42)).thenReturn(new RestrictionEntity());
         // when
-        permissionBoundary.removeRestriction(42);
+        permissionBoundary.removeRestriction(42, true);
         // then
         verify(restrictionRepository).deleteRestrictionById(42);
         verify(permissionRepository).forceReloadingOfLists();
@@ -869,7 +869,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(1)).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA), Arrays.asList(Action.CREATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA), Arrays.asList(Action.CREATE), false, true);
 
         // then
         assertThat(total, is(2));
@@ -888,7 +888,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(1)).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(null, Arrays.asList(userName1, userName2), Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(null, Arrays.asList(userName1, userName2), Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE), false, true);
 
         // then
         assertThat(total, is(4));
@@ -909,7 +909,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(1)).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA), Arrays.asList(Action.CREATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(permissionName1, permissionName2), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA), Arrays.asList(Action.CREATE), false, true);
 
         // then
         assertThat(total, is(6));
@@ -927,7 +927,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(1)).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1), null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1), null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(12));
@@ -947,7 +947,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(1)).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(24));
@@ -967,7 +967,7 @@ public class PermissionBoundaryTest {
         when(resourceGroupRepository.find(anyInt())).thenReturn(new ResourceGroupEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1, 2), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), Arrays.asList(1, 2), null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(48));
@@ -989,7 +989,7 @@ public class PermissionBoundaryTest {
         when(resourceTypeRepository.getByName(anyString())).thenReturn(new ResourceTypeEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, Arrays.asList(resourceTypeName1, resourceTypeName2), ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, Arrays.asList(resourceTypeName1, resourceTypeName2), ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(48));
@@ -1009,7 +1009,7 @@ public class PermissionBoundaryTest {
         when(resourceTypeRepository.getByName(anyString())).thenReturn(new ResourceTypeEntity());
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, Arrays.asList(resourceTypeName1, resourceTypeName2), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, Arrays.asList(resourceTypeName1, resourceTypeName2), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(24));
@@ -1028,7 +1028,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName(resourceTypePermission.getValue())).thenReturn(resourceTypePermission);
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, Arrays.asList(contextNameA, contextNameB), Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(24));
@@ -1045,7 +1045,7 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName(resourceTypePermission.getValue())).thenReturn(resourceTypePermission);
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
 
         // then
         assertThat(total, is(12));
@@ -1061,7 +1061,7 @@ public class PermissionBoundaryTest {
         when(resourceTypeRepository.getByName(anyString())).thenReturn(new ResourceTypeEntity());
 
         // when // then
-        permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(resourcePermission.getValue()), Arrays.asList(1), Arrays.asList(resourceTypeName1), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false);
+        permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(resourcePermission.getValue()), Arrays.asList(1), Arrays.asList(resourceTypeName1), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
     }
 
 }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
@@ -854,7 +854,7 @@ public class PermissionBoundaryTest {
 
         // then
         verify(permissionService).hasPermission(Permission.ADD_ADMIN_PERMISSIONS_ON_CREATED_RESOURCE);
-        verify(restrictionRepository, times(8)).create(any(RestrictionEntity.class));
+        verify(restrictionRepository, times(5)).create(any(RestrictionEntity.class));
     }
 
     @Test

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
@@ -874,6 +874,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(2));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -893,6 +894,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(4));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -914,6 +916,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(6));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -932,6 +935,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(12));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -952,6 +956,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -972,6 +977,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(48));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -994,6 +1000,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(48));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -1014,6 +1021,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -1033,6 +1041,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(1)).forceReloadingOfLists();
     }
 
     @Test
@@ -1045,11 +1054,12 @@ public class PermissionBoundaryTest {
         when(permissionRepository.getPermissionByName(resourceTypePermission.getValue())).thenReturn(resourceTypePermission);
 
         // when
-        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
+        int total = permissionBoundary.createMultipleRestrictions(roleName1, Arrays.asList(userName1, userName2), Arrays.asList(resourcePermission.getValue(), resourceTypePermission.getValue()), null, null, ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, false);
 
         // then
         assertThat(total, is(12));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
+        verify(permissionRepository, times(0)).forceReloadingOfLists();
     }
 
     @Test(expected=AMWException.class)
@@ -1062,6 +1072,7 @@ public class PermissionBoundaryTest {
 
         // when // then
         permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(resourcePermission.getValue()), Arrays.asList(1), Arrays.asList(resourceTypeName1), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
+        verify(permissionRepository, times(0)).forceReloadingOfLists();
     }
 
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/RESTApplication.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/RESTApplication.java
@@ -60,6 +60,7 @@ public class RESTApplication extends Application {
         resources.add(EnvironmentsRest.class);
         resources.add(AuditViewRest.class);
         resources.add(RestrictionsRest.class);
+        resources.add(UncaughtExceptionMapper.class);
         resources.add(ClientErrorExceptionMapper.class);
         resources.add(EJBExceptionMapper.class);
         resources.add(ExceptionDtoBodyWriter.class);

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/IllegalArgumentExceptionMapper.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/IllegalArgumentExceptionMapper.java
@@ -25,9 +25,9 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalStateException> {
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
     @Override
-    public Response toResponse(IllegalStateException exception) {
+    public Response toResponse(IllegalArgumentException exception) {
         return Response.status(Response.Status.BAD_REQUEST).entity(new ExceptionDto(exception)).build();
     }
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/IllegalStateExceptionMapper.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/IllegalStateExceptionMapper.java
@@ -20,7 +20,6 @@
 
 package ch.mobi.itc.mobiliar.rest.exceptions;
 
-import javax.persistence.NoResultException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/UncaughtExceptionMapper.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/exceptions/UncaughtExceptionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * AMW - Automated Middleware allows you to manage the configurations of
+ * your Java EE applications on an unlimited number of different environments
+ * with various versions, including the automated deployment of those apps.
+ * Copyright (C) 2013-2016 by Puzzle ITC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.mobi.itc.mobiliar.rest.exceptions;
+ 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+ 
+@Provider
+public class UncaughtExceptionMapper implements ExceptionMapper<Throwable> {  
+    @Override
+    public Response toResponse(Throwable exception) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ExceptionDto(exception)).build();
+    }
+}

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
@@ -212,8 +212,20 @@ public class RestrictionsRest {
     @GET
     @Path("/roles/{roleName}")
     @ApiOperation(value = "Get all Restrictions assigned to a specific Role")
-    public Response getRoleRestriction(@ApiParam("UserName") @PathParam("roleName") String roleName) {
+    public Response getRoleRestriction(@ApiParam("RoleName") @PathParam("roleName") String roleName) {
         return restrictionsToResponse(permissionBoundary.getRestrictionsByRoleName(roleName));
+    }
+
+    /**
+     * Removes a role with all it's permissions
+     * @param id
+     */
+    @DELETE
+    @Path("/roles/{roleName}")
+    @ApiOperation(value = "Removes a role with all it's permissions")
+    public Response deleteRole(@ApiParam("RoleName") @PathParam("roleName") String roleName, @DefaultValue("true") @QueryParam("reload") boolean reload) {
+        permissionBoundary.deleteRole(roleName, reload);
+        return Response.status(OK).build();
     }
 
     /**

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
@@ -316,4 +316,15 @@ public class RestrictionsRest {
         return Response.status(OK).entity(restrictionList).build();
     }
 
+    /**
+     * Reload the permission cache
+     */
+    @POST
+    @Path("/reload")
+    @ApiOperation(value = "Reload the permission cache")
+    public Response reloadCache() {
+        permissionBoundary.reloadCache();
+        return Response.status(OK).build();
+    }
+
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionsRest.java
@@ -63,7 +63,7 @@ public class RestrictionsRest {
     @POST
     @ApiOperation(value = "Add a Restriction")
     public Response addRestriction(@ApiParam("Add a Restriction, either a role- or a userName must be set") RestrictionDTO request,
-                                   @QueryParam("delegation") boolean delegation) {
+                                   @QueryParam("delegation") boolean delegation, @DefaultValue("true") @QueryParam("reload") boolean reload) {
         Integer id;
         if (request.getId() != null) {
             return Response.status(BAD_REQUEST).entity(new ExceptionDto("Id must be null")).build();
@@ -73,7 +73,7 @@ public class RestrictionsRest {
         }
         try {
             id = permissionBoundary.createRestriction(request.getRoleName(), request.getUserName(), request.getPermission().getName(), request.getResourceGroupId(),
-                    request.getResourceTypeName(), request.getResourceTypePermission(), request.getContextName(), request.getAction(), delegation);
+                    request.getResourceTypeName(), request.getResourceTypePermission(), request.getContextName(), request.getAction(), delegation, reload);
         } catch (AMWException e) {
             return Response.status(BAD_REQUEST).entity(new ExceptionDto(e.getMessage())).build();
         }
@@ -93,14 +93,14 @@ public class RestrictionsRest {
     @Path("/multi/")
     @ApiOperation(value = "Add a multiple Restrictions")
     public Response addRestriction(@ApiParam("Add multiple Restrictions, either a role- or one or more userNames must be set") RestrictionsCreationDTO request,
-                                   @QueryParam("delegation") boolean delegation) {
+                                   @QueryParam("delegation") boolean delegation, @DefaultValue("true") @QueryParam("reload") boolean reload) {
         if (request.getPermissionNames().isEmpty()) {
             return Response.status(BAD_REQUEST).entity(new ExceptionDto("At least one Permission is required")).build();
         }
         int count;
         try {
             count = permissionBoundary.createMultipleRestrictions(request.getRoleName(), request.getUserNames(), request.getPermissionNames(), request.getResourceGroupIds(),
-                    request.getResourceTypeNames(), request.getResourceTypePermission(), request.getContextNames(), request.getActions(), delegation);
+                    request.getResourceTypeNames(), request.getResourceTypePermission(), request.getContextNames(), request.getActions(), delegation, reload);
         } catch (AMWException e) {
             return Response.status(BAD_REQUEST).entity(new ExceptionDto(e.getMessage())).build();
         }
@@ -146,12 +146,13 @@ public class RestrictionsRest {
     // support digit only
     @Produces("application/json")
     @ApiOperation(value = "Update a Restriction")
-    public Response updateRestriction(@ApiParam("Restriction ID") @PathParam("id") Integer id, RestrictionDTO request) {
+    public Response updateRestriction(@ApiParam("Restriction ID") @PathParam("id") Integer id, RestrictionDTO request,
+                                      @DefaultValue("true") @QueryParam("reload") boolean reload) {
         boolean success;
         try {
             success = permissionBoundary.updateRestriction(id, request.getRoleName(), request.getUserName(), request.getPermission().getName(),
                     request.getResourceGroupId(), request.getResourceTypeName(), request.getResourceTypePermission(),
-                    request.getContextName(), request.getAction());
+                    request.getContextName(), request.getAction(), reload);
         } catch (AMWException e) {
             return Response.status(BAD_REQUEST).entity(new ExceptionDto(e.getMessage())).build();
         }
@@ -169,9 +170,10 @@ public class RestrictionsRest {
     @Path("/{id : \\d+}")
     // support digit only
     @ApiOperation(value = "Remove a Restriction")
-    public Response deleteRestriction(@ApiParam("Restriction ID") @PathParam("id") Integer id) {
+    public Response deleteRestriction(@ApiParam("Restriction ID") @PathParam("id") Integer id,
+                                      @DefaultValue("true") @QueryParam("reload") boolean reload) {
         try {
-            permissionBoundary.removeRestriction(id);
+            permissionBoundary.removeRestriction(id, reload);
         } catch (AMWException e) {
             return Response.status(NOT_FOUND).entity(new ExceptionDto(e.getMessage())).build();
         }

--- a/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionTest.java
+++ b/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionTest.java
@@ -216,10 +216,10 @@ public class RestrictionTest {
     public void shouldReturnStateBadRequestIfUpdateRestrictionFails() throws AMWException {
         // given
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(1, "valid", null, RESOURCE, 8, null, null, null, null);
-        doThrow(new AMWException("bad")).when(rest.permissionBoundary).updateRestriction(1, "valid", null, RESOURCE.name(), 8, null, null, null, null);
+        doThrow(new AMWException("bad")).when(rest.permissionBoundary).updateRestriction(1, "valid", null, RESOURCE.name(), 8, null, null, null, null, true);
 
         // when
-        Response response = rest.updateRestriction(1, restrictionDTO);
+        Response response = rest.updateRestriction(1, restrictionDTO, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -228,10 +228,10 @@ public class RestrictionTest {
     @Test
     public void shouldReturnStateNotFoundIfRestrictionToBeDeletedWasNotFound() throws AMWException {
         // given
-        doThrow(new AMWException("bad")).when(rest.permissionBoundary).removeRestriction(1);
+        doThrow(new AMWException("bad")).when(rest.permissionBoundary).removeRestriction(1, true);
 
         // when
-        Response response = rest.deleteRestriction(1);
+        Response response = rest.deleteRestriction(1, true);
 
         // then
         assertEquals(NOT_FOUND.getStatusCode(), response.getStatus());
@@ -240,7 +240,7 @@ public class RestrictionTest {
     @Test
     public void shouldReturnStateNoContentIfRestrictionHasBeenDeletedSuccessfully() throws AMWException {
         // given // when
-        Response response = rest.deleteRestriction(1);
+        Response response = rest.deleteRestriction(1, true);
 
         // then
         assertEquals(NO_CONTENT.getStatusCode(), response.getStatus());

--- a/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionTest.java
+++ b/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/permissions/RestrictionTest.java
@@ -141,7 +141,7 @@ public class RestrictionTest {
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(1, null, null, RESOURCE, null, null, null, null, null);
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -151,10 +151,10 @@ public class RestrictionTest {
     public void shouldReturnStateBadRequestIfRoleNameAndUserNameAreMissing() throws AMWException {
         // given
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(null, null, null, RESOURCE, null, null, null, null, null);
-        when(rest.permissionBoundary.createRestriction(null, null, RESOURCE.name(), null, null, null, null, null, false)).thenThrow(new AMWException("bad"));
+        when(rest.permissionBoundary.createRestriction(null, null, RESOURCE.name(), null, null, null, null, null, false, true)).thenThrow(new AMWException("bad"));
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -164,10 +164,10 @@ public class RestrictionTest {
     public void shouldReturnStateBadRequestIfRoleNameIsInvalid() throws AMWException {
         // given
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(null, "invalid", null, RESOURCE, null, null, null, null, null);
-        when(rest.permissionBoundary.createRestriction("invalid", null, RESOURCE.name(), null, null, null, null, null, false)).thenThrow(new AMWException("bad"));
+        when(rest.permissionBoundary.createRestriction("invalid", null, RESOURCE.name(), null, null, null, null, null, false, true)).thenThrow(new AMWException("bad"));
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -179,7 +179,7 @@ public class RestrictionTest {
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(null, "fritz", null, RESOURCE, null, null, null, null, null);
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(CREATED.getStatusCode(), response.getStatus());
@@ -189,10 +189,10 @@ public class RestrictionTest {
     public void shouldReturnStateBadRequestIfResourceIdIsInvalid() throws AMWException {
         // given
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(null, "valid", null, RESOURCE, 1, null, null, null, null);
-        when(rest.permissionBoundary.createRestriction("valid", null, RESOURCE.name(), 1, null, null, null, null, false)).thenThrow(new AMWException("bad"));
+        when(rest.permissionBoundary.createRestriction("valid", null, RESOURCE.name(), 1, null, null, null, null, false, true)).thenThrow(new AMWException("bad"));
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());
@@ -202,10 +202,10 @@ public class RestrictionTest {
     public void shouldReturnStateBadRequestIfResourceTypeNameIsInvalid() throws AMWException {
         // given
         ch.mobi.itc.mobiliar.rest.dtos.RestrictionDTO restrictionDTO = new RestrictionDTO(null, "valid", null, RESOURCE, null, "invalid", null, null, null);
-        when(rest.permissionBoundary.createRestriction("valid", null, RESOURCE.name(), null, "invalid", null, null, null, false)).thenThrow(new AMWException("bad"));
+        when(rest.permissionBoundary.createRestriction("valid", null, RESOURCE.name(), null, "invalid", null, null, null, false, true)).thenThrow(new AMWException("bad"));
 
         // when
-        Response response = rest.addRestriction(restrictionDTO, false);
+        Response response = rest.addRestriction(restrictionDTO, false, true);
 
         // then
         assertEquals(BAD_REQUEST.getStatusCode(), response.getStatus());


### PR DESCRIPTION
Closes #415 
Closes #414 

PermissionBoundary
* public methods got a new reload parameter
* private methodes no longer reload the cache
* createAutoAssignedRestrictions only adds valid permissions for the resourceType
* new method delete role, cascade deletes restrictions as well

RestrictionsRest
* nutating methods got an optional reload parameter, default true
* new reload method
* new method delete role

Other:
* added new catch all exception mapper
* fixed some mapper