### PR TITLE
Reload permission caches explicitly

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/boundary/ContextLocator.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/boundary/ContextLocator.java
@@ -23,7 +23,7 @@ package ch.puzzle.itc.mobiliar.business.environment.boundary;
 import ch.puzzle.itc.mobiliar.business.auditview.control.AuditService;
 import ch.puzzle.itc.mobiliar.business.environment.control.ContextRepository;
 import ch.puzzle.itc.mobiliar.business.environment.entity.ContextEntity;
-import ch.puzzle.itc.mobiliar.business.security.control.PermissionRepository;
+import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.control.RestrictionRepository;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
@@ -42,7 +42,7 @@ public class ContextLocator {
 	ContextRepository contextRepository;
 
 	@Inject
-	PermissionRepository permissionRepository;
+	PermissionService permissionService;
 
 	@Inject
 	RestrictionRepository restrictionRepository;
@@ -87,8 +87,7 @@ public class ContextLocator {
 				}
 			}
 			restrictionRepository.deleteAllWithContext(context);
-			permissionRepository.setReloadRolesAndPermissionsList(true);
-			permissionRepository.setReloadDeployableRoleList(true);
+			permissionService.reloadCache();
 			contextRepository.remove(context);
 		} else {
 			throw new AMWException("Es wurde versucht den Kontext \"Global\" (id: "+contextId+" zu löschen.");

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -866,6 +866,6 @@ public class PermissionBoundary implements Serializable {
 
     @HasPermission(permission = Permission.ASSIGN_REMOVE_PERMISSION)
     public void reloadCache() {
-        permissionRepository.forceReloadingOfLists();
+        permissionService.reloadCache();
     }
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRepository.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRepository.java
@@ -23,7 +23,6 @@ package ch.puzzle.itc.mobiliar.business.security.control;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ejb.Schedule;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -35,17 +34,6 @@ import ch.puzzle.itc.mobiliar.business.security.entity.*;
 public class PermissionRepository {
 	@Inject
 	private EntityManager entityManager;
-
-	private static boolean reloadDeployableRoleList;
-	private static boolean reloadRolesAndPermissionsList;
-	private static boolean reloadUserRestrictionsList;
-
-	@Schedule(hour = "*", minute = "*/20", persistent = false)
-	public void forceReloadingOfLists() {
-		reloadDeployableRoleList = true;
-		reloadRolesAndPermissionsList = true;
-		reloadUserRestrictionsList = true;
-	}
 
 	/**
 	 * Returns Roles which are allowed to deploy
@@ -136,30 +124,6 @@ public class PermissionRepository {
 		entityManager.remove(role);
 	}
 
-	public boolean isReloadDeployableRoleList() {
-		return reloadDeployableRoleList;
-	}
-
-	public void setReloadDeployableRoleList(boolean reloadDeployableRoleList) {
-		this.reloadDeployableRoleList = reloadDeployableRoleList;
-	}
-
-	public boolean isReloadRolesAndPermissionsList() {
-		return reloadRolesAndPermissionsList;
-	}
-
-	public void setReloadRolesAndPermissionsList(boolean reloadRolesAndPermissionsList) {
-		this.reloadRolesAndPermissionsList = reloadRolesAndPermissionsList;
-	}
-
-	public boolean isReloadUserRestrictionsList() {
-		return reloadUserRestrictionsList;
-	}
-
-	public void setReloadUserRestrictionsList(boolean reloadUserRestrictionsList) {
-		this.reloadUserRestrictionsList = reloadUserRestrictionsList;
-	}
-
 	/**
 	 * Returns Roles which have a Restriction matching the provided Permission
 	 *
@@ -172,19 +136,4 @@ public class PermissionRepository {
 				.setParameter("permission", permission.name()).getResultList();
 		return result == null ? new ArrayList<RoleEntity>() : result;
 	}
-
-	/**
-	 * Returns Roles which have a Restriction matching the provided Permission and Action
-	 *
-	 * @param permission
-	 * @param action
-	 * @return
-	 */
-	private List<RoleEntity> getRolesHavingRestrictionsWithPermissionAndAction(Permission permission, Action action) {
-		List<RoleEntity> result = entityManager
-				.createQuery("from RoleEntity r left join fetch r.restrictions res where res.permission.value =:permission and (res.action =:action or res.action = 'ALL')", RoleEntity.class)
-				.setParameter("permission", permission.name()).setParameter("action", action).getResultList();
-		return result == null ? new ArrayList<RoleEntity>() : result;
-	}
-
 }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundaryTest.java
@@ -197,7 +197,7 @@ public class PermissionBoundaryTest {
         permissionBoundary.updateRestriction(1, "existing", null, "good", null, null, null, null, null, true);
         // then
         verify(restrictionRepository).merge(any(RestrictionEntity.class));
-        verify(permissionRepository).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test(expected=AMWException.class)
@@ -299,7 +299,7 @@ public class PermissionBoundaryTest {
         permissionBoundary.createRestriction("existing", null, "good", null, null, null, null, null, false, true);
         // then
         verify(restrictionRepository).create(any(RestrictionEntity.class));
-        verify(permissionRepository).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -415,7 +415,7 @@ public class PermissionBoundaryTest {
         permissionBoundary.removeRestriction(42, true);
         // then
         verify(restrictionRepository).deleteRestrictionById(42);
-        verify(permissionRepository).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -878,7 +878,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(2));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -898,7 +898,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(4));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -920,7 +920,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(6));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -939,7 +939,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(12));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -960,7 +960,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -981,7 +981,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(48));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -1004,7 +1004,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(48));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -1025,7 +1025,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -1045,7 +1045,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(24));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(1)).forceReloadingOfLists();
+        verify(permissionService).reloadCache();
     }
 
     @Test
