### PR TITLE
change from old url uk.maven.org/maven2 to the new one repo1.maven.or…

### DIFF
--- a/AMW_shakedown/pom.xml
+++ b/AMW_shakedown/pom.xml
@@ -36,8 +36,8 @@
     <repositories>
         <repository>
             <id>central</id>
-            <name>Maven Central Repository Europe</name>
-            <url>http://uk.maven.org/maven2</url>
+            <name>Maven Central Repository</name>
+            <url>https://repo1.maven.org/maven2/</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <repositories>
         <repository>
             <id>central</id>
-            <name>Maven Central Repository Europe</name>
-            <url>http://uk.maven.org/maven2</url>
+            <name>Maven Central Repository</name>
+            <url>https://repo1.maven.org/maven2/</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>


### PR DESCRIPTION
Change from old url uk.maven.org/maven2 to the new one repo1.maven.org/maven2

_Remark_: It is not possible to use old maven central repository url, following message is received:
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required