### PR TITLE
Use ubuntu bionic/18.04 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: required
 cache:
   directories:


### PR DESCRIPTION
By default travis uses 16.04 with docker 18.0, which is quite old...