### PR TITLE
serverView: cache user permissions in view

### DIFF
--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/server/ServerListView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/server/ServerListView.java
@@ -39,6 +39,7 @@ import ch.puzzle.itc.mobiliar.common.util.ConfigurationService;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import ch.puzzle.itc.mobiliar.common.util.ConfigKey;
 import ch.puzzle.itc.mobiliar.presentation.ViewBackingBean;
+import ch.puzzle.itc.mobiliar.presentation.security.SecurityDataProvider;
 import ch.puzzle.itc.mobiliar.presentation.util.NavigationUtils;
 import lombok.Getter;
 import lombok.Setter;
@@ -56,7 +57,8 @@ public class ServerListView implements Serializable {
 	private ResourceGroupLocator resourceGroupLocator;
 	@Inject
 	private CommonDomainService commonServcie;
-
+	@Inject
+	private SecurityDataProvider securityDataProvider;
 	
 	@Inject
 	@Getter
@@ -75,8 +77,16 @@ public class ServerListView implements Serializable {
 	@Getter
 	private String vmUrlParam = ConfigurationService.getProperty(ConfigKey.VM_URL_PARAM);
 
+	@Getter
+	private boolean appServerReadPermission;
+	@Getter
+	private boolean resourceReadPermission;
+
 	// called by preRenderView event
 	public void init() throws GeneralDBException {
+		//cache permissions in view
+		this.appServerReadPermission = securityDataProvider.hasPermissionForResourceType("RESOURCE", "READ", "APPLICATIONSERVER");
+		this.resourceReadPermission = securityDataProvider.hasPermission("RESOURCE", "READ");
 		if(!FacesContext.getCurrentInstance().isPostback()) {
 			if(!serverListFilter.isEmpty() || serverListFilter.isEmptySearch()) {
 				servers = serverView.getServers(serverListFilter.getHost(), serverListFilter.getAppServer(), serverListFilter.getRuntime(),

--- a/AMW_web/src/main/webapp/pages/serverListView.xhtml
+++ b/AMW_web/src/main/webapp/pages/serverListView.xhtml
@@ -139,12 +139,12 @@
 								<h:outputText style="white-space: nowrap" value="AppServer" />
 							</f:facet>
 							<h:link value="#{server.appServer}" outcome="editResourceView"
-								rendered="${securityDataProvider.hasPermissionForResourceType('RESOURCE', 'READ', 'APPLICATIONSERVER')}">
+								rendered="${serverListView.appServerReadPermission}">
 								<f:param name="id" value="#{server.appServerId}" />
 								<f:param name="ctx" value="#{server.environmentId}" />
 							</h:link>
 							<h:outputText
-								rendered="${!securityDataProvider.hasPermissionForResourceType('RESOURCE', 'READ', 'APPLICATIONSERVER')}"
+								rendered="${!serverListView.appServerReadPermission}"
 								value="#{server.appServer}" />
 						</h:column>
 
@@ -168,12 +168,12 @@
 								<h:outputText style="white-space: nowrap" value="Node" />
 							</f:facet>
 							<h:link value="#{server.node}" outcome="editResourceView"
-								rendered="${securityDataProvider.hasPermission('RESOURCE', 'READ')}">
+								rendered="${serverListView.resourceReadPermission}">
 								<f:param name="id" value="#{server.nodeId}" />
 								<f:param name="ctx" value="#{server.environmentId}" />
 							</h:link>
 							<h:outputText
-								rendered="${!securityDataProvider.hasPermission('RESOURCE', 'READ')}"
+								rendered="${!serverListView.resourceReadPermission}"
 								value="#{server.node}" />
 						</h:column>
 


### PR DESCRIPTION
Caches the needed permissions for the view in the bean.
Reduces calls to the securityDataProvider from 4 times per row/server to two times per view load.
This reduces the load times of the screen by almost factor three in our env.