### PR TITLE
Corrected padding

### DIFF
--- a/AMW_web/src/main/webapp/sass/_nav.scss
+++ b/AMW_web/src/main/webapp/sass/_nav.scss
@@ -88,9 +88,9 @@ aside {
 	}
 }
 
-.level2 a { padding-left: $grid-padding + 2em; }
-.level3 a { padding-left: $grid-padding + 4em; }
-.level4 a { padding-left: $grid-padding + 6em; }
+.level2 a { padding-left: $grid-padding + 1em; }
+.level3 a { padding-left: $grid-padding + 3em; }
+.level4 a { padding-left: $grid-padding + 5em; }
 
 
 // ---------------------------------------------------------------------------

--- a/AMW_web/src/main/webapp/stylesheets/screen.css
+++ b/AMW_web/src/main/webapp/stylesheets/screen.css
@@ -854,17 +854,17 @@ aside nav > ul > li ul li a {
 
 /* line 91, ../sass/_nav.scss */
 .level2 a {
-  padding-left: 5em;
+  padding-left: 4em;
 }
 
 /* line 92, ../sass/_nav.scss */
 .level3 a {
-  padding-left: 7em;
+  padding-left: 6em;
 }
 
 /* line 93, ../sass/_nav.scss */
 .level4 a {
-  padding-left: 9em;
+  padding-left: 8em;
 }
 
 /* line 104, ../sass/_nav.scss */


### PR DESCRIPTION
With this commit, long name aliases of environments (like development) no longer break the navigation layout 