### PR TITLE
558 missing hsts header

### DIFF
--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,4 +1,5 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
-path('/index.html') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
+path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
+regex('/(.*)')  -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')

--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,5 +1,5 @@
 not regex('/assets/') -> set(attribute='%{o,Vary}', value='Accept-Encoding')
 not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-age=3600')
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
-path('/index.html') -> set(attribute='%{o,Content-Security-Policy-Report-Only}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
+regex('/(.*)') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
 regex('/(.*)')  -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')

--- a/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,1 +1,2 @@
 path('/index.html') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; img-src 'self' data: https:; object-src 'none'; script-src 'self' 'sha256-g/dtgh1vP6FrsyPn1mwp5MR1i5jUUZV40V0TGRvZcMM='; style-src 'self' 'unsafe-inline'; style-src-elem https://fonts.googleapis.com 'self' 'unsafe-inline'; font-src https://fonts.gstatic.com;")
+regex('/(.*)') -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')

--- a/AMW_web/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_web/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,0 +1,1 @@
+regex('/(.*)') -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')


### PR DESCRIPTION
Adds HSTS-Header for AMW_web (richfaces and angular) and AMW_rest (swagger).

Additionally an upgrade for the Angular-CSP-Part to match all path-attributes not only `/index.html` 