### PR TITLE
546 no restrictive csp

### DIFF
--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,3 +1,4 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
+path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:")

--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,4 +1,4 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
-path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
+path('/index.html') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")

--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,4 +1,4 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
-path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:")
+path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")

--- a/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,0 +1,1 @@
+path('/index.html') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; img-src 'self' data: https:; object-src 'none'; script-src 'self' 'sha256-g/dtgh1vP6FrsyPn1mwp5MR1i5jUUZV40V0TGRvZcMM='; style-src 'self' 'unsafe-inline'; style-src-elem https://fonts.googleapis.com 'self' 'unsafe-inline'; font-src https://fonts.gstatic.com;")

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -11,8 +11,7 @@ import java.io.PrintWriter;
 @WebFilter(filterName = "CspNonceFilter", urlPatterns = {"/*"})
 public class CspNonceFilter implements Filter {
 
-    //TODO remove -Report-Only to enforce policy
-    private static final String CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
+    private static final String CSP_HEADER_KEY = "Content-Security-Policy";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -51,8 +51,7 @@ public class CspNonceFilter implements Filter {
 
     private String getCspHeader(String nonce) {
         return String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, HASHES) +
-                "connect-src 'self'; script-src-attr 'unsafe-inline';" +
-                //TODO frame-anchestors base-uri
+                "connect-src 'self'; script-src-attr 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none';" +
                 " style-src 'self' 'unsafe-inline';";
     }
 

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -13,7 +13,6 @@ public class CspNonceFilter implements Filter {
 
     //TODO remove -Report-Only to enforce policy
     private static final String CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
-    private static final String HASHES = "'sha256-56Xl7F05vDGrlZ0zsrpH5ur8snvD2VXeGJW6hJvvbxU=' 'sha256-JnUQNzIwUQpUTIqGq+F8FFSf1//vhdKJyY/8LSNVWh0='";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -46,8 +45,11 @@ public class CspNonceFilter implements Filter {
     }
 
     private String getCspHeader(String nonce) {
-        return String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, HASHES) +
-                "connect-src 'self'; script-src-attr 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none';" +
+        return String.format("default-src 'self';" +
+                " script-src 'strict-dynamic' 'nonce-%s' 'unsafe-eval';", nonce) +
+                " connect-src 'self';" +
+                " script-src-attr 'unsafe-inline';" +
+                " frame-ancestors 'none'; base-uri 'self'; object-src 'none';" +
                 " style-src 'self' 'unsafe-inline';";
     }
 

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -1,0 +1,99 @@
+package ch.puzzle.itc.mobiliar.presentation.security;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+
+@WebFilter(filterName = "CspNonceFilter", urlPatterns = {"/*"})
+public class CspNonceFilter implements Filter {
+
+    private static final int NONCE_SIZE = 32;
+    //TODO remove -Report-Only to enforce policy
+    private static final String CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+
+        final HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+        CharResponseWrapper charResponseWrapper = new CharResponseWrapper((HttpServletResponse) servletResponse) {
+            @Override
+            public void setHeader(String name, String value) {
+                httpResponse.setHeader(name, value);
+            }
+        };
+        String nonce = getNonce();
+        httpResponse.setHeader(CSP_HEADER_KEY, getCspHeader(nonce));
+
+        filterChain.doFilter(servletRequest, charResponseWrapper);
+        if (charResponseWrapper.toString().contains("script")) {
+            PrintWriter out = servletResponse.getWriter();
+            CharArrayWriter caw = new CharArrayWriter();
+            caw.write(charResponseWrapper.toString().replace("<script", "<script nonce=\"" + nonce + "\"" ));
+            charResponseWrapper.setContentLength(caw.toString().length());
+            out.write(caw.toString());
+            out.close();
+        }
+
+    }
+
+    private String getCspHeader(String nonce) {
+        String hashes = String.join(" ", getHashes());
+        StringBuilder sb =  new StringBuilder();
+        sb.append(String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, hashes))
+                .append("connect-src 'self'; script-src-attr 'unsafe-inline';")
+                .append(" style-src 'self' 'unsafe-inline';");
+        return sb.toString();
+    }
+
+    private List<String> getHashes() {
+        return List.of(
+                "'sha256-56Xl7F05vDGrlZ0zsrpH5ur8snvD2VXeGJW6hJvvbxU='",
+                "'sha256-JnUQNzIwUQpUTIqGq+F8FFSf1//vhdKJyY/8LSNVWh0='"
+        );
+    }
+
+    private String getNonce() {
+        byte[] nonce = new byte[NONCE_SIZE];
+        new SecureRandom().nextBytes(nonce);
+
+        return Base64.getEncoder().encodeToString(nonce);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    public class CharResponseWrapper extends
+            HttpServletResponseWrapper {
+        private CharArrayWriter output;
+
+        public String toString() {
+            return output.toString();
+        }
+
+        public CharResponseWrapper(HttpServletResponse response) {
+            super(response);
+            output = new CharArrayWriter();
+
+        }
+
+        public PrintWriter getWriter() {
+            return new PrintWriter(output);
+        }
+
+
+    }
+}

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -17,6 +17,7 @@ public class CspNonceFilter implements Filter {
     private static final int NONCE_SIZE = 32;
     //TODO remove -Report-Only to enforce policy
     private static final String CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
+    private static final String HASHES = "'sha256-56Xl7F05vDGrlZ0zsrpH5ur8snvD2VXeGJW6hJvvbxU=' 'sha256-JnUQNzIwUQpUTIqGq+F8FFSf1//vhdKJyY/8LSNVWh0='";
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
@@ -49,19 +50,10 @@ public class CspNonceFilter implements Filter {
     }
 
     private String getCspHeader(String nonce) {
-        String hashes = String.join(" ", getHashes());
-        StringBuilder sb =  new StringBuilder();
-        sb.append(String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, hashes))
-                .append("connect-src 'self'; script-src-attr 'unsafe-inline';")
-                .append(" style-src 'self' 'unsafe-inline';");
-        return sb.toString();
-    }
-
-    private List<String> getHashes() {
-        return List.of(
-                "'sha256-56Xl7F05vDGrlZ0zsrpH5ur8snvD2VXeGJW6hJvvbxU='",
-                "'sha256-JnUQNzIwUQpUTIqGq+F8FFSf1//vhdKJyY/8LSNVWh0='"
-        );
+        return String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, HASHES) +
+                "connect-src 'self'; script-src-attr 'unsafe-inline';" +
+                //TODO frame-anchestors base-uri
+                " style-src 'self' 'unsafe-inline';";
     }
 
     private String getNonce() {
@@ -73,10 +65,9 @@ public class CspNonceFilter implements Filter {
 
     @Override
     public void destroy() {
-
     }
 
-    public class CharResponseWrapper extends
+    public static class CharResponseWrapper extends
             HttpServletResponseWrapper {
         private CharArrayWriter output;
 
@@ -93,7 +84,5 @@ public class CspNonceFilter implements Filter {
         public PrintWriter getWriter() {
             return new PrintWriter(output);
         }
-
-
     }
 }

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/CspNonceFilter.java
@@ -7,14 +7,10 @@ import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.security.SecureRandom;
-import java.util.Base64;
-import java.util.List;
 
 @WebFilter(filterName = "CspNonceFilter", urlPatterns = {"/*"})
 public class CspNonceFilter implements Filter {
 
-    private static final int NONCE_SIZE = 32;
     //TODO remove -Report-Only to enforce policy
     private static final String CSP_HEADER_KEY = "Content-Security-Policy-Report-Only";
     private static final String HASHES = "'sha256-56Xl7F05vDGrlZ0zsrpH5ur8snvD2VXeGJW6hJvvbxU=' 'sha256-JnUQNzIwUQpUTIqGq+F8FFSf1//vhdKJyY/8LSNVWh0='";
@@ -34,7 +30,7 @@ public class CspNonceFilter implements Filter {
                 httpResponse.setHeader(name, value);
             }
         };
-        String nonce = getNonce();
+        String nonce = Nonce.next().toString();
         httpResponse.setHeader(CSP_HEADER_KEY, getCspHeader(nonce));
 
         filterChain.doFilter(servletRequest, charResponseWrapper);
@@ -53,13 +49,6 @@ public class CspNonceFilter implements Filter {
         return String.format("default-src 'self'; script-src 'self' 'nonce-%s' %s 'unsafe-eval'; ", nonce, HASHES) +
                 "connect-src 'self'; script-src-attr 'unsafe-inline'; frame-ancestors 'none'; base-uri 'none';" +
                 " style-src 'self' 'unsafe-inline';";
-    }
-
-    private String getNonce() {
-        byte[] nonce = new byte[NONCE_SIZE];
-        new SecureRandom().nextBytes(nonce);
-
-        return Base64.getEncoder().encodeToString(nonce);
     }
 
     @Override

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/Nonce.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/security/Nonce.java
@@ -1,0 +1,40 @@
+package ch.puzzle.itc.mobiliar.presentation.security;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang3.ArrayUtils;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Random;
+
+public class Nonce {
+
+    protected static final int NONCE_SIZE = 32;
+    private static final Random RND = new SecureRandom();
+
+    private final byte[] nonce;
+
+
+    private Nonce(final byte[] nonce) {
+        this.nonce = ArrayUtils.clone(nonce);
+    }
+
+    /**
+     * Creates a new nonce with a randomly generated 256-bit (32-byte)
+     * value, Base64URL-encoded.
+     */
+    public static Nonce next() {
+        byte[] bytes = new byte[NONCE_SIZE];
+        RND.nextBytes(bytes);
+
+        return new Nonce(bytes);
+    }
+
+    /**
+     * Converts nonce to Base64URL-encoded string
+     */
+    @Override
+    public String toString() {
+        return Base64.getEncoder().encodeToString(nonce);
+    }
+}

--- a/AMW_web/src/main/webapp/pages/templates/template.xhtml
+++ b/AMW_web/src/main/webapp/pages/templates/template.xhtml
@@ -122,7 +122,7 @@
     <h:form id="navigationForm">
         <header>
         <div class="container">
-            <object class="liimaLogo" data="../resources/images/misc/Liima.svg">Liima</object>
+            <img class="liimaLogo" src="../resources/images/misc/Liima.svg" alt="Liima" />
             <nav>
             <ul>
                 <li>

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/security/NonceTest.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/security/NonceTest.java
@@ -1,0 +1,28 @@
+package ch.puzzle.itc.mobiliar.presentation.security;
+
+import org.junit.Test;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class NonceTest {
+
+    @Test
+    public void shouldGetNextNonce() {
+        Nonce nonce = Nonce.next();
+        Nonce nonce2 = Nonce.next();
+        assertNotEquals(nonce2, nonce);
+    }
+
+    @Test
+    public void shouldGet32BitNonce() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        Nonce nonce = Nonce.next();
+        assertEquals(nonce.toString().length(), Base64.getEncoder().encodeToString(bytes).length());
+    }
+
+}


### PR DESCRIPTION
With this pull request, a stronger CSP is established. With this CSP all JSF-Script-blocks get a unique nonce per response or are whitelisted through a hash. Frame-Anchestors and Base-Uri directives are specified.

The CSP is in Report-Only mode. Before merging it should be removed to enforce the CSP.
