### PR TITLE
Issue/549 incomplete audit view

### DIFF
--- a/AMW_angular/io/src/app/auditview/auditview-table/auditview-table.component.html
+++ b/AMW_angular/io/src/app/auditview/auditview-table/auditview-table.component.html
@@ -74,7 +74,7 @@
         </td>
         <td>
           <ngb-highlight
-            [result]="entry.oldValue | newlineFilter"
+            [result]="entry.value | newlineFilter"
             [term]="service.searchTerm"
           ></ngb-highlight>
         </td>

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
@@ -446,6 +446,7 @@ public class PropertyEditor {
             HasContexts<?> hasContextMerged = entityManager.merge(hasContexts);
             ContextEntity contextMerged = entityManager.merge(context);
             ContextDependency<?> contextDependency = hasContextMerged.getOrCreateContext(contextMerged);
+            auditService.storeIdInThreadLocalForAuditLog(contextDependency);
             propertyValueService.setPropertyValue(contextDependency, propertyDescriptorId,
                     unobfuscatedValue);
         }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditorTest.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 
+import ch.puzzle.itc.mobiliar.business.auditview.control.AuditService;
 import ch.puzzle.itc.mobiliar.business.environment.control.ContextDomainService;
 import ch.puzzle.itc.mobiliar.business.property.entity.*;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.control.ResourceRelationContextRepository;
@@ -110,11 +111,13 @@ public class PropertyEditorTest {
     ForeignableService foreignableServiceMock;
 
     @Mock
+    AuditService auditServiceMock;
+
+    @Mock
     Logger log;
 
     @InjectMocks
     PropertyEditor editor;
-
 
     @Test(expected = ValidationException.class)
     public void setPropertyValueOnResourceForContextOnInvalidArgumentShouldThrowValidationException() throws Exception {
@@ -214,6 +217,7 @@ public class PropertyEditorTest {
 
         //then
         verify(propertyValueServiceMock).setPropertyValue(ArgumentMatchers.any(ContextDependency.class), eq(1), ArgumentMatchers.eq(propertyValue));
+        verify(auditServiceMock).storeIdInThreadLocalForAuditLog(any(ContextDependency.class));
 
     }
 
@@ -453,6 +457,7 @@ public class PropertyEditorTest {
 
         // then
         verify(propertyValueServiceMock).setPropertyValue(ArgumentMatchers.any(ContextDependency.class), eq(1), ArgumentMatchers.eq(propertyValue));
+       // verify(auditServiceMock).storeIdInThreadLocalForAuditLog(any(HasContexts.class));
     }
 
 
@@ -778,7 +783,7 @@ public class PropertyEditorTest {
 
         // then
         verify(propertyValueServiceMock).setPropertyValue(ArgumentMatchers.any(ContextDependency.class), eq(1), ArgumentMatchers.eq(propertyValue));
-
+        verify(auditServiceMock).storeIdInThreadLocalForAuditLog(any(ContextDependency.class));
     }
 
 


### PR DESCRIPTION
In order to correctly write the audit log, the id has to be stored in the threadlocal.
I also noticed that the Auditview in the Frontend does not show the new value. only the old values are shown.

this fixes #549 