### PR TITLE
542 server side template injection

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessor.java
@@ -37,6 +37,7 @@ import ch.puzzle.itc.mobiliar.common.exception.TemplatePropertyException.CAUSE;
 
 import freemarker.cache.StringTemplateLoader;
 import freemarker.core.ParseException;
+import freemarker.core.TemplateClassResolver;
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
 
@@ -212,6 +213,9 @@ public class BaseTemplateProcessor {
 
     public static Configuration getConfiguration(AMWTemplateExceptionHandler templateExceptionHandler) {
         Configuration cfg = new Configuration(Configuration.VERSION_2_3_22);
+        // prevents Server-Side Template Injection
+        cfg.setNewBuiltinClassResolver(TemplateClassResolver.ALLOWS_NOTHING_RESOLVER);
+        cfg.setAPIBuiltinEnabled(false);
         cfg.setTemplateExceptionHandler(templateExceptionHandler);
         cfg.setShowErrorTips(false);
         cfg.setLogTemplateExceptions(false);

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorTest.java
@@ -631,6 +631,45 @@ public class BaseTemplateProcessorTest {
         assertTrue(result.isSuccess());
     }
 
+    @Test
+    public void shouldFailCallingNewBuiltIn() throws IOException {
+        // given
+        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+
+        TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#assign ex = \"freemarker.template.utility.Execute\"?new()>${ex(\"id\")}");
+
+        templates.add(templateDescriptorEntity);
+
+        GenerationUnit unit = new GenerationUnit(null, null, templates, null);
+
+        // when
+        GenerationUnitGenerationResult result = processor.generateResourceTemplates(unit, getAmwTemplateModel(null, null));
+
+        //then
+        GeneratedTemplate generatedTemplate = result.getGeneratedTemplates().get(0);
+        assertFalse(result.isSuccess());
+        assertTrue(generatedTemplate.getErrorMessages().size() > 0);
+    }
+
+    @Test
+    public void shouldFailCallingApiBuiltIn() throws IOException {
+        // given
+        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+
+        TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#assign uri=object?api.class.getResource(\"/\").toURI()>${uri}");
+
+        templates.add(templateDescriptorEntity);
+
+        GenerationUnit unit = new GenerationUnit(null, null, templates, null);
+
+        // when
+        GenerationUnitGenerationResult result = processor.generateResourceTemplates(unit, getAmwTemplateModel(null, null));
+
+        //then
+        GeneratedTemplate generatedTemplate = result.getGeneratedTemplates().get(0);
+        assertFalse(result.isSuccess());
+        assertTrue(generatedTemplate.getErrorMessages().size() > 0);
+    }
 
 	private TemplateDescriptorEntity createTemplate(String templateContent) {
 		TemplateDescriptorEntity templateDescriptorEntity = new TemplateDescriptorEntity();


### PR DESCRIPTION
With this pull request, the freemarker-template-processor prevents the usage of `api()` and `new()`-functions in template-expressions with the updated configuration and limits server-side-code-execution.
