### PR TITLE
Switch back to unoptimized query for oracle

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/JpaSqlResultMapper.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/JpaSqlResultMapper.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.persistence.Query;
@@ -96,6 +97,9 @@ public class JpaSqlResultMapper {
 			result.add(obj);
 		}
 		catch (Exception e) {
+			System.out.println("Constructor: " + ctor);
+			System.out.println("args: " + Arrays.toString(normalizeArgs(args, ctor.getParameterTypes())));
+			System.out.println("result: " + Arrays.toString(result.toArray()));
 			throw new RuntimeException(e);
 		}
 	}

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/control/PropertyEditingQueries.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/control/PropertyEditingQueries.java
@@ -53,7 +53,9 @@ public class PropertyEditingQueries {
     private static final String CONSUMEDRESRELFK = "CONSUMEDRESOURCERELATION_ID";
     private static final String PROVIDEDRESRELTABLE = QueryUtils.getTable(ProvidedResourceRelationEntity.class);
     private static final String PROVIDEDRESRELFK = "PROVIDEDRESOURCERELATION_ID";
-    private static final String LOAD_PROPERTY_DESCRIPTORS_FOR_RESOURCE_OPTIMIZED = "loadPropertyDescriptorsForResourceOptimized.sql";
+    /* Switch back to unoptimized query for oracle, see: https://github.com/liimaorg/liima/issues/484
+       original: LOAD_PROPERTY_DESCRIPTORS_FOR_RESOURCE_OPTIMIZED = "loadPropertyDescriptorsForResourceOptimized.sql"; */
+    private static final String LOAD_PROPERTY_DESCRIPTORS_FOR_RESOURCE_OPTIMIZED = "loadPropertyDescriptorsForResource.sql";
     private static final String LOAD_PROPERTY_DESCRIPTORS_FOR_RESOURCE = "loadPropertyDescriptorsForResource.sql";
 
     public Query getPropertyValueForResource(int resourceId, List<Integer> resourceTypeIds, List<Integer> contextIds) {


### PR DESCRIPTION
Switch back to unoptimized query for oracle and add logging for property creation exceptions.

With this change related instance properties don't cause an exception anymore. See #484.
The underlying issue is not fixed with this, but it restores the app to a working state.
