### PR TITLE
557 download allows content sniffing

### DIFF
--- a/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_angular/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -3,3 +3,4 @@ not regex('/assets/') -> set(attribute='%{o,Cache-Control}', value='public, max-
 path('/index.html') -> set(attribute='%{o,Cache-Control}', value='no-cache')
 regex('/(.*)') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; script-src-attr 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; object-src 'none';")
 regex('/(.*)')  -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')
+regex('/(.*)') -> set(attribute='%{o,X-Content-Type-Options}', value='nosniff;')

--- a/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_rest/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,2 +1,4 @@
 path('/index.html') -> set(attribute='%{o,Content-Security-Policy}', value="default-src 'self'; img-src 'self' data: https:; object-src 'none'; script-src 'self' 'sha256-g/dtgh1vP6FrsyPn1mwp5MR1i5jUUZV40V0TGRvZcMM='; style-src 'self' 'unsafe-inline'; style-src-elem https://fonts.googleapis.com 'self' 'unsafe-inline'; font-src https://fonts.gstatic.com;")
 regex('/(.*)') -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')
+regex('/(.*)') -> set(attribute='%{o,X-Content-Type-Options}', value='nosniff;')
+

--- a/AMW_web/src/main/webapp/WEB-INF/undertow-handlers.conf
+++ b/AMW_web/src/main/webapp/WEB-INF/undertow-handlers.conf
@@ -1,1 +1,2 @@
 regex('/(.*)') -> set(attribute='%{o,Strict-Transport-Security}', value='max-age=31536000; includeSubDomains;')
+regex('/(.*)') -> set(attribute='%{o,X-Content-Type-Options}', value='nosniff;')


### PR DESCRIPTION
Adds header to prevent content-sniffing in `angular` and `web`-module. 
(I guess the implementation in the web-module is obsolete and the Class `DeploymentCSVExport.java` is dead code.)