### PR TITLE
remove unsed package tags-input

### DIFF
--- a/AMW_angular/io/package-lock.json
+++ b/AMW_angular/io/package-lock.json
@@ -2511,11 +2511,6 @@
       "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
       "integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA=="
     },
-    "bootstrap-tagsinput": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-tagsinput/-/bootstrap-tagsinput-0.7.1.tgz",
-      "integrity": "sha1-/+Owa74qEGlF7ygUVoAFqU8hGTc="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/AMW_angular/io/package.json
+++ b/AMW_angular/io/package.json
@@ -26,7 +26,6 @@
     "@ng-select/ng-select": "~3.7.2",
     "bootstrap-3-typeahead": "4.0.2",
     "bootstrap-sass": "3.4.1",
-    "bootstrap-tagsinput": "0.7.1",
     "eonasdan-bootstrap-datetimepicker": "4.17.47",
     "jquery": "^3.4.1",
     "rxjs": "~6.5.4",

--- a/AMW_angular/io/src/app/app.component.scss
+++ b/AMW_angular/io/src/app/app.component.scss
@@ -25,7 +25,6 @@ $icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/type';
 @import '~bootstrap-sass/assets/stylesheets/bootstrap/utilities';
 
-@import '~bootstrap-tagsinput/dist/bootstrap-tagsinput';
 @import '~eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker';
 @import 'auditview/auditview.scss';
 @import 'deployment/deployments.scss';
@@ -192,12 +191,6 @@ body {
     padding-right: 40px;
     padding-left: 40px;
   }
-}
-
-.bootstrap-tagsinput .tag {
-  border: 1px solid #d9d9d9;
-  background-color: #ededed;
-  color: #333333;
 }
 
 .datepicker {


### PR DESCRIPTION
I checked the application and noticed that bootstrap-tagsinput is not used anywhere in the frontend.

The permission screen uses tags but is based on the ng-select package. 

This merge request resolves #537 