### PR TITLE
AMW_web: set secure and http-only flags for cookie, make sure cookie isn't sent via url param

### DIFF
--- a/AMW_web/src/main/webapp/WEB-INF/web.xml
+++ b/AMW_web/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,11 @@
 
 	<session-config>
 		<session-timeout>60</session-timeout>
+		<cookie-config>
+			<http-only>true</http-only>
+			<secure>true</secure>
+		</cookie-config>
+		<tracking-mode>COOKIE</tracking-mode>
 	</session-config>
 
 	<servlet>


### PR DESCRIPTION
fixes #693 