@@ -1063,7 +1063,7 @@ public class PermissionBoundaryTest {
         // then
         assertThat(total, is(12));
         verify(restrictionRepository, times(total)).create(any(RestrictionEntity.class));
-        verify(permissionRepository, times(0)).forceReloadingOfLists();
+        verify(permissionService, times(0)).reloadCache();
     }
 
     @Test(expected=AMWException.class)
@@ -1076,7 +1076,7 @@ public class PermissionBoundaryTest {
 
         // when // then
         permissionBoundary.createMultipleRestrictions(roleName1, null, Arrays.asList(resourcePermission.getValue()), Arrays.asList(1), Arrays.asList(resourceTypeName1), ResourceTypePermission.ANY, null, Arrays.asList(Action.CREATE, Action.UPDATE), false, true);
-        verify(permissionRepository, times(0)).forceReloadingOfLists();
+        verify(permissionService, times(0)).reloadCache();
     }
 
 }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionServiceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionServiceTest.java
@@ -899,7 +899,6 @@ public class PermissionServiceTest {
 	@Test
 	public void shouldOnlyReloadWhenNeeded() {
 		// given
-		when(permissionService.permissionRepository.isReloadRolesAndPermissionsList()).thenReturn(false);
 		permissionService.rolesWithRestrictions = new HashMap<>();
 
 		// when
@@ -912,8 +911,7 @@ public class PermissionServiceTest {
 	@Test
 	public void shouldObtainRolesWithRestrictions() {
 		// given
-		when(permissionService.permissionRepository.isReloadRolesAndPermissionsList()).thenReturn(true);
-		when(permissionService.permissionRepository.getRolesWithRestrictions()).thenReturn(null);
+		when(permissionService.permissionRepository.getRolesWithRestrictions()).thenReturn(EMPTY_LIST);
 
 		// when
 		permissionService.getPermissions();
@@ -925,7 +923,6 @@ public class PermissionServiceTest {
 	@Test
 	public void shouldObtainDeployableRolesOnGetDeployableRolesWhenNeeded() {
 		// given
-		when(permissionService.permissionRepository.isReloadDeployableRoleList()).thenReturn(true);
 		when(permissionService.permissionRepository.getDeployableRoles()).thenReturn(EMPTY_LIST);
 
 		// when


### PR DESCRIPTION
Instead of setting a flag for the permissions cache reload, the reload is now done explicitly. User cache can't be loaded ahead of time so it is still loaded on demand.

Why?
* Reduces the randomness from which code the cache is reloaded. Potential fix for #480.
* Reduces potential concurrent reloads.