### PR TITLE
Only use HasPermissionInterceptor if the annotation is set

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploymentparameter/boundary/DeploymentParameterBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploymentparameter/boundary/DeploymentParameterBoundary.java
@@ -26,14 +26,12 @@ import ch.puzzle.itc.mobiliar.business.deploymentparameter.entity.DeploymentPara
 import ch.puzzle.itc.mobiliar.business.deploymentparameter.entity.Key;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.utils.ValidationException;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
@@ -43,7 +41,6 @@ import static ch.puzzle.itc.mobiliar.business.security.entity.Action.DELETE;
 import static ch.puzzle.itc.mobiliar.business.security.entity.Action.UPDATE;
 
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class DeploymentParameterBoundary {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -25,16 +25,13 @@ import java.util.List;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.util.ApplicationServerContainer;
 
 /**
  * The ScreenDomainService for Applist Screens
  */
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class ApplistScreenDomainService {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/commons/CommonDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/commons/CommonDomainService.java
@@ -29,7 +29,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceGroupPersis
 import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceTypeProvider;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.*;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.GeneralDBException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
@@ -38,7 +37,6 @@ import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -59,7 +57,6 @@ import java.util.logging.Logger;
  *
  */
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 public class CommonDomainService {
     @Inject
     private EntityManager entityManager;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/control/EnvironmentsScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/control/EnvironmentsScreenDomainService.java
@@ -26,13 +26,11 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceTypeProvide
 import ch.puzzle.itc.mobiliar.business.security.control.SecurityScreenDomainService;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.ContextNames;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -42,7 +40,6 @@ import java.util.logging.Logger;
 /**
  * Use {@link ContextRepository} - move all functionality to the control to fulfill the cec pattern
  */
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 @Deprecated
 public class EnvironmentsScreenDomainService {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/foreignable/boundary/ForeignableBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/foreignable/boundary/ForeignableBoundary.java
@@ -26,16 +26,13 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 
 import ch.puzzle.itc.mobiliar.business.foreignable.control.ForeignableService;
 import ch.puzzle.itc.mobiliar.business.foreignable.entity.Foreignable;
 import ch.puzzle.itc.mobiliar.business.foreignable.entity.ForeignableAttributesDTO;
 import ch.puzzle.itc.mobiliar.business.foreignable.entity.ForeignableOwner;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class ForeignableBoundary implements Serializable {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
@@ -49,7 +49,6 @@ import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.utils.ValidationException;
 import ch.puzzle.itc.mobiliar.business.utils.ValidationHelper;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
@@ -59,7 +58,6 @@ import ch.puzzle.itc.mobiliar.common.util.ContextNames;
 import javax.ejb.EJBException;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import java.util.*;
@@ -69,7 +67,6 @@ import java.util.logging.Logger;
  * ALL boundary for property editing
  */
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 public class PropertyEditor {
 
     // TODO Move methods to the proper boundary

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyTagEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyTagEditor.java
@@ -25,17 +25,14 @@ import ch.puzzle.itc.mobiliar.business.property.entity.PropertyTagEntity;
 import ch.puzzle.itc.mobiliar.business.property.entity.PropertyTagType;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import java.util.List;
 
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class PropertyTagEditor {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/control/PropertyTypeScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/control/PropertyTypeScreenDomainService.java
@@ -25,7 +25,6 @@ import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -36,7 +35,6 @@ import ch.puzzle.itc.mobiliar.business.property.entity.PropertyTagEntity;
 import ch.puzzle.itc.mobiliar.business.property.entity.PropertyTypeEntity;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.*;
 
 /**
@@ -44,7 +42,6 @@ import ch.puzzle.itc.mobiliar.common.exception.*;
  *
  */
 // TODO: transfer to PropertyTypeService
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class PropertyTypeScreenDomainService {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/releasing/control/ReleaseMgmtService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/releasing/control/ReleaseMgmtService.java
@@ -28,13 +28,11 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.GeneralDBException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import java.util.*;
@@ -43,7 +41,6 @@ import java.util.logging.Logger;
 import static ch.puzzle.itc.mobiliar.business.security.entity.Action.*;
 
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 public class ReleaseMgmtService {
 
     @Inject

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/CopyResource.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/CopyResource.java
@@ -35,7 +35,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 
 import ch.puzzle.itc.mobiliar.business.domain.commons.CommonDomainService;
@@ -51,7 +50,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroup;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
 import ch.puzzle.itc.mobiliar.common.exception.NotAuthorizedException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
@@ -62,7 +60,6 @@ import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
  * @author cweber
  */
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class CopyResource {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -27,7 +27,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.usersettings.control.UserSettingsService;
 import ch.puzzle.itc.mobiliar.business.usersettings.entity.FavoriteResourceEntity;
 import ch.puzzle.itc.mobiliar.business.usersettings.entity.UserSettingsEntity;
@@ -37,14 +36,12 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class ResourceRelations {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
@@ -34,7 +34,6 @@ import ch.puzzle.itc.mobiliar.business.security.control.RestrictionRepository;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
@@ -43,7 +42,6 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -54,7 +52,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class ResourceTypeDomainService {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/boundary/PermissionBoundary.java
@@ -34,7 +34,6 @@ import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.control.RestrictionRepository;
 import ch.puzzle.itc.mobiliar.business.security.entity.*;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.utils.Identifiable;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
@@ -43,7 +42,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -54,7 +52,6 @@ import java.util.Map;
  * A boundary for checking permissions of view elements
  */
 @Stateless
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 public class PermissionBoundary implements Serializable {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/SecurityScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/SecurityScreenDomainService.java
@@ -25,21 +25,18 @@ import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.security.entity.PermissionEntity;
 
 /**
  * @author aromano
  * 
  */
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class SecurityScreenDomainService {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownStpService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownStpService.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
@@ -39,7 +38,6 @@ import javax.persistence.criteria.Root;
 
 import ch.puzzle.itc.mobiliar.business.generator.control.ShakedownTestGeneratorDomainService;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.template.control.TemplatesScreenDomainService;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownStpEntity;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
@@ -52,7 +50,6 @@ import static ch.puzzle.itc.mobiliar.business.security.entity.Action.CREATE;
 import static ch.puzzle.itc.mobiliar.business.security.entity.Action.DELETE;
 import static ch.puzzle.itc.mobiliar.business.security.entity.Action.UPDATE;
 
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class ShakedownStpService {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/shakedown/control/ShakedownTestService.java
@@ -37,7 +37,6 @@ import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ProvidedResourceR
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestEntity;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestEntity.ApplicationsFromApplicationServer;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestEntity.shakedownTest_state;
@@ -53,7 +52,6 @@ import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
@@ -67,7 +65,6 @@ import java.util.logging.Logger;
 
 import static ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownTestFilterTypes.QLConstants.*;
 
-@Interceptors(HasPermissionInterceptor.class)
 @Stateless
 public class ShakedownTestService{
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -37,7 +37,6 @@ import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.template.control.FreemarkerSyntaxValidator;
 import ch.puzzle.itc.mobiliar.business.template.entity.RevisionInformation;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
@@ -54,7 +53,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -63,7 +61,6 @@ import java.util.logging.Logger;
 
 @Stateless
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-@Interceptors(HasPermissionInterceptor.class)
 public class TemplateEditor {
 
 	@Inject

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/control/TemplatesScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/control/TemplatesScreenDomainService.java
@@ -27,7 +27,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.*;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.*;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermissionInterceptor;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.control.ResourceRelationService;
 import ch.puzzle.itc.mobiliar.business.environment.entity.ContextEntity;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
@@ -39,7 +38,6 @@ import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
 import javax.inject.Inject;
-import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.Query;
@@ -51,7 +49,6 @@ import javax.persistence.criteria.Root;
 import java.util.*;
 import java.util.logging.Logger;
 
-@Interceptors(HasPermissionInterceptor.class)
 @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 @Stateless
 public class TemplatesScreenDomainService {

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/interceptor/HasPermissionInterceptorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/interceptor/HasPermissionInterceptorTest.java
@@ -58,7 +58,7 @@ public class HasPermissionInterceptorTest {
         when(context.getTarget()).thenReturn(new TestBoundary());
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void shouldNotCallPermissionService() throws Exception {
         //given
         when(context.getMethod()).thenReturn(TestBoundary.class.getMethod("noPermissionNeeded"));


### PR DESCRIPTION
The roleCall interceptor was called many times without the HasPermission annotation being present. The interceptor needs the annotation to work.

This pull request removes these calls and stops checking if the annotation is set in the interceptor.