### PR TITLE
use custom tooltip to resolve conflict with bootstrap

### DIFF
--- a/AMW_web/src/main/webapp/resources/js/property-tooltips.js
+++ b/AMW_web/src/main/webapp/resources/js/property-tooltips.js
@@ -3,7 +3,7 @@
  */
 var propertyTooltips = function() {
     // hide all tooltips
-    $('.tooltip').hide();
+    $('--property--info-box').hide();
 
     // create jquerytools tooltip
     $(".info").tooltip({

--- a/AMW_web/src/main/webapp/resources/mobi/foreignableOwnerTooltip.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/foreignableOwnerTooltip.xhtml
@@ -17,7 +17,7 @@
             <i class="icon icon-owner"/>
         </a>
 
-        <div class="tooltip">
+        <div class="--property--info-box">
             <h2>
                 <h:outputText value="Owned by #{cc.attrs.foreignableAttributes.owner}"/>
             </h2>

--- a/AMW_web/src/main/webapp/resources/mobi/propertyTooltip.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/propertyTooltip.xhtml
@@ -15,7 +15,7 @@
         <i class="icon ${isTesting ? 'icon-infoWhite' : 'icon-info' }"/>
     </a>
 
-    <div class="tooltip">
+    <div class="--property--info-box">
         <h2>
             <h:outputText value="${cc.attrs.property.propertyDisplayName}"/>
         </h2>

--- a/AMW_web/src/main/webapp/resources/mobi/suspectRelationTooltip.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/suspectRelationTooltip.xhtml
@@ -19,7 +19,7 @@
         <i class="icon icon-warning"/>
         </a>
 
-        <div class="tooltip">
+        <div class="--property--info-box">
             <h2>
                 <h:outputText value="Suspect relation"/>
             </h2>

--- a/AMW_web/src/main/webapp/stylesheets/screen.css
+++ b/AMW_web/src/main/webapp/stylesheets/screen.css
@@ -987,8 +987,7 @@ aside nav > ul > li ul li a {
   background-color: #2060a0;
 }
 
-/* line 8, ../sass/_tooltip.scss */
-.tooltip {
+.--property--info-box {
   display: none;
   padding: 20px;
   background: white;
@@ -1006,28 +1005,7 @@ aside nav > ul > li ul li a {
   box-shadow: 1px 1px 6px #d6d6d6;
   margin-left: -5px;
 }
-/* line 18, ../sass/_tooltip.scss */
-.tooltip:before {
-  content: ' ';
-  position: absolute;
-  width: 0;
-  height: 0;
-  left: -1px;
-  top: -12px;
-  border: 6px solid;
-  border-color: #eaeaea transparent transparent #f8f8f8;
-}
-/* line 31, ../sass/_tooltip.scss */
-.tooltip:after {
-  content: ' ';
-  position: absolute;
-  width: 0;
-  height: 0;
-  left: 0px;
-  top: -14px;
-  border: 7px solid;
-  border-color: #fff transparent transparent #fff;
-}
+
 
 /* line 5, ../sass/_alerts.scss */
 .alert {


### PR DESCRIPTION
Bootstrap provides a new tooltip component starting with version 5.2 - this component interfered with our custom tooltip solution since both rely on the `tooltip` class.

I changed the classname for the property info box and it seems to work now. I was also able to remove some unused css.

Please verify that the info boxes for `foreignableOwnerTooltip` and `suspectRelationTooltip` also work properly.

fixes #689 