### PR TITLE
add missing deployment exRuntime code

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentBoundary.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/boundary/DeploymentBoundary.java
@@ -335,6 +335,14 @@ public class DeploymentBoundary {
         return deployment.getRelease().getName();
     }
 
+    public String getDeletedRuntimeName(DeploymentEntity deployment) {
+        if (deployment.getRuntime() == null) {
+            ResourceEntity res = (ResourceEntity) auditService.getDeletedEntity(new ResourceEntity(), deployment.getExRuntimeResourceId());
+            return res.getName();
+        }
+        return deployment.getRuntime().getName();
+    }
+
     private void populateDeletedContextMap() {
         deletedContextNameIdMap = new HashMap<>();
         List<ContextEntity> allDeletedEnvironments = contextLocator.getAllDeletedEnvironments();

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/deployments/DeploymentsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/deployments/DeploymentsRest.java
@@ -175,6 +175,9 @@ public class DeploymentsRest {
         if (deployment.getExReleaseId() != null) {
             properties.setReleaseName(deploymentBoundary.getDeletedReleaseName(deployment));
         }
+        if (deployment.getExRuntimeResourceId() != null) {
+            properties.setRuntimeName(deploymentBoundary.getDeletedRuntimeName(deployment));
+        }
         deploymentDTO.setPreservedValues(deployment, properties);
         deploymentDTO.setActions(new DeploymentActionsDTO());
         return deploymentDTO;


### PR DESCRIPTION
Fixes a NullPointerException on the deployment REST service when a runtime was deleted. Exception: 
```
2020-09-02 08:45:55,652 logLev=ERROR class=org.jboss.as.ejb3.invocation thread="default task-12010" corrID= caller= user= WFLYEJB0034: EJB Invocation failed on component DeploymentsRest for method public javax.ws.rs.core.Response ch.mobi.itc.mobiliar.rest.deployments.DeploymentsRest.getDeployments(java.lang.String,java.lang.String,java.lang.String,java.lang.Integer,java.lang.Integer): javax.ejb.EJBException: java.lang.NullPointerException
....
Caused by: java.lang.NullPointerException
        at deployment.AMW.ear.AMW_rest.war//ch.mobi.itc.mobiliar.rest.dtos.DeploymentDTO.setPreservedValues(DeploymentDTO.java:106)
        at deployment.AMW.ear.AMW_rest.war//ch.mobi.itc.mobiliar.rest.deployments.DeploymentsRest.createPreservedDeploymentDTO(DeploymentsRest.java:178)
        at deployment.AMW.ear.AMW_rest.war//ch.mobi.itc.mobiliar.rest.deployments.DeploymentsRest.createDeploymentDTO(DeploymentsRest.java:153)
        at deployment.AMW.ear.AMW_rest.war//ch.mobi.itc.mobiliar.rest.deployments.DeploymentsRest.createDeploymentDTOs(DeploymentsRest.java:146)
```

Sample REST call: AMW_rest/resources/deployments/filter?filters=[{"name":"Environment","comp":"eq","val":"P"},{"name":"Latest+deployment+job+for+App+Server+and+Env","comp":"eq","val":""}]

