### PR TITLE
434 template paths

### DIFF
--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
@@ -1,0 +1,87 @@
+package ch.puzzle.itc.mobiliar.business.template.boundary;
+
+import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
+
+public class TemplateEditorTest {
+
+    TemplateEditor templateEditor;
+    TemplateDescriptorEntity templateDescriptorEntity;
+
+    @Before
+    public void setUp() throws Exception {
+         templateEditor = new TemplateEditor();
+         templateDescriptorEntity = new TemplateDescriptorEntity();
+         templateDescriptorEntity.setName("template-name");
+         templateDescriptorEntity.setName("a/valid/target-path");
+    }
+
+    @Test
+    public void shouldThrowExceptionEmptyTemplateName() {
+        // given
+        templateDescriptorEntity.setName("");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("The template name must not be empty"));
+    }
+
+    @Test
+    public void shouldThrowExceptionPathStartsWithPathTraversal() {
+        // given
+        templateDescriptorEntity.setTargetPath("../starts/with/path-traversal");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("No path traversals like '../' allowed in file path"));
+    }
+
+    @Test
+    public void shouldThrowExceptionPathContainsPathTraversals() {
+        // given
+        templateDescriptorEntity.setTargetPath("path/contains/../../../../path-traversals");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("No path traversals like '../' allowed in file path"));
+    }
+
+    @Test
+    public void shouldThrowExpectionAbsoluteTemplatePath()  {
+        // given
+        templateDescriptorEntity.setTargetPath("/absolute/path/is/not/allowed");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("Absolute paths are not allowed for file path"));
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForTemplateWithNameAndValidPath() throws AMWException {
+        // given
+
+        // when
+        templateEditor.validateTemplate(templateDescriptorEntity);
+
+        // then
+        // test fails if an exception is thrown
+    }
+}

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -252,36 +252,9 @@ public class EditTemplateView implements Serializable {
         boolean success = true;
         String errorMessage = "Was not able to save the template: ";
         try {
-            // set the template to testing mode...
-            template.setTesting(settings.isTestingMode());
-            if (template.isTesting()) {
-                if (selectedStp != null) {
-                    template.setName(selectedStp.getStpName());
-                } else {
-                    throwError("No STP-name selected!");
-                }
-            }
-
-            if (template.getId() == null && !canAdd()) {
-                throwError("No permission to create template!");
-            } else if (!canModifyTemplates()) {
-                throwError("No permission to modify templates!");
-            }
-            if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
-                throwError("Absolute paths are not allowed for file path");
-            }
-
-            if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
-                throwError("No path traversals like '../' allowed in file path");
-            }
-            if (relationIdForTemplate != null) {
-                templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
-                        resourceId != null);
-            } else if (resourceId == null) {
-                templateEditor.saveTemplateForResourceType(template, resourceTypeId);
-            } else {
-                templateEditor.saveTemplateForResource(template, resourceId);
-            }
+            setTemplateName();
+            validateInput();
+            saveTemplate();
         } catch (ResourceNotFoundException | ResourceTypeNotFoundException e) {
             success = fail(errorMessage + e.getMessage());
         } catch (AMWException e) {
@@ -289,6 +262,43 @@ public class EditTemplateView implements Serializable {
         }
         if (success) {
             succeed();
+        }
+    }
+
+    private void setTemplateName() throws AMWException {
+        template.setTesting(settings.isTestingMode());
+        if (template.isTesting()) {
+            if (selectedStp != null) {
+                template.setName(selectedStp.getStpName());
+            } else {
+                throwError("No STP-name selected!");
+            }
+        }
+    }
+
+    private void saveTemplate() throws AMWException {
+        if (relationIdForTemplate != null) {
+            templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
+                    resourceId != null);
+        } else if (resourceId == null) {
+            templateEditor.saveTemplateForResourceType(template, resourceTypeId);
+        } else {
+            templateEditor.saveTemplateForResource(template, resourceId);
+        }
+    }
+
+    private void validateInput() throws AMWException {
+        if (template.getId() == null && !canAdd()) {
+            throwError("No permission to create template!");
+        } else if (!canModifyTemplates()) {
+            throwError("No permission to modify templates!");
+        }
+        if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
+            throwError("Absolute paths are not allowed for file path");
+        }
+
+        if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
+            throwError("No path traversals like '../' allowed in file path");
         }
     }
 

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -253,7 +253,7 @@ public class EditTemplateView implements Serializable {
         String errorMessage = "Was not able to save the template: ";
         try {
             setTemplateName();
-            validateInput();
+            checkPermissions();
             saveTemplate();
         } catch (ResourceNotFoundException | ResourceTypeNotFoundException e) {
             success = fail(errorMessage + e.getMessage());
@@ -287,18 +287,11 @@ public class EditTemplateView implements Serializable {
         }
     }
 
-    private void validateInput() throws AMWException {
+    private void checkPermissions() throws AMWException {
         if (template.getId() == null && !canAdd()) {
             throwError("No permission to create template!");
         } else if (!canModifyTemplates()) {
             throwError("No permission to modify templates!");
-        }
-        if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
-            throwError("Absolute paths are not allowed for file path");
-        }
-
-        if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
-            throwError("No path traversals like '../' allowed in file path");
         }
     }
 

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -73,45 +73,6 @@ public class EditTemplateViewTest {
     }
 
     @Test
-    public void shouldRejectAbsoluteTemplatePath() throws AMWException {
-        // given
-        template.setTargetPath("/absolute/path/is/not/allowed");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("Absolute paths are not allowed for file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
-    public void shouldRejectTemplatePathStartsWithPathTraversals() throws AMWException {
-        // given
-        template.setTargetPath("../../path/traversals/not/allowed");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
-    public void shouldRejectTemplatePathWithPathTraversalsInsidePath() throws AMWException {
-        // given
-        template.setTargetPath("you/can/../../../../traverse/paths/like/this");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
     public void shouldRejectTemplateInTestingModeWihtoutSelectedSTP() throws AMWException {
         // given
         doReturn(true).when(settings).isTestingMode();

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -1,0 +1,107 @@
+package ch.puzzle.itc.mobiliar.presentation.templateEdit;
+
+import ch.puzzle.itc.mobiliar.business.template.boundary.TemplateEditor;
+import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import ch.puzzle.itc.mobiliar.presentation.util.UserSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EditTemplateViewTest {
+
+    @Mock
+    UserSettings settings;
+
+    @Mock
+    TemplateEditor templateEditor;
+
+    @Spy
+    @InjectMocks
+    EditTemplateView editTemplateView;
+
+    private TemplateDescriptorEntity template;
+
+    @Before
+    public void setUp() {
+        doReturn(false).when(settings).isTestingMode();
+        doReturn(true).when(editTemplateView).canModifyTemplates();
+        doReturn(false).when(editTemplateView).fail(any(AMWException.class));
+
+        template = editTemplateView.getTemplate();
+        template.setId(1);
+    }
+
+    @Test
+    public void shouldRejectTemplateCreateIfNotAllowed() throws AMWException {
+        // given
+        template.setId(null);
+        doReturn(false).when(editTemplateView).canModifyTemplates();
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView, never()).succeed();
+        verify(editTemplateView).throwError("No permission to create template!");
+    }
+
+    @Test
+    public void shouldRejectTemplateModifyIfNotAllowed() throws AMWException {
+        // given
+        doReturn(false).when(editTemplateView).canModifyTemplates();
+
+        //when
+        editTemplateView.save();
+
+        //then
+        verify(editTemplateView, never()).succeed();
+        verify(editTemplateView).throwError("No permission to modify templates!");
+    }
+
+    @Test
+    public void shouldRejectAbsoluteTemplatePath() throws AMWException {
+        // given
+        template.setTargetPath("/absolute/path/is/not/allowed");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("absolute paths are not allowed for file path");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplatePathStartsWithPathTraversals() throws AMWException {
+        // given
+        template.setTargetPath("../../path/traversals/not/allowed");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplatePathWithPathTraversalsInsidePath() throws AMWException {
+        // given
+        template.setTargetPath("you/can/../../../../traverse/paths/like/this");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView, never()).succeed();
+    }
+}

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -1,5 +1,6 @@
 package ch.puzzle.itc.mobiliar.presentation.templateEdit;
 
+import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownStpEntity;
 import ch.puzzle.itc.mobiliar.business.template.boundary.TemplateEditor;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
@@ -20,13 +21,17 @@ public class EditTemplateViewTest {
     @Mock
     UserSettings settings;
 
-    @Mock
+    @Spy
     TemplateEditor templateEditor;
+
+    @Mock
+    ShakedownStpEntity selectedStp;
 
     @Spy
     @InjectMocks
     EditTemplateView editTemplateView;
 
+    @Spy
     private TemplateDescriptorEntity template;
 
     @Before
@@ -34,6 +39,7 @@ public class EditTemplateViewTest {
         doReturn(false).when(settings).isTestingMode();
         doReturn(true).when(editTemplateView).canModifyTemplates();
         doReturn(false).when(editTemplateView).fail(any(AMWException.class));
+        doNothing().when(editTemplateView).succeed();
 
         template = editTemplateView.getTemplate();
         template.setId(1);
@@ -75,7 +81,7 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("absolute paths are not allowed for file path");
+        verify(editTemplateView).throwError("Absolute paths are not allowed for file path");
         verify(editTemplateView, never()).succeed();
     }
 
@@ -88,7 +94,7 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
         verify(editTemplateView, never()).succeed();
     }
 
@@ -101,7 +107,100 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
         verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplateInTestingModeWihtoutSelectedSTP() throws AMWException {
+        // given
+        doReturn(true).when(settings).isTestingMode();
+        editTemplateView.setSelectedStpId(9999); // clear selectedStp in the view
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("No STP-name selected!");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldSetTemplateNameFromSelectedStp() throws AMWException {
+        // given
+        doReturn(true).when(settings).isTestingMode();
+        doReturn("name-of-selected-stp").when(selectedStp).getStpName();
+
+        editTemplateView.setResourceTypeId(10);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(template).setName("name-of-selected-stp");
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForRelationWithRousourceIdNull() throws AMWException {
+        // given
+        editTemplateView.setRelationIdForTemplate(1);
+        editTemplateView.setResourceId(null);
+        doNothing().when(templateEditor).saveTemplateForRelation(template, 1, false);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForRelation(template, 1, false);
+        verify(editTemplateView).succeed();
+
+    }
+
+    @Test
+    public void shouldSaveTemplateForRelationWithResourceId() throws AMWException {
+        editTemplateView.setRelationIdForTemplate(1);
+        editTemplateView.setResourceId(123);
+        doNothing().when(templateEditor).saveTemplateForRelation(template, 1, true);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForRelation(template, 1, true);
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForResourceType() throws AMWException {
+        // given
+        editTemplateView.setRelationIdForTemplate(null);
+        editTemplateView.setResourceId(null);
+        editTemplateView.setResourceTypeId(99);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForResourceType(template, 99);
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForResource() throws AMWException {
+        // given
+        editTemplateView.setResourceTypeId(null);
+        editTemplateView.setRelationIdForTemplate(null);
+        editTemplateView.setResourceId(10);
+        doNothing().when(templateEditor).saveTemplateForResource(template, 10);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForResource(template, 10);
+        verify(editTemplateView).succeed();
     }
 }


### PR DESCRIPTION
Validate the specified path for the template. Absolute paths starting with "/" and path traversals "../" are not allowed.

I allowed myself to add some wrapper methods in order to be able to write some unit tests and slightly refactor the save() method (mostly for readability)

fixes #434 