### PR TITLE
Timepicker fixup

### DIFF
--- a/AMW_angular/io/.gitignore
+++ b/AMW_angular/io/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+debug.log
 # Only exists if Bazel was run
 /bazel-out
 

--- a/AMW_angular/io/src/app/auditview/auditview-table/auditview-table.service.ts
+++ b/AMW_angular/io/src/app/auditview/auditview-table/auditview-table.service.ts
@@ -75,7 +75,6 @@ export class AuditviewTableService {
       tap(() => this._loading$.next(true)),
       debounceTime(200),
       map(([searchTerm, sortColumn, sortDirection, auditlogEntries]) => {
-        console.log('mapping it');
         return this._search(
           searchTerm,
           sortColumn,

--- a/AMW_angular/io/src/app/deployment/deployment.component.spec.ts
+++ b/AMW_angular/io/src/app/deployment/deployment.component.spec.ts
@@ -21,6 +21,7 @@ import * as moment from 'moment';
 import { SharedModule } from '../shared/shared.module';
 import { NavigationStoreService } from '../navigation/navigation-store.service';
 import { DATE_FORMAT } from '../core/amw-constants';
+import { DateTimeModel } from '../shared/date-time-picker/date-time.model';
 @Component({
   template: '',
 })
@@ -327,7 +328,7 @@ describe('DeploymentComponent (create deployment)', () => {
       id: 5,
       tagDate: 1485378084103,
     } as ResourceTag;
-    component.deploymentDate = '2017-01-02 12:00';
+    component.deploymentDate = DateTimeModel.fromLocalString('2017-01-02 12:00', DATE_FORMAT);
     component.transDeploymentParameters = [
       { key: 'atest', value: 'foo' } as DeploymentParameter,
       { key: 'btest', value: 'bar' } as DeploymentParameter,

--- a/AMW_angular/io/src/app/deployment/deployment.component.ts
+++ b/AMW_angular/io/src/app/deployment/deployment.component.ts
@@ -47,7 +47,7 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
   runtime: Relation = null;
   resourceTags: ResourceTag[] = [this.defaultResourceTag];
   selectedResourceTag: ResourceTag = this.defaultResourceTag;
-  deploymentDate: DateTimeModel = new DateTimeModel();
+  deploymentDate: DateTimeModel = null;
   appsWithVersion: AppWithVersion[] = [];
   transDeploymentParameter: DeploymentParameter = {} as DeploymentParameter;
   transDeploymentParameters: DeploymentParameter[] = [];

--- a/AMW_angular/io/src/app/deployment/deployment.component.ts
+++ b/AMW_angular/io/src/app/deployment/deployment.component.ts
@@ -19,6 +19,7 @@ import * as moment from 'moment';
 import * as $ from 'jquery'; // this needs to be here...
 import { NavigationStoreService } from '../navigation/navigation-store.service';
 import { DATE_FORMAT } from '../core/amw-constants';
+import { DateTimeModel } from '../shared/date-time-picker/date-time.model';
 
 @Component({
   selector: 'amw-deployment',
@@ -46,7 +47,7 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
   runtime: Relation = null;
   resourceTags: ResourceTag[] = [this.defaultResourceTag];
   selectedResourceTag: ResourceTag = this.defaultResourceTag;
-  deploymentDate: string = '';
+  deploymentDate: DateTimeModel = new DateTimeModel();
   appsWithVersion: AppWithVersion[] = [];
   transDeploymentParameter: DeploymentParameter = {} as DeploymentParameter;
   transDeploymentParameters: DeploymentParameter[] = [];
@@ -134,7 +135,6 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
     if (!this.selectedRelease) {
       this.selectedRelease = this.releases[0];
     }
-    console.log('selected release is ' + this.selectedRelease.release);
     this.getRelatedForRelease();
     this.goTo(this.selectedAppserver.name + '/' + this.selectedRelease.release);
   }
@@ -171,13 +171,11 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
 
   requestDeployment() {
     this.requestOnly = true;
-    console.log('requestDeployment()');
     this.prepareDeployment();
   }
 
   createDeployment() {
     this.requestOnly = false;
-    console.log('createDeployment()');
     this.prepareDeployment();
   }
 
@@ -418,10 +416,7 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
           : new Date().getTime();
     }
     if (this.deploymentDate) {
-      const dateTime = moment(this.deploymentDate, DATE_FORMAT);
-      if (dateTime && dateTime.isValid()) {
-        deploymentRequest.deploymentDate = dateTime.valueOf();
-      }
+      deploymentRequest.deploymentDate = this.deploymentDate.toEpoch();
     }
     if (this.transDeploymentParameters.length > 0) {
       deploymentRequest.deploymentParameters = this.transDeploymentParameters;
@@ -487,7 +482,6 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
   // for url params only
   private setPreselected() {
     if (this.appserverName) {
-      console.log('pre-selected server is ' + this.appserverName);
       this.selectedAppserver = _.find(this.appservers, {
         name: this.appserverName,
       });
@@ -521,7 +515,6 @@ export class DeploymentComponent implements OnInit, AfterViewInit {
   // for url params only
   private setRelease() {
     if (this.releaseName) {
-      console.log('pre-selected release is ' + this.releaseName);
       this.selectedRelease = this.releases.find(
         (release) => release.release === this.releaseName
       );

--- a/AMW_angular/io/src/app/deployments/deployments-list.component.html
+++ b/AMW_angular/io/src/app/deployments/deployments-list.component.html
@@ -309,21 +309,6 @@
           </button>
         </div>
         <div class="modal-body">
-          <div
-            *ngIf="errorMessage"
-            class="alert alert-warning alert-dismissible"
-            role="alert"
-          >
-            <span [innerHTML]="errorMessage"></span>
-            <button
-              type="button"
-              class="close"
-              data-dismiss="alert"
-              aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
           <div class="input-group date">
             <app-date-time-picker
               [(ngModel)]="deploymentDate"

--- a/AMW_angular/io/src/app/deployments/deployments-list.component.ts
+++ b/AMW_angular/io/src/app/deployments/deployments-list.component.ts
@@ -37,8 +37,6 @@ export class DeploymentsListComponent {
 
   hasPermissionShakedownTest: boolean = null;
 
-  errorMessage: string = '';
-
   allSelected: boolean = false;
 
   failureReason: { [key: string]: string } = {
@@ -71,7 +69,6 @@ export class DeploymentsListComponent {
       .canCreateShakedownTest(this.deployment.appServerId)
       .subscribe(
         /* happy path */ (r) => (this.hasPermissionShakedownTest = r),
-        /* error path */ (e) => (this.errorMessage = e),
         /* onComplete */ () => $('#deploymentConfirmation').modal('show')
       );
   }
@@ -88,18 +85,11 @@ export class DeploymentsListComponent {
 
   doDateChange() {
     if (this.deployment) {
-      this.errorMessage = '';
-      const dateTime = this.deploymentDate.toEpoch();
-      // todo: move to timepicker
- //     if (!dateTime || !dateTime.isValid()) {
- //       this.errorMessage = 'Invalid date';
- //     } else {
-        this.deployment.deploymentDate = dateTime.valueOf();
-        this.editDeploymentDate.emit(this.deployment);
-        $('#deploymentDateChange').modal('hide');
-        delete this.deployment;
-        delete this.deploymentDate;
-  //    }
+      this.deployment.deploymentDate = this.deploymentDate.toEpoch();
+      this.editDeploymentDate.emit(this.deployment);
+      $('#deploymentDateChange').modal('hide');
+      delete this.deployment;
+      delete this.deploymentDate;
     }
   }
 

--- a/AMW_angular/io/src/app/deployments/deployments-list.component.ts
+++ b/AMW_angular/io/src/app/deployments/deployments-list.component.ts
@@ -87,7 +87,6 @@ export class DeploymentsListComponent {
   }
 
   doDateChange() {
-    debugger;
     if (this.deployment) {
       this.errorMessage = '';
       const dateTime = moment(this.deploymentDate, DATE_FORMAT);

--- a/AMW_angular/io/src/app/deployments/deployments-list.component.ts
+++ b/AMW_angular/io/src/app/deployments/deployments-list.component.ts
@@ -3,8 +3,7 @@ import { Deployment } from '../deployment/deployment';
 import { DeploymentFilter } from '../deployment/deployment-filter';
 import { ResourceService } from '../resource/resource.service';
 import * as _ from 'lodash';
-import * as moment from 'moment';
-import { DATE_FORMAT } from '../core/amw-constants';
+import { DateTimeModel } from '../shared/date-time-picker/date-time.model';
 
 @Component({
   selector: 'amw-deployments-list',
@@ -34,7 +33,7 @@ export class DeploymentsListComponent {
 
   deployment: Deployment;
 
-  deploymentDate: number;
+  deploymentDate: DateTimeModel = new DateTimeModel();
 
   hasPermissionShakedownTest: boolean = null;
 
@@ -62,6 +61,7 @@ export class DeploymentsListComponent {
 
   showDateChange(deploymentId: number) {
     this.deployment = _.find(this.deployments, ['id', deploymentId]);
+    this.deploymentDate = DateTimeModel.fromEpoch(this.deployment.deploymentDate);
     $('#deploymentDateChange').modal('show');
   }
 
@@ -89,16 +89,17 @@ export class DeploymentsListComponent {
   doDateChange() {
     if (this.deployment) {
       this.errorMessage = '';
-      const dateTime = moment(this.deploymentDate, DATE_FORMAT);
-      if (!dateTime || !dateTime.isValid()) {
-        this.errorMessage = 'Invalid date';
-      } else {
+      const dateTime = this.deploymentDate.toEpoch();
+      // todo: move to timepicker
+ //     if (!dateTime || !dateTime.isValid()) {
+ //       this.errorMessage = 'Invalid date';
+ //     } else {
         this.deployment.deploymentDate = dateTime.valueOf();
         this.editDeploymentDate.emit(this.deployment);
         $('#deploymentDateChange').modal('hide');
         delete this.deployment;
         delete this.deploymentDate;
-      }
+  //    }
     }
   }
 

--- a/AMW_angular/io/src/app/permission/permission.component.ts
+++ b/AMW_angular/io/src/app/permission/permission.component.ts
@@ -191,7 +191,6 @@ export class PermissionComponent implements OnInit, OnDestroy, AfterViewInit {
   createRestrictions(restrictionsCreation: RestrictionsCreation) {
     this.clearMessages();
     this.isLoading = true;
-    console.log('createRestrictions ' + JSON.stringify(restrictionsCreation));
     this.permissionService
       .createRestrictions(restrictionsCreation, this.delegationMode)
       .subscribe(

--- a/AMW_angular/io/src/app/shared/date-time-picker/dae-time.model.spec.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/dae-time.model.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import * as moment from 'moment';
+import { DateTimePickerComponent } from './date-time-picker.component';
+import { DateTimeModel } from "./date-time.model";
+
+describe('DateTimeModel', () => {
+  it('should convert dates correctly', () => {
+    var fixture = TestBed.createComponent(DateTimePickerComponent);
+    var component = fixture.componentInstance;
+    var testDate = '02.01.2017 12:00';
+
+    var m = moment(testDate, component.dateStringFormat);
+    var dateTimeFromString = DateTimeModel.fromLocalString(testDate, component.dateStringFormat);
+    var dateTimeFromEpoch = DateTimeModel.fromEpoch(m.valueOf());
+
+    expect(dateTimeFromString.day).toEqual(m.date());
+    expect(dateTimeFromString.month).toEqual(m.month() + 1);
+
+    expect(dateTimeFromString).toEqual(dateTimeFromEpoch);
+
+    expect(dateTimeFromString.toEpoch()).toEqual(m.valueOf());
+  });
+});

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
@@ -4,8 +4,9 @@
     class="form-control"
     (blur)="inputBlur($event)"
     [ngModel]="dateString"
-    (change)="onInputChange($event)"
+    (change)="onDateStringChange($event)"
     [disabled]="disabled"
+    placeholder="{{ dateStringFormat }}"
   />
 
   <div class="input-group-append">

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
@@ -31,7 +31,6 @@
   <div>
     <div *ngIf="!showTimePickerToggle">
       <ngb-datepicker
-        [startDate]="datetime"
         name="datepicker"
         [ngModel]="datetime"
         (ngModelChange)="onDateChange($event)"

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
@@ -3,7 +3,7 @@
     [ngClass]="ngControl?.valid ? 'ng-valid' : 'ng-invalid'"
     class="form-control"
     (blur)="inputBlur($event)"
-    [ngModel]="dateString | date: inputDatetimeFormat"
+    [ngModel]="dateString"
     (change)="onInputChange($event)"
     [disabled]="disabled"
   />

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.html
@@ -1,3 +1,9 @@
+<div *ngIf="errorMessage" class="alert alert-warning alert-dismissible" role="alert">
+  <span [innerHTML]="errorMessage"></span>
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
 <div class="input-group mr-2">
   <input
     [ngClass]="ngControl?.valid ? 'ng-valid' : 'ng-invalid'"
@@ -25,6 +31,7 @@
   <div>
     <div *ngIf="!showTimePickerToggle">
       <ngb-datepicker
+        [startDate]="datetime"
         name="datepicker"
         [ngModel]="datetime"
         (ngModelChange)="onDateChange($event)"

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
@@ -11,7 +11,7 @@ import {
   NgbTimeStruct,
   NgbPopoverConfig,
   NgbPopover,
-  NgbDatepicker,
+  NgbDateStruct,
 } from '@ng-bootstrap/ng-bootstrap';
 import {
   NG_VALUE_ACCESSOR,
@@ -56,9 +56,7 @@ export class DateTimePickerComponent
 
   showTimePickerToggle = false;
   datetime = new DateTimeModel();
-
-  @ViewChild(NgbDatepicker)
-  dp: NgbDatepicker;
+  errorMessage = "";
 
   @ViewChild(NgbPopover)
   popover: NgbPopover;
@@ -84,7 +82,6 @@ export class DateTimePickerComponent
   }
 
   writeValue(newModel: DateTimeModel) {
-    debugger;
     if (newModel) {
       this.datetime = Object.assign(this.datetime, newModel)
       //this.datetime = newModel;
@@ -115,8 +112,8 @@ export class DateTimePickerComponent
   onDateStringChange($event: any) {
     const value = $event.target.value;
     const dt = DateTimeModel.fromLocalString(value, this.dateStringFormat);
+    this.errorMessage = ""
 
-    //todo: handle invalid datestring
     if (dt) {
       this.datetime = dt;
       this.onChange(dt);
@@ -124,27 +121,28 @@ export class DateTimePickerComponent
       this.datetime = new DateTimeModel();
       this.dateString = '';
       this.onChange(this.datetime);
+    } else {
+      this.errorMessage = "Invalid date!"
     }
   }
 
-  onDateChange($event) {
-    debugger;
-    this.datetime.year = $event.year;
-    this.datetime.month = $event.month;
-    this.datetime.day = $event.day;
-
-    this.dp.navigateTo({
-      year: this.datetime.year,
-      month: this.datetime.month,
-    });
+  onDateChange(event: NgbDateStruct) {
+    if(!event) {
+      return
+    }
+    this.datetime.year = event.year;
+    this.datetime.month = event.month;
+    this.datetime.day = event.day;
     this.setDateString();
   }
 
   onTimeChange(event: NgbTimeStruct) {
+    if(!event) {
+      return
+    }
     this.datetime.hour = event.hour;
     this.datetime.minute = event.minute;
     this.datetime.second = event.second;
-
     this.setDateString();
   }
 

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
@@ -51,12 +51,10 @@ export class DateTimePickerComponent
   secondStep = 30;
   @Input()
   seconds = false;
-
   @Input()
   disabled = false;
 
   showTimePickerToggle = false;
-
   datetime = new DateTimeModel();
 
   @ViewChild(NgbDatepicker)
@@ -85,14 +83,12 @@ export class DateTimePickerComponent
     });
   }
 
-  writeValue(newModel: string) {
+  writeValue(newModel: DateTimeModel) {
+    debugger;
     if (newModel) {
-      this.datetime = Object.assign(
-        this.datetime,
-        DateTimeModel.fromLocalString(newModel, this.dateStringFormat)
-      );
-      this.dateString = newModel;
-      this.setDateStringModel();
+      this.datetime = Object.assign(this.datetime, newModel)
+      //this.datetime = newModel;
+      this.setDateString();
     } else {
       this.datetime = new DateTimeModel();
     }
@@ -115,23 +111,24 @@ export class DateTimePickerComponent
     this.disabled = isDisabled;
   }
 
-  onInputChange($event: any) {
+  // called when user updates the datestring directly
+  onDateStringChange($event: any) {
     const value = $event.target.value;
     const dt = DateTimeModel.fromLocalString(value, this.dateStringFormat);
 
+    //todo: handle invalid datestring
     if (dt) {
       this.datetime = dt;
-      this.setDateStringModel();
+      this.onChange(dt);
     } else if (value.trim() === '') {
       this.datetime = new DateTimeModel();
       this.dateString = '';
-      this.onChange(this.dateString);
-    } else {
-      this.onChange(value);
+      this.onChange(this.datetime);
     }
   }
 
   onDateChange($event) {
+    debugger;
     this.datetime.year = $event.year;
     this.datetime.month = $event.month;
     this.datetime.day = $event.day;
@@ -140,7 +137,7 @@ export class DateTimePickerComponent
       year: this.datetime.year,
       month: this.datetime.month,
     });
-    this.setDateStringModel();
+    this.setDateString();
   }
 
   onTimeChange(event: NgbTimeStruct) {
@@ -148,12 +145,12 @@ export class DateTimePickerComponent
     this.datetime.minute = event.minute;
     this.datetime.second = event.second;
 
-    this.setDateStringModel();
+    this.setDateString();
   }
 
-  setDateStringModel() {
+  setDateString() {
     this.dateString = this.datetime.toString(this.dateStringFormat);
-    this.onChange(this.dateString);
+    this.onChange(this.datetime);
   }
 
   inputBlur($event) {

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time-picker.component.ts
@@ -40,8 +40,9 @@ export class DateTimePickerComponent
   @Input()
   dateString: string;
 
+  // moment js format
   @Input()
-  inputDatetimeFormat = 'dd.MM.yyyy HH:mm';
+  dateStringFormat = 'DD.MM.yyyy HH:mm';
   @Input()
   hourStep = 1;
   @Input()
@@ -88,7 +89,7 @@ export class DateTimePickerComponent
     if (newModel) {
       this.datetime = Object.assign(
         this.datetime,
-        DateTimeModel.fromLocalString(newModel)
+        DateTimeModel.fromLocalString(newModel, this.dateStringFormat)
       );
       this.dateString = newModel;
       this.setDateStringModel();
@@ -116,7 +117,7 @@ export class DateTimePickerComponent
 
   onInputChange($event: any) {
     const value = $event.target.value;
-    const dt = DateTimeModel.fromLocalString(value);
+    const dt = DateTimeModel.fromLocalString(value, this.dateStringFormat);
 
     if (dt) {
       this.datetime = dt;
@@ -131,24 +132,9 @@ export class DateTimePickerComponent
   }
 
   onDateChange($event) {
-    if ($event.year) {
-      $event = `${$event.year}-${$event.month}-${$event.day}`;
-    }
-
-    const date = DateTimeModel.fromLocalString($event);
-
-    if (!date) {
-      this.dateString = this.dateString;
-      return;
-    }
-
-    if (!this.datetime) {
-      this.datetime = date;
-    }
-
-    this.datetime.year = date.year;
-    this.datetime.month = date.month;
-    this.datetime.day = date.day;
+    this.datetime.year = $event.year;
+    this.datetime.month = $event.month;
+    this.datetime.day = $event.day;
 
     this.dp.navigateTo({
       year: this.datetime.year,
@@ -166,7 +152,7 @@ export class DateTimePickerComponent
   }
 
   setDateStringModel() {
-    this.dateString = this.datetime.toString();
+    this.dateString = this.datetime.toString(this.dateStringFormat);
     this.onChange(this.dateString);
   }
 

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
@@ -17,46 +17,48 @@ export class DateTimeModel implements NgbDateTimeStruct {
     Object.assign(this, init);
   }
 
-  public static fromLocalString(dateString: string, format: string): DateTimeModel {
-    const date = moment(dateString, format).toDate();
-    const isValidDate = !isNaN(date.valueOf());
-
-    if (!dateString || !isValidDate) {
+  private static fromMoment(m: moment.Moment): DateTimeModel {
+    if (!m.isValid()) {
       return null;
     }
-
     return new DateTimeModel({
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
-      hour: date.getHours(),
-      minute: date.getMinutes(),
-      second: date.getSeconds(),
-      timeZoneOffset: date.getTimezoneOffset(),
+      year: m.year(),
+      month: m.month() + 1,
+      day: m.day(),
+      hour: m.hour(),
+      minute: m.minute(),
+      second: m.second(),
+      timeZoneOffset: m.utcOffset(),
     });
+  }
+
+  public static fromLocalString(dateString: string, format: string): DateTimeModel {
+    const m = moment(dateString, format);
+    return this.fromMoment(m);
   }
 
   public static fromEpoch(epoch: number) {
-    debugger;
-    const date = moment(epoch).toDate();
-    return new DateTimeModel({
-      year: date.getFullYear(),
-      month: date.getMonth() + 1,
-      day: date.getDate(),
-      hour: date.getHours(),
-      minute: date.getMinutes(),
-      second: date.getSeconds(),
-      timeZoneOffset: date.getTimezoneOffset(),
-    });
+    const m = moment(epoch);
+    return this.fromMoment(m);
+  }
+
+  private toMoment(): moment.Moment {
+    return moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});;
   }
 
   public toString(format: string): string {
-    const m = moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});
+    const m = this.toMoment();
+    if (!m.isValid()) {
+      return null;
+    }
     return m.format(format);
   }
 
   public toEpoch(): number {
-    const m = moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});
+    const m = this.toMoment();
+    if (!m.isValid()) {
+      return null;
+    }
     return m.valueOf();
   }
 }

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
@@ -36,16 +36,27 @@ export class DateTimeModel implements NgbDateTimeStruct {
     });
   }
 
-  private isInteger(value: any): value is number {
-    return (
-      typeof value === 'number' &&
-      isFinite(value) &&
-      Math.floor(value) === value
-    );
+  public static fromEpoch(epoch: number) {
+    debugger;
+    const date = moment(epoch).toDate();
+    return new DateTimeModel({
+      year: date.getFullYear(),
+      month: date.getMonth() + 1,
+      day: date.getDate(),
+      hour: date.getHours(),
+      minute: date.getMinutes(),
+      second: date.getSeconds(),
+      timeZoneOffset: date.getTimezoneOffset(),
+    });
   }
 
   public toString(format: string): string {
     const m = moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});
     return m.format(format);
+  }
+
+  public toEpoch(): number {
+    const m = moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});
+    return m.valueOf();
   }
 }

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
@@ -23,8 +23,10 @@ export class DateTimeModel implements NgbDateTimeStruct {
     }
     return new DateTimeModel({
       year: m.year(),
+      // months start at 0
       month: m.month() + 1,
-      day: m.day(),
+      // date is the day of month
+      day: m.date(),
       hour: m.hour(),
       minute: m.minute(),
       second: m.second(),
@@ -43,7 +45,7 @@ export class DateTimeModel implements NgbDateTimeStruct {
   }
 
   private toMoment(): moment.Moment {
-    return moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});;
+    return moment({ year: this.year, month: this.month - 1, date: this.day, hour: this.hour, minute: this.minute, second: this.second});;
   }
 
   public toString(format: string): string {

--- a/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
+++ b/AMW_angular/io/src/app/shared/date-time-picker/date-time.model.ts
@@ -1,5 +1,5 @@
 import { NgbTimeStruct, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
-import { DatePipe } from '@angular/common';
+import * as moment from 'moment';
 
 export interface NgbDateTimeStruct extends NgbDateStruct, NgbTimeStruct {}
 
@@ -17,9 +17,8 @@ export class DateTimeModel implements NgbDateTimeStruct {
     Object.assign(this, init);
   }
 
-  public static fromLocalString(dateString: string): DateTimeModel {
-    const date = new Date(dateString);
-
+  public static fromLocalString(dateString: string, format: string): DateTimeModel {
+    const date = moment(dateString, format).toDate();
     const isValidDate = !isNaN(date.valueOf());
 
     if (!dateString || !isValidDate) {
@@ -45,49 +44,8 @@ export class DateTimeModel implements NgbDateTimeStruct {
     );
   }
 
-  public toString(): string {
-    if (
-      this.isInteger(this.year) &&
-      this.isInteger(this.month) &&
-      this.isInteger(this.day)
-    ) {
-      const year = this.year.toString().padStart(2, '0');
-      const month = this.month.toString().padStart(2, '0');
-      const day = this.day.toString().padStart(2, '0');
-
-      if (!this.hour) {
-        this.hour = 0;
-      }
-      if (!this.minute) {
-        this.minute = 0;
-      }
-      if (!this.second) {
-        this.second = 0;
-      }
-
-      this.timeZoneOffset = new Date(
-        this.year,
-        this.month - 1, // javascript has zero-based months
-        this.day
-      ).getTimezoneOffset();
-
-      const hour = this.hour.toString().padStart(2, '0');
-      const minute = this.minute.toString().padStart(2, '0');
-      const second = this.second.toString().padStart(2, '0');
-
-      const tzo = -this.timeZoneOffset;
-      const dif = tzo >= 0 ? '+' : '-';
-      const pad = (num) => {
-        const norm = Math.floor(Math.abs(num));
-        return (norm < 10 ? '0' : '') + norm;
-      };
-
-      const isoString = `${pad(year)}-${pad(month)}-${pad(day)}T${pad(
-        hour
-      )}:${pad(minute)}:${pad(second)}${dif}${pad(tzo / 60)}:${pad(tzo % 60)}`;
-      return isoString;
-    }
-
-    return null;
+  public toString(format: string): string {
+    const m = moment({ year: this.year, month: this.month - 1, day: this.day, hour: this.hour, minute: this.minute, second: this.second});
+    return m.format(format);
   }
 }


### PR DESCRIPTION
Fixes #580 
I refactored the datetime picker to use the struct as the model instead of the string and added converter methods.
It now uses moment js for date conversion, it's only used in the model so it could be switched out easily (moment is officially in maintenance mode).
Moved the error messages to the datetime picker component.