### PR TITLE
Cache roles a user has to reduce calls to sessionContext.isCallerInRole

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
@@ -21,7 +21,6 @@
 package ch.puzzle.itc.mobiliar.business.security.control;
 
 import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity;
-import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentState;
 import ch.puzzle.itc.mobiliar.business.environment.entity.ContextEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
@@ -60,6 +59,8 @@ public class PermissionService implements Serializable {
     static Map<String, List<RestrictionDTO>> rolesWithRestrictions;
     // map containing UserRestrictions with Restrictions (non legacy)
     static Map<String, List<RestrictionEntity>> userRestrictions;
+    // User role cache for the current call
+    private HashSet<String> userRoles = null;
 
     Map<String, List<RestrictionDTO>> getDeployableRoles() {
         boolean isReload = permissionRepository.isReloadDeployableRoleList();
@@ -81,7 +82,7 @@ public class PermissionService implements Serializable {
      */
     public boolean hasPermissionToSeeDeployment() {
         for (Map.Entry<String, List<RestrictionDTO>> entry : getDeployableRoles().entrySet()) {
-            if (sessionContext.isCallerInRole(entry.getKey())) {
+            if (isCallerInRole(entry.getKey())) {
                 return true;
             }
         }
@@ -93,7 +94,7 @@ public class PermissionService implements Serializable {
      */
     public boolean hasPermissionToCreateDeployment() {
         for (Map.Entry<String, List<RestrictionDTO>> entry : getDeployableRoles().entrySet()) {
-            if (sessionContext.isCallerInRole(entry.getKey())) {
+            if (isCallerInRole(entry.getKey())) {
                 for (RestrictionDTO restrictionDTO : entry.getValue()) {
                     if (restrictionDTO.getRestriction().getAction().equals(Action.CREATE)
                             || restrictionDTO.getRestriction().getAction().equals(Action.ALL)) {
@@ -110,7 +111,7 @@ public class PermissionService implements Serializable {
      */
     public boolean hasPermissionToEditDeployment() {
         for (Map.Entry<String, List<RestrictionDTO>> entry : getDeployableRoles().entrySet()) {
-            if (sessionContext.isCallerInRole(entry.getKey())) {
+            if (isCallerInRole(entry.getKey())) {
                 for (RestrictionDTO restrictionDTO : entry.getValue()) {
                     if (restrictionDTO.getRestriction().getAction().equals(Action.UPDATE)
                             || restrictionDTO.getRestriction().getAction().equals(Action.ALL)) {
@@ -339,10 +340,8 @@ public class PermissionService implements Serializable {
             for (Map.Entry<String, List<RestrictionDTO>> entry : deployableRolesWithRestrictions.entrySet()) {
                 matchPermissionsAndContext(permissionName, action, context, resourceGroup, resourceGroup.getResourceType(), allowedRoles, entry);
             }
-            for (String roleName : allowedRoles) {
-                if (sessionContext.isCallerInRole(roleName)) {
-                    return true;
-                }
+            if (hasAllowedRole(allowedRoles)) {
+                return true;
             }
             return hasUserRestriction(permissionName, context, action, resourceGroup, null);
         }
@@ -366,10 +365,37 @@ public class PermissionService implements Serializable {
                     matchPermissionsAndContext(permissionName, action, context, resourceGroup, resourceType, allowedRoles, entry);
                 }
             }
-            for (String roleName : allowedRoles) {
-                if (sessionContext.isCallerInRole(roleName)) {
-                    return true;
-                }
+            return hasAllowedRole(allowedRoles);
+        }
+        return false;
+    }
+
+    /**
+     * Cache the user roles in bean so we don't have to call sessionContext.isCallerInRole so often.
+     * sessionContext.isCallerInRole causes a stack trace to be created JBoss internally which takes time.
+     */
+    private HashSet<String> getUserRoles() {
+        if(this.userRoles != null) {
+            return this.userRoles;
+        }
+        HashSet<String> userRoles = new HashSet<>();
+        for(String role : getPermissions().keySet()) {
+            if (sessionContext.isCallerInRole(role)) {
+                userRoles.add(role);
+            }
+        }
+        this.userRoles = userRoles;
+        return userRoles;
+    }
+
+    private boolean isCallerInRole(String roleName) {
+        return getUserRoles().contains(roleName);
+    }
+
+    private boolean hasAllowedRole(List<String> allowedRoles) {
+        for(String role : allowedRoles) {
+            if(isCallerInRole(role)) {
+                return true;
             }
         }
         return false;
@@ -387,11 +413,7 @@ public class PermissionService implements Serializable {
             for (Map.Entry<String, List<RestrictionDTO>> entry : entries) {
                 matchPermissionsAndContext(permissionName, action, null, resourceGroup, resourceType, allowedRoles, entry);
             }
-            for (String roleName : allowedRoles) {
-                if (sessionContext.isCallerInRole(roleName)) {
-                    return true;
-                }
-            }
+            return hasAllowedRole(allowedRoles);
         }
         return false;
     }
@@ -762,7 +784,7 @@ public class PermissionService implements Serializable {
         List<RestrictionEntity> restrictions = new ArrayList<>();
         Map<String, List<RestrictionDTO>> roleWithRestrictions = getPermissions();
         for (String roleName : roleWithRestrictions.keySet()) {
-            if (sessionContext.isCallerInRole(roleName)) {
+            if (isCallerInRole(roleName)) {
                 for (RestrictionDTO restrictionDTO : roleWithRestrictions.get(roleName)) {
                     restrictions.add(restrictionDTO.getRestriction());
                 }


### PR DESCRIPTION
Our perf tool showed that calls to isCallerInRole cause a stack trace to be generated (no exception is thrown). With the new permission model isCallerInRole is hit very often and constant stack trace generation slows the app down.
With this change, the roles a user actually has is cached inside the bean and with this avoids the need to repeatedly call isCallerInRole.
The appList and resources screen get a small speed increase from this.