### PR TITLE
Deployment can be canceled after confirm

### DIFF
--- a/AMW_angular/io/yarn.lock
+++ b/AMW_angular/io/yarn.lock
@@ -119,9 +119,9 @@
   version "3.2.18"
   resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.2.18.tgz#a1cd262034cd8c79fa4d9b2a409d8f747ac2f72f"
 
-"@types/lodash@4.14.88":
-  version "4.14.88"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.88.tgz#97eaf2dc668f33ed8e511a5b627035f4ea20b0f5"
+"@types/lodash@4.14.116":
+  version "4.14.116"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.116.tgz#5ccf215653e3e8c786a58390751033a9adca0eb9"
 
 "@types/lodash@^4.14.37":
   version "4.14.86"
@@ -4021,13 +4021,17 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.5.0, lodash@~4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+lodash@4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.5.0, lodash@~4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
 lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.5:
   version "4.17.10"

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
@@ -315,8 +315,10 @@ public class PermissionService implements Serializable {
     }
 
     public boolean hasPermissionForCancelDeployment(DeploymentEntity deployment) {
-        // cancel is only for requester
-        return getCurrentUserName().equals(deployment.getDeploymentRequestUser());
+        return getCurrentUserName().equals(deployment.getDeploymentRequestUser())
+                || (deployment.getDeploymentConfirmed() != null && deployment.getDeploymentConfirmed()
+                        && hasPermissionAndActionForDeploymentOnContext(deployment.getContext(),
+                                deployment.getResource().getResourceGroup(), Action.UPDATE));
     }
 
     /**


### PR DESCRIPTION
Closes #424 
After a deployment has been confirmed a user with Deployment update permission can also cancel a deployment now.