### PR TITLE
Don't cache Angular index.html

### DIFF
--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,2 +1,3 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
+path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')


### PR DESCRIPTION
Don't cache the Angular index.html so that the browser automatically loads the new app version.
The path of to index is actually just `/` but in the filter you have to specify the path inside the war.