### PR TITLE
434 template paths permission check explorations

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionService.java
@@ -30,8 +30,8 @@ import ch.puzzle.itc.mobiliar.common.exception.NotAuthorizedException;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.ejb.SessionContext;
 import javax.ejb.Schedule;
+import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -967,4 +967,10 @@ public class PermissionService implements Serializable {
         return true;
     }
 
+    public void assertHasPermissionShakedownTestMode(boolean testingMode) {
+        if (testingMode) {
+            checkPermissionAndFireException(Permission.SHAKEDOWN_TEST_MODE,
+                                            "execute shakedown test mode");
+        }
+    }
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -132,8 +132,7 @@ public class TemplateEditor {
 
 	@TransactionAttribute(TransactionAttributeType.REQUIRED)
 	boolean hasTemplateWithSameName(TemplateDescriptorEntity template, HasContexts<?> hasContext) {
-		for (ContextDependency<?> c : hasContext.getContextsByLowestContext(contextService
-																					.getGlobalResourceContextEntity())) {
+		for (ContextDependency<?> c : hasContext.getContextsByLowestContext(contextService.getGlobalResourceContextEntity())) {
 			for (TemplateDescriptorEntity t : c.getTemplates()) {
 				// If the template doesn't exist but has the same name, we return true
 				if (!t.getId().equals(template.getId()) && t.getName().equals(template.getName())) {
@@ -144,9 +143,9 @@ public class TemplateEditor {
 		return false;
 	}
 
-	public <T extends HasContexts<?>> void saveTemplateForRelation(
-			TemplateDescriptorEntity template, Integer relationId, boolean resourceEdit)
-			throws AMWException {
+	public <T extends HasContexts<?>> void saveTemplateForRelation(TemplateDescriptorEntity template,
+																   Integer relationId,
+																   boolean resourceEdit) throws AMWException {
 		HasContexts<?> resourceRelation = null;
 		if (relationId != null) {
 			if (resourceEdit) {
@@ -218,8 +217,7 @@ public class TemplateEditor {
 		}
 
 
-		ContextDependency<?> globalContext = hasContext.getOrCreateContext(contextService
-																				   .getGlobalResourceContextEntity());
+		ContextDependency<?> globalContext = hasContext.getOrCreateContext(contextService.getGlobalResourceContextEntity());
 		if (template.getId() == null) {
 			entityManager.persist(template);
 			globalContext.addTemplate(template);
@@ -236,8 +234,7 @@ public class TemplateEditor {
 	 * @throws TemplateNotDeletableException
 	 */
 	public void removeTemplate(Integer templateId) throws TemplateNotDeletableException {
-		TemplateDescriptorEntity templateDescriptor = entityManager.find(TemplateDescriptorEntity.class,
-				templateId);
+		TemplateDescriptorEntity templateDescriptor = entityManager.find(TemplateDescriptorEntity.class, templateId);
 		if (templateDescriptor != null && templateDescriptor.getName() != null
 				&& SystemCallTemplate.getName().equals(templateDescriptor.getName())) {
 			String message = SystemCallTemplate.getName() + " Template can't be deleted since it is a system template!";
@@ -246,14 +243,29 @@ public class TemplateEditor {
 		}
 		AbstractContext owner = getOwnerOfTemplate(templateDescriptor);
 		if (owner != null) {
-			if (owner instanceof ResourceContextEntity && !permissionService.hasPermission(Permission.RESOURCE_TEMPLATE, null,
-					Action.DELETE, ((ResourceContextEntity) owner).getContextualizedObject().getResourceGroup(), null)) {
+			if (owner instanceof ResourceContextEntity && !permissionService.hasPermission(Permission.RESOURCE_TEMPLATE,
+																						   null,
+																						   Action.DELETE,
+																						   ((ResourceContextEntity) owner)
+																								   .getContextualizedObject()
+																								   .getResourceGroup(),
+																						   null)) {
 				throw new NotAuthorizedException("Not authorized to remove the template of a resource");
-			} else if (owner instanceof ResourceRelationContextEntity && !permissionService.hasPermission(Permission.RESOURCE_TEMPLATE, null,
-					Action.DELETE, ((ResourceRelationContextEntity) owner).getContextualizedObject().getMasterResource().getResourceGroup(), null)) {
+			} else if (owner instanceof ResourceRelationContextEntity && !permissionService.hasPermission(Permission.RESOURCE_TEMPLATE,
+																										  null,
+																										  Action.DELETE,
+																										  ((ResourceRelationContextEntity) owner)
+																												  .getContextualizedObject()
+																												  .getMasterResource()
+																												  .getResourceGroup(),
+																										  null)) {
 				throw new NotAuthorizedException("Not authorized to remove the template of a resource");
-			} else if (owner instanceof ResourceTypeContextEntity && !permissionService.hasPermission(Permission.RESOURCETYPE_TEMPLATE, null,
-					Action.DELETE, null, ((ResourceTypeContextEntity) owner).getContextualizedObject())) {
+			} else if (owner instanceof ResourceTypeContextEntity && !permissionService.hasPermission(Permission.RESOURCETYPE_TEMPLATE,
+																									  null,
+																									  Action.DELETE,
+																									  null,
+																									  ((ResourceTypeContextEntity) owner)
+																											  .getContextualizedObject())) {
 				throw new NotAuthorizedException("Not authorized to remove the template of a resource type");
 			}
 			auditService.storeIdInThreadLocalForAuditLog(owner);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -36,6 +36,7 @@ import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationC
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
+import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
 import ch.puzzle.itc.mobiliar.business.template.control.FreemarkerSyntaxValidator;
 import ch.puzzle.itc.mobiliar.business.template.entity.RevisionInformation;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
@@ -143,6 +144,7 @@ public class TemplateEditor {
 		return false;
 	}
 
+
 	public <T extends HasContexts<?>> void saveTemplateForRelation(TemplateDescriptorEntity template,
 																   Integer relationId,
 																   boolean resourceEdit) throws AMWException {
@@ -165,6 +167,7 @@ public class TemplateEditor {
 		}
 	}
 
+	@HasPermission(permission = Permission.RESOURCE_TEMPLATE, oneOfAction = {Action.UPDATE, Action.CREATE})
 	public void saveTemplateForResource(TemplateDescriptorEntity template, Integer resourceId,
 										boolean testingMode) throws AMWException {
 		permissionService.assertHasPermissionShakedownTestMode(testingMode);
@@ -176,6 +179,7 @@ public class TemplateEditor {
 		saveTemplate(template, resourceEntity);
 	}
 
+	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, oneOfAction = {Action.UPDATE, Action.CREATE})
 	public void saveTemplateForResourceType(TemplateDescriptorEntity template, Integer resourceTypeId,
 											boolean testingMode) throws AMWException {
 		permissionService.assertHasPermissionShakedownTestMode(testingMode);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -171,10 +171,12 @@ public class TemplateEditor {
 	public void saveTemplateForResource(TemplateDescriptorEntity template, Integer resourceId,
 										boolean testingMode) throws AMWException {
 		permissionService.assertHasPermissionShakedownTestMode(testingMode);
-		Action action = getAction(template);
-		permissionService.checkPermissionAndFireException(Permission.RESOURCE_TEMPLATE,
-														  action,
-														  "create/ modify resource templates");
+		if (!testingMode) {
+			Action action = getAction(template);
+			permissionService.checkPermissionAndFireException(Permission.RESOURCE_TEMPLATE,
+															  action,
+															  "create/ modify resource templates");
+		}
 		ResourceEntity resourceEntity = entityManager.find(ResourceEntity.class, resourceId);
 		saveTemplate(template, resourceEntity);
 	}
@@ -183,10 +185,12 @@ public class TemplateEditor {
 	public void saveTemplateForResourceType(TemplateDescriptorEntity template, Integer resourceTypeId,
 											boolean testingMode) throws AMWException {
 		permissionService.assertHasPermissionShakedownTestMode(testingMode);
-		Action action = getAction(template);
-		permissionService.checkPermissionAndFireException(Permission.RESOURCETYPE_TEMPLATE,
-														  action,
-														  "create/ modify resource type templates");
+		if (!testingMode) {
+			Action action = getAction(template);
+			permissionService.checkPermissionAndFireException(Permission.RESOURCETYPE_TEMPLATE,
+															  action,
+															  "create/ modify resource type templates");
+		}
 		ResourceTypeEntity resourceTypeEntity = entityManager.find(ResourceTypeEntity.class, resourceTypeId);
 		saveTemplate(template, resourceTypeEntity);
 	}

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -32,7 +32,9 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeContextEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.control.ResourceRelationService;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.AbstractResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationContextEntity;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationTypeEntity;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
@@ -148,71 +150,131 @@ public class TemplateEditor {
 	public <T extends HasContexts<?>> void saveTemplateForRelation(
 			TemplateDescriptorEntity template, Integer relationId, boolean resourceEdit)
 			throws AMWException {
-		HasContexts<?> resourceRelation = null;
 		if (relationId != null) {
 			if (resourceEdit) {
-				permissionService.checkPermissionAndFireException(Permission.RESOURCE_TEMPLATE,
-																  Action.UPDATE,
-																  "save resource templates");
-				resourceRelation = relationService.getResourceRelation(relationId);
+				udpateTemplate(template, relationService.getResourceRelation(relationId));
 			} else {
-				permissionService.checkPermissionAndFireException(Permission.RESOURCETYPE_TEMPLATE,
-																  Action.UPDATE,
-																  "save resource type templates");
-				resourceRelation = relationService.getResourceTypeRelation(relationId);
+				updateTemplate(template, relationService.getResourceTypeRelation(relationId));
 			}
 		}
+	}
+
+
+	public void saveTemplateForResource(TemplateDescriptorEntity template, Integer resourceId,
+										boolean testingMode) throws AMWException {
+
+		ResourceEntity resourceEntity = entityManager.find(ResourceEntity.class, resourceId);
+		if (template.getId() == null) {
+			createTemplate(template, resourceEntity, testingMode);
+		} else {
+			updateTemplate(template, resourceEntity, testingMode);
+		}
+	}
+
+
+	public void saveTemplateForResourceType(TemplateDescriptorEntity template, Integer resourceTypeId,
+											boolean testingMode) throws AMWException {
+		ResourceTypeEntity resourceTypeEntity = entityManager.find(ResourceTypeEntity.class, resourceTypeId);
+		if (template.getId() == null) {
+			createTemplate(template, resourceTypeEntity, testingMode);
+		} else {
+			updateTemplate(template, resourceTypeEntity, testingMode);
+		}
+
+	}
+
+	private void createTemplate(TemplateDescriptorEntity template, ResourceEntity resourceEntity,
+								boolean testingMode) throws AMWException {
+		if (testingMode) {
+			createTemplateInTestingMode(template, resourceEntity);
+		} else {
+			createTemplate(template, resourceEntity);
+		}
+	}
+
+	private void createTemplate(TemplateDescriptorEntity template, ResourceTypeEntity resourceTypeEntity,
+								boolean testingMode) throws AMWException {
+		if (testingMode) {
+			createTemplateInTestingMode(template, resourceTypeEntity);
+		} else {
+			createTemplate(template, resourceTypeEntity);
+		}
+	}
+
+	private void updateTemplate(TemplateDescriptorEntity template, ResourceTypeEntity resourceTypeEntity,
+								boolean testingMode) throws AMWException {
+		if (testingMode) {
+			updateTemplateInTestingMode(template, resourceTypeEntity);
+		} else {
+			updateTemplate(template, resourceTypeEntity);
+		}
+	}
+
+	private void updateTemplate(TemplateDescriptorEntity template, ResourceEntity resourceEntity,
+								boolean testingMode) throws AMWException {
+		if (testingMode) {
+			updateTemplateInTestingMode(template, resourceEntity);
+		} else {
+			updateTemplate(template, resourceEntity);
+		}
+	}
+
+	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, action = Action.CREATE)
+	private void createTemplate(TemplateDescriptorEntity template,
+								ResourceTypeEntity resourceTypeEntity) throws AMWException {
+		saveTemplate(template, resourceTypeEntity);
+	}
+
+	@HasPermission(permission = Permission.RESOURCE_TEMPLATE, action = Action.CREATE)
+	private void createTemplate(TemplateDescriptorEntity template,
+								ResourceEntity resourceTypeEntity) throws AMWException {
+		saveTemplate(template, resourceTypeEntity);
+	}
+
+
+	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, action = Action.UPDATE)
+	private void updateTemplate(TemplateDescriptorEntity template,
+								ResourceTypeEntity resourceTypeEntity) throws AMWException {
+		saveTemplate(template, resourceTypeEntity);
+	}
+
+	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, action = Action.UPDATE)
+	private void updateTemplate(TemplateDescriptorEntity template,
+								ResourceEntity resourceEntity) throws AMWException {
+		saveTemplate(template, resourceEntity);
+	}
+
+	@HasPermission(permission = Permission.RESOURCE_TEMPLATE, action = Action.UPDATE)
+	private void udpateTemplate(TemplateDescriptorEntity template,
+								AbstractResourceRelationEntity resourceRelation) throws AMWException {
 		if (resourceRelation != null) {
 			saveTemplate(template, resourceRelation);
 		}
 	}
 
-	@HasPermission(permission = Permission.RESOURCE_TEMPLATE, oneOfAction = {Action.UPDATE, Action.CREATE})
-	public void saveTemplateForResource(TemplateDescriptorEntity template, Integer resourceId,
-										boolean testingMode) throws AMWException {
-
-		boolean hasPermission = template.getId() == null
-				? this.hasPermissionToAddResourceTemplate(resourceId, testingMode)
-				: this.hasPermissionToUpdateResourceTemplate(resourceId, testingMode);
-
-		if (!hasPermission) {
-			throw new AMWException("no permission to add/ update template for resource");
+	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, action = Action.UPDATE)
+	private void updateTemplate(TemplateDescriptorEntity template,
+								ResourceRelationTypeEntity resourceTypeRelation) throws AMWException {
+		if (resourceTypeRelation != null) {
+			saveTemplate(template, resourceTypeRelation);
 		}
-		saveTemplate(template, entityManager.find(ResourceEntity.class, resourceId));
 	}
 
-	@HasPermission(permission = Permission.RESOURCETYPE_TEMPLATE, oneOfAction = {Action.UPDATE, Action.CREATE})
-	public void saveTemplateForResourceType(TemplateDescriptorEntity template, Integer resourceTypeId,
-											boolean testingMode) throws AMWException {
-		boolean hasPermission = template.getId() == null ?
-				this.hasPermissionToAddResourceTypeTemplate(resourceTypeId, testingMode) :
-				this.hasPermissionToUpdateResourceTypeTemplate(resourceTypeId, testingMode);
 
-		if (!hasPermission) {
-			throw new AMWException("no permission to add/ update template for resource type!");
-		}
-		saveTemplate(template, entityManager.find(ResourceTypeEntity.class, resourceTypeId));
+	@HasPermission(permission = Permission.SHAKEDOWN_TEST_MODE)
+	private void createTemplateInTestingMode(TemplateDescriptorEntity template,
+											 HasContexts<?> hasContext) throws AMWException {
+		saveTemplate(template, hasContext);
 	}
 
-	public boolean hasPermissionToAddResourceTypeTemplate(Integer resourceTypeId, boolean testingMode) {
-		ResourceTypeEntity type = entityManager.find(ResourceTypeEntity.class, resourceTypeId);
-		return permissionService.hasPermissionToAddResourceTypeTemplate(type, testingMode);
+
+	@HasPermission(permission = Permission.SHAKEDOWN_TEST_MODE)
+	private void updateTemplateInTestingMode(TemplateDescriptorEntity template,
+											 HasContexts<?> hasContexts) throws AMWException {
+		saveTemplate(template, hasContexts);
+
 	}
 
-	public boolean hasPermissionToUpdateResourceTypeTemplate(Integer resourceTypeId, boolean testingMode) {
-		ResourceTypeEntity type = entityManager.find(ResourceTypeEntity.class, resourceTypeId);
-		return permissionService.hasPermissionToUpdateResourceTypeTemplate(type, testingMode);
-	}
-
-	public boolean hasPermissionToAddResourceTemplate(Integer resourceId, boolean testingMode) {
-		ResourceEntity res = entityManager.find(ResourceEntity.class, resourceId);
-		return permissionService.hasPermissionToAddResourceTemplate(res, testingMode);
-	}
-
-	public boolean hasPermissionToUpdateResourceTemplate(Integer resourceId, boolean testingMode) {
-		ResourceEntity res = entityManager.find(ResourceEntity.class, resourceId);
-		return permissionService.hasPermissionToUpdateResourceTemplate(res, testingMode);
-	}
 
 	void validateTemplate(TemplateDescriptorEntity templateDescriptorEntity) throws AMWException {
 		if (StringUtils.isEmpty(templateDescriptorEntity.getName())) {

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
@@ -1,0 +1,87 @@
+package ch.puzzle.itc.mobiliar.business.template.boundary;
+
+import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
+
+public class TemplateEditorTest {
+
+    TemplateEditor templateEditor;
+    TemplateDescriptorEntity templateDescriptorEntity;
+
+    @Before
+    public void setUp() throws Exception {
+         templateEditor = new TemplateEditor();
+         templateDescriptorEntity = new TemplateDescriptorEntity();
+         templateDescriptorEntity.setName("template-name");
+         templateDescriptorEntity.setName("a/valid/target-path");
+    }
+
+    @Test
+    public void shouldThrowExceptionEmptyTemplateName() {
+        // given
+        templateDescriptorEntity.setName("");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("The template name must not be empty"));
+    }
+
+    @Test
+    public void shouldThrowExceptionPathStartsWithPathTraversal() {
+        // given
+        templateDescriptorEntity.setTargetPath("../starts/with/path-traversal");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("No path traversals like '../' allowed in file path"));
+    }
+
+    @Test
+    public void shouldThrowExceptionPathContainsPathTraversals() {
+        // given
+        templateDescriptorEntity.setTargetPath("path/contains/../../../../path-traversals");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("No path traversals like '../' allowed in file path"));
+    }
+
+    @Test
+    public void shouldThrowExpectionAbsoluteTemplatePath()  {
+        // given
+        templateDescriptorEntity.setTargetPath("/absolute/path/is/not/allowed");
+
+        // when
+        AMWException exception = assertThrows(AMWException.class,
+                                              () -> templateEditor.validateTemplate(templateDescriptorEntity));
+
+        // then
+        assertThat(exception.getMessage(), is("Absolute paths are not allowed for file path"));
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForTemplateWithNameAndValidPath() throws AMWException {
+        // given
+
+        // when
+        templateEditor.validateTemplate(templateDescriptorEntity);
+
+        // then
+        // test fails if an exception is thrown
+    }
+}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditorTest.java
@@ -1,25 +1,55 @@
 package ch.puzzle.itc.mobiliar.business.template.boundary;
 
+import ch.puzzle.itc.mobiliar.business.environment.entity.HasContexts;
+import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
+import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.control.ResourceRelationService;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.AbstractResourceRelationEntity;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationTypeEntity;
+import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
+import ch.puzzle.itc.mobiliar.business.security.entity.Action;
+import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import ch.puzzle.itc.mobiliar.common.exception.NotAuthorizedException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.persistence.EntityManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TemplateEditorTest {
 
+    @InjectMocks
+    @Spy
     TemplateEditor templateEditor;
+
+    @Spy
+    PermissionService permissionService;
+
+    @Mock
+    EntityManager entityManager;
+
+    @Mock
+    ResourceRelationService relationService;
+
     TemplateDescriptorEntity templateDescriptorEntity;
 
     @Before
     public void setUp() throws Exception {
-         templateEditor = new TemplateEditor();
-         templateDescriptorEntity = new TemplateDescriptorEntity();
-         templateDescriptorEntity.setName("template-name");
-         templateDescriptorEntity.setName("a/valid/target-path");
+        templateDescriptorEntity = new TemplateDescriptorEntity();
+        templateDescriptorEntity.setName("template-name");
+        templateDescriptorEntity.setName("a/valid/target-path");
     }
 
     @Test
@@ -83,5 +113,265 @@ public class TemplateEditorTest {
 
         // then
         // test fails if an exception is thrown
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResourceTypeInTestingMode_missingPermission() {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.SHAKEDOWN_TEST_MODE);
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResourceType(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                true));
+        // then
+        assertThat(exception.getMessage(), is("Not Authorized! You're not allowed to execute shakedown test mode!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResourceTypeInTestingMode_withPermission() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.SHAKEDOWN_TEST_MODE);
+        ResourceTypeEntity resourceTypeEntity = new ResourceTypeEntity();
+        doReturn(resourceTypeEntity).when(entityManager).find(ResourceTypeEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+
+        // when
+        templateEditor.saveTemplateForResourceType(templateDescriptorEntity, 1, true);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResourceType_missingPermissionForActionCreate() {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.CREATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResourceType(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                false));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to create/ modify resource type templates!"));
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResourceType_missingPermissionForActionUpdate() {
+        // given
+        templateDescriptorEntity.setId(1);
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.UPDATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResourceType(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                false));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to create/ modify resource type templates!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResourceType_actionAdd() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.CREATE);
+        ResourceTypeEntity resourceTypeEntity = new ResourceTypeEntity();
+        doReturn(resourceTypeEntity).when(entityManager).find(ResourceTypeEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+
+        // when
+        templateEditor.saveTemplateForResourceType(templateDescriptorEntity, 1, false);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResourceType_actionUpdate() throws AMWException {
+        // given
+        templateDescriptorEntity.setId(1);
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.UPDATE);
+        ResourceTypeEntity resourceTypeEntity = new ResourceTypeEntity();
+        doReturn(resourceTypeEntity).when(entityManager).find(ResourceTypeEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+
+        // when
+        templateEditor.saveTemplateForResourceType(templateDescriptorEntity, 1, false);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeEntity);
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResourceInTestingMode_missingPermission() {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.SHAKEDOWN_TEST_MODE);
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResource(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                true));
+        // then
+        assertThat(exception.getMessage(), is("Not Authorized! You're not allowed to execute shakedown test mode!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResourceInTestingMode_withPermission() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.SHAKEDOWN_TEST_MODE);
+        ResourceEntity resourceEntity = new ResourceEntity();
+        doReturn(resourceEntity).when(entityManager).find(ResourceEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+
+        // when
+        templateEditor.saveTemplateForResource(templateDescriptorEntity, 1, true);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResource_missingPermissionForActionCreate() {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.CREATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResource(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                false));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to create/ modify resource templates!"));
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForResource_missingPermissionForActionUpdate() {
+        // given
+        templateDescriptorEntity.setId(1);
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.UPDATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class,
+                                                        () -> templateEditor.saveTemplateForResource(
+                                                                templateDescriptorEntity,
+                                                                1,
+                                                                false));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to create/ modify resource templates!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResource_actionAdd() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.CREATE);
+        ResourceEntity resourceEntity = new ResourceEntity();
+        doReturn(resourceEntity).when(entityManager).find(ResourceEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+
+        // when
+        templateEditor.saveTemplateForResource(templateDescriptorEntity, 1, false);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForResource_actionUpdate() throws AMWException {
+        // given
+        templateDescriptorEntity.setId(1);
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.UPDATE);
+        ResourceEntity resourceEntity = new ResourceEntity();
+        doReturn(resourceEntity).when(entityManager).find(ResourceEntity.class, 1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+
+        // when
+        templateEditor.saveTemplateForResource(templateDescriptorEntity, 1, false);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceEntity);
+    }
+
+    @Test
+    public void shouldDoNothingSaveTemplateForRelation_relationIdIsNull() throws AMWException {
+        // given
+
+        // when
+        templateEditor.saveTemplateForRelation(templateDescriptorEntity, null, true);
+
+        // then
+        verify(templateEditor, never()).saveTemplate(any(TemplateDescriptorEntity.class), any(HasContexts.class));
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForRelation_noPermissionForResource() throws AMWException {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.UPDATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class, () ->
+                templateEditor.saveTemplateForRelation(templateDescriptorEntity, 1, true));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to update templates for resource relations!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForRelation_isResourceEdit() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCE_TEMPLATE, Action.UPDATE);
+        AbstractResourceRelationEntity resourceRelation = mock(AbstractResourceRelationEntity.class);
+
+        doReturn(resourceRelation).when(relationService).getResourceRelation(1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceRelation);
+
+        // when
+        templateEditor.saveTemplateForRelation(templateDescriptorEntity, 1, true);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceRelation);
+    }
+
+    @Test
+    public void shouldRejectSaveTemplateForRelation_noPermissionForResourceType() throws AMWException {
+        // given
+        doReturn(false).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.UPDATE);
+
+        // when
+        NotAuthorizedException exception = assertThrows(NotAuthorizedException.class, () ->
+                templateEditor.saveTemplateForRelation(templateDescriptorEntity, 1, false));
+
+        // then
+        assertThat(exception.getMessage(),
+                   is("Not Authorized! You're not allowed to update templates for resource type relations!"));
+    }
+
+    @Test
+    public void shouldAllowSaveTemplateForRelation_notResourceEdit() throws AMWException {
+        // given
+        doReturn(true).when(permissionService).hasPermission(Permission.RESOURCETYPE_TEMPLATE, Action.UPDATE);
+        ResourceRelationTypeEntity resourceTypeRelation = new ResourceRelationTypeEntity();
+        doReturn(resourceTypeRelation).when(relationService).getResourceTypeRelation(1);
+        doNothing().when(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeRelation);
+
+        // when
+        templateEditor.saveTemplateForRelation(templateDescriptorEntity, 1, false);
+
+        // then
+        verify(templateEditor).saveTemplate(templateDescriptorEntity, resourceTypeRelation);
     }
 }

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -252,36 +252,9 @@ public class EditTemplateView implements Serializable {
         boolean success = true;
         String errorMessage = "Was not able to save the template: ";
         try {
-            // set the template to testing mode...
-            template.setTesting(settings.isTestingMode());
-            if (template.isTesting()) {
-                if (selectedStp != null) {
-                    template.setName(selectedStp.getStpName());
-                } else {
-                    throwError("No STP-name selected!");
-                }
-            }
-
-            if (template.getId() == null && !canAdd()) {
-                throwError("No permission to create template!");
-            } else if (!canModifyTemplates()) {
-                throwError("No permission to modify templates!");
-            }
-            if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
-                throwError("Absolute paths are not allowed for file path");
-            }
-
-            if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
-                throwError("No path traversals like '../' allowed in file path");
-            }
-            if (relationIdForTemplate != null) {
-                templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
-                        resourceId != null);
-            } else if (resourceId == null) {
-                templateEditor.saveTemplateForResourceType(template, resourceTypeId);
-            } else {
-                templateEditor.saveTemplateForResource(template, resourceId);
-            }
+            setTemplateName();
+            validateInput();
+            saveTemplate();
         } catch (ResourceNotFoundException | ResourceTypeNotFoundException e) {
             success = fail(errorMessage + e.getMessage());
         } catch (AMWException e) {
@@ -289,6 +262,43 @@ public class EditTemplateView implements Serializable {
         }
         if (success) {
             succeed();
+        }
+    }
+
+    private void setTemplateName() throws AMWException {
+        template.setTesting(settings.isTestingMode());
+        if (template.isTesting()) {
+            if (selectedStp != null) {
+                template.setName(selectedStp.getStpName());
+            } else {
+                throwError("No STP-name selected!");
+            }
+        }
+    }
+
+    private void saveTemplate() throws AMWException {
+        if (relationIdForTemplate != null) {
+            templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
+                    resourceId != null);
+        } else if (resourceId == null) {
+            templateEditor.saveTemplateForResourceType(template, resourceTypeId);
+        } else {
+            templateEditor.saveTemplateForResource(template, resourceId);
+        }
+    }
+
+    private void validateInput() throws AMWException {
+        if (template.getId() == null && !canAdd()) {
+            throwError("No permission to create template!");
+        } else if (!canModifyTemplates()) {
+            throwError("No permission to modify templates!");
+        }
+        if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
+            throwError("Absolute paths are not allowed for file path");
+        }
+
+        if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
+            throwError("No path traversals like '../' allowed in file path");
         }
     }
 

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -253,7 +253,7 @@ public class EditTemplateView implements Serializable {
         String errorMessage = "Was not able to save the template: ";
         try {
             setTemplateName();
-            validateInput();
+            checkPermissions();
             saveTemplate();
         } catch (ResourceNotFoundException | ResourceTypeNotFoundException e) {
             success = fail(errorMessage + e.getMessage());
@@ -287,18 +287,11 @@ public class EditTemplateView implements Serializable {
         }
     }
 
-    private void validateInput() throws AMWException {
+    private void checkPermissions() throws AMWException {
         if (template.getId() == null && !canAdd()) {
             throwError("No permission to create template!");
         } else if (!canModifyTemplates()) {
             throwError("No permission to modify templates!");
-        }
-        if (template.getTargetPath() != null && template.getTargetPath().startsWith("/")) {
-            throwError("Absolute paths are not allowed for file path");
-        }
-
-        if (template.getTargetPath() != null && template.getTargetPath().contains("../")) {
-            throwError("No path traversals like '../' allowed in file path");
         }
     }
 

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -60,10 +60,10 @@ public class EditTemplateView implements Serializable {
     UserSettings settings;
 
     @Inject
-    ShakedownStpService stpService;
+    PermissionService permissionService;
 
     @Inject
-    PermissionService permissionService;
+    ShakedownStpService stpService;
 
     @Inject
     @Getter
@@ -288,7 +288,6 @@ public class EditTemplateView implements Serializable {
         }
     }
 
-
     public boolean canModifyTemplates() {
         if (settings.isTestingMode()) {
             return permissionService.hasPermission(Permission.SHAKEDOWN_TEST_MODE);
@@ -299,27 +298,11 @@ public class EditTemplateView implements Serializable {
     }
 
     private Permission getPermission() {
-        Permission permission;
-        if (isEditResource()) {
-            permission = Permission.RESOURCE_TEMPLATE;
-        } else {
-            permission = Permission.RESOURCETYPE_TEMPLATE;
-        }
-        return permission;
+        return isEditResource() ? Permission.RESOURCE_TEMPLATE : Permission.RESOURCETYPE_TEMPLATE;
     }
 
     private Action getAction() {
-        Action action;
-        if (isNewTemplate()) {
-            action = Action.CREATE;
-        } else {
-            action = Action.UPDATE;
-        }
-        return action;
-    }
-
-    private boolean canAdd() {
-        return canModifyTemplates();
+        return isNewTemplate() ? Action.CREATE : Action.UPDATE;
     }
 
     public boolean isRelation() {

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -281,9 +281,9 @@ public class EditTemplateView implements Serializable {
             templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
                     resourceId != null);
         } else if (resourceId == null) {
-            templateEditor.saveTemplateForResourceType(template, resourceTypeId);
+            templateEditor.saveTemplateForResourceType(template, resourceTypeId, settings.isTestingMode());
         } else {
-            templateEditor.saveTemplateForResource(template, resourceId);
+            templateEditor.saveTemplateForResource(template, resourceId, settings.isTestingMode());
         }
     }
 

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -73,45 +73,6 @@ public class EditTemplateViewTest {
     }
 
     @Test
-    public void shouldRejectAbsoluteTemplatePath() throws AMWException {
-        // given
-        template.setTargetPath("/absolute/path/is/not/allowed");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("Absolute paths are not allowed for file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
-    public void shouldRejectTemplatePathStartsWithPathTraversals() throws AMWException {
-        // given
-        template.setTargetPath("../../path/traversals/not/allowed");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
-    public void shouldRejectTemplatePathWithPathTraversalsInsidePath() throws AMWException {
-        // given
-        template.setTargetPath("you/can/../../../../traverse/paths/like/this");
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
-        verify(editTemplateView, never()).succeed();
-    }
-
-    @Test
     public void shouldRejectTemplateInTestingModeWihtoutSelectedSTP() throws AMWException {
         // given
         doReturn(true).when(settings).isTestingMode();

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -1,0 +1,107 @@
+package ch.puzzle.itc.mobiliar.presentation.templateEdit;
+
+import ch.puzzle.itc.mobiliar.business.template.boundary.TemplateEditor;
+import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
+import ch.puzzle.itc.mobiliar.presentation.util.UserSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EditTemplateViewTest {
+
+    @Mock
+    UserSettings settings;
+
+    @Mock
+    TemplateEditor templateEditor;
+
+    @Spy
+    @InjectMocks
+    EditTemplateView editTemplateView;
+
+    private TemplateDescriptorEntity template;
+
+    @Before
+    public void setUp() {
+        doReturn(false).when(settings).isTestingMode();
+        doReturn(true).when(editTemplateView).canModifyTemplates();
+        doReturn(false).when(editTemplateView).fail(any(AMWException.class));
+
+        template = editTemplateView.getTemplate();
+        template.setId(1);
+    }
+
+    @Test
+    public void shouldRejectTemplateCreateIfNotAllowed() throws AMWException {
+        // given
+        template.setId(null);
+        doReturn(false).when(editTemplateView).canModifyTemplates();
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView, never()).succeed();
+        verify(editTemplateView).throwError("No permission to create template!");
+    }
+
+    @Test
+    public void shouldRejectTemplateModifyIfNotAllowed() throws AMWException {
+        // given
+        doReturn(false).when(editTemplateView).canModifyTemplates();
+
+        //when
+        editTemplateView.save();
+
+        //then
+        verify(editTemplateView, never()).succeed();
+        verify(editTemplateView).throwError("No permission to modify templates!");
+    }
+
+    @Test
+    public void shouldRejectAbsoluteTemplatePath() throws AMWException {
+        // given
+        template.setTargetPath("/absolute/path/is/not/allowed");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("absolute paths are not allowed for file path");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplatePathStartsWithPathTraversals() throws AMWException {
+        // given
+        template.setTargetPath("../../path/traversals/not/allowed");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplatePathWithPathTraversalsInsidePath() throws AMWException {
+        // given
+        template.setTargetPath("you/can/../../../../traverse/paths/like/this");
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView, never()).succeed();
+    }
+}

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -93,7 +93,7 @@ public class EditTemplateViewTest {
         doReturn("name-of-selected-stp").when(selectedStp).getStpName();
 
         editTemplateView.setResourceTypeId(10);
-        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10, settings.isTestingMode());
 
         // when
         editTemplateView.save();
@@ -139,13 +139,13 @@ public class EditTemplateViewTest {
         editTemplateView.setRelationIdForTemplate(null);
         editTemplateView.setResourceId(null);
         editTemplateView.setResourceTypeId(99);
-        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99, settings.isTestingMode());
 
         // when
         editTemplateView.save();
 
         // then
-        verify(templateEditor).saveTemplateForResourceType(template, 99);
+        verify(templateEditor).saveTemplateForResourceType(template, 99, settings.isTestingMode());
         verify(editTemplateView).succeed();
     }
 
@@ -155,13 +155,13 @@ public class EditTemplateViewTest {
         editTemplateView.setResourceTypeId(null);
         editTemplateView.setRelationIdForTemplate(null);
         editTemplateView.setResourceId(10);
-        doNothing().when(templateEditor).saveTemplateForResource(template, 10);
+        doNothing().when(templateEditor).saveTemplateForResource(template, 10, settings.isTestingMode());
 
         // when
         editTemplateView.save();
 
         // then
-        verify(templateEditor).saveTemplateForResource(template, 10);
+        verify(templateEditor).saveTemplateForResource(template, 10, settings.isTestingMode());
         verify(editTemplateView).succeed();
     }
 }

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -1,5 +1,6 @@
 package ch.puzzle.itc.mobiliar.presentation.templateEdit;
 
+import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownStpEntity;
 import ch.puzzle.itc.mobiliar.business.template.boundary.TemplateEditor;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 import ch.puzzle.itc.mobiliar.common.exception.AMWException;
@@ -20,13 +21,17 @@ public class EditTemplateViewTest {
     @Mock
     UserSettings settings;
 
-    @Mock
+    @Spy
     TemplateEditor templateEditor;
+
+    @Mock
+    ShakedownStpEntity selectedStp;
 
     @Spy
     @InjectMocks
     EditTemplateView editTemplateView;
 
+    @Spy
     private TemplateDescriptorEntity template;
 
     @Before
@@ -34,6 +39,7 @@ public class EditTemplateViewTest {
         doReturn(false).when(settings).isTestingMode();
         doReturn(true).when(editTemplateView).canModifyTemplates();
         doReturn(false).when(editTemplateView).fail(any(AMWException.class));
+        doNothing().when(editTemplateView).succeed();
 
         template = editTemplateView.getTemplate();
         template.setId(1);
@@ -75,7 +81,7 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("absolute paths are not allowed for file path");
+        verify(editTemplateView).throwError("Absolute paths are not allowed for file path");
         verify(editTemplateView, never()).succeed();
     }
 
@@ -88,7 +94,7 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
         verify(editTemplateView, never()).succeed();
     }
 
@@ -101,7 +107,100 @@ public class EditTemplateViewTest {
         editTemplateView.save();
 
         // then
-        verify(editTemplateView).throwError("no path traversals like '../' allowed in file path");
+        verify(editTemplateView).throwError("No path traversals like '../' allowed in file path");
         verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldRejectTemplateInTestingModeWihtoutSelectedSTP() throws AMWException {
+        // given
+        doReturn(true).when(settings).isTestingMode();
+        editTemplateView.setSelectedStpId(9999); // clear selectedStp in the view
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(editTemplateView).throwError("No STP-name selected!");
+        verify(editTemplateView, never()).succeed();
+    }
+
+    @Test
+    public void shouldSetTemplateNameFromSelectedStp() throws AMWException {
+        // given
+        doReturn(true).when(settings).isTestingMode();
+        doReturn("name-of-selected-stp").when(selectedStp).getStpName();
+
+        editTemplateView.setResourceTypeId(10);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(template).setName("name-of-selected-stp");
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForRelationWithRousourceIdNull() throws AMWException {
+        // given
+        editTemplateView.setRelationIdForTemplate(1);
+        editTemplateView.setResourceId(null);
+        doNothing().when(templateEditor).saveTemplateForRelation(template, 1, false);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForRelation(template, 1, false);
+        verify(editTemplateView).succeed();
+
+    }
+
+    @Test
+    public void shouldSaveTemplateForRelationWithResourceId() throws AMWException {
+        editTemplateView.setRelationIdForTemplate(1);
+        editTemplateView.setResourceId(123);
+        doNothing().when(templateEditor).saveTemplateForRelation(template, 1, true);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForRelation(template, 1, true);
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForResourceType() throws AMWException {
+        // given
+        editTemplateView.setRelationIdForTemplate(null);
+        editTemplateView.setResourceId(null);
+        editTemplateView.setResourceTypeId(99);
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForResourceType(template, 99);
+        verify(editTemplateView).succeed();
+    }
+
+    @Test
+    public void shouldSaveTemplateForResource() throws AMWException {
+        // given
+        editTemplateView.setResourceTypeId(null);
+        editTemplateView.setRelationIdForTemplate(null);
+        editTemplateView.setResourceId(10);
+        doNothing().when(templateEditor).saveTemplateForResource(template, 10);
+
+        // when
+        editTemplateView.save();
+
+        // then
+        verify(templateEditor).saveTemplateForResource(template, 10);
+        verify(editTemplateView).succeed();
     }
 }

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateViewTest.java
@@ -37,39 +37,11 @@ public class EditTemplateViewTest {
     @Before
     public void setUp() {
         doReturn(false).when(settings).isTestingMode();
-        doReturn(true).when(editTemplateView).canModifyTemplates();
         doReturn(false).when(editTemplateView).fail(any(AMWException.class));
         doNothing().when(editTemplateView).succeed();
 
         template = editTemplateView.getTemplate();
         template.setId(1);
-    }
-
-    @Test
-    public void shouldRejectTemplateCreateIfNotAllowed() throws AMWException {
-        // given
-        template.setId(null);
-        doReturn(false).when(editTemplateView).canModifyTemplates();
-
-        // when
-        editTemplateView.save();
-
-        // then
-        verify(editTemplateView, never()).succeed();
-        verify(editTemplateView).throwError("No permission to create template!");
-    }
-
-    @Test
-    public void shouldRejectTemplateModifyIfNotAllowed() throws AMWException {
-        // given
-        doReturn(false).when(editTemplateView).canModifyTemplates();
-
-        //when
-        editTemplateView.save();
-
-        //then
-        verify(editTemplateView, never()).succeed();
-        verify(editTemplateView).throwError("No permission to modify templates!");
     }
 
     @Test
@@ -93,7 +65,7 @@ public class EditTemplateViewTest {
         doReturn("name-of-selected-stp").when(selectedStp).getStpName();
 
         editTemplateView.setResourceTypeId(10);
-        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10, settings.isTestingMode());
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 10, true);
 
         // when
         editTemplateView.save();
@@ -104,7 +76,7 @@ public class EditTemplateViewTest {
     }
 
     @Test
-    public void shouldSaveTemplateForRelationWithRousourceIdNull() throws AMWException {
+    public void shouldSaveTemplateForRelationWithResourceIdNull() throws AMWException {
         // given
         editTemplateView.setRelationIdForTemplate(1);
         editTemplateView.setResourceId(null);
@@ -139,7 +111,7 @@ public class EditTemplateViewTest {
         editTemplateView.setRelationIdForTemplate(null);
         editTemplateView.setResourceId(null);
         editTemplateView.setResourceTypeId(99);
-        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99, settings.isTestingMode());
+        doNothing().when(templateEditor).saveTemplateForResourceType(template, 99, false);
 
         // when
         editTemplateView.save();
@@ -155,7 +127,7 @@ public class EditTemplateViewTest {
         editTemplateView.setResourceTypeId(null);
         editTemplateView.setRelationIdForTemplate(null);
         editTemplateView.setResourceId(10);
-        doNothing().when(templateEditor).saveTemplateForResource(template, 10, settings.isTestingMode());
+        doNothing().when(templateEditor).saveTemplateForResource(template, 10, false);
 
         // when
         editTemplateView.save();


### PR DESCRIPTION
With this pull request, the permission checks to save/ update a template for resources, resource types and resource (type) relations is completely pushed to the business module.

Template Paths are now validated and absolute paths and paths traversals are not allowed