### PR TITLE
fix: prevent renaming different resources to same name

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/property/boundary/PropertyEditor.java
@@ -369,7 +369,7 @@ public class PropertyEditor {
 
     private void verifyAndSetResourceName(String resourceName, ResourceEntity resource) throws AMWException {
         if (resourceName == null || !resourceName.equals(resource.getName())) {
-            resourceValidationService.validateResourceName(resourceName);
+            resourceValidationService.validateResourceName(resourceName, resource.getId());
             resource.setName(resourceName);
         }
     }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
@@ -29,7 +29,6 @@ import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 
 import javax.inject.Inject;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Validation logic for resources, resource groups and resource types

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
@@ -29,6 +29,7 @@ import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Validation logic for resources, resource groups and resource types
@@ -40,15 +41,19 @@ public class ResourceValidationService {
 
     /**
      * @param resourceName - the resource name to be validated
+     * @param id - the id of the resource
      * @throws AMWException - if the name is invalid, an AMW exception is thrown
      */
-    public void validateResourceName(String resourceName) throws AMWException {
+    public void validateResourceName(String resourceName, Integer id) throws AMWException {
         if (resourceName == null || resourceName.trim().isEmpty()) {
             throw new AMWException("The resource name must not be empty!");
         }
+        if (id == null) {
+            throw new AMWException("The resource id must not be empty!");
+        }
         // Check if a resource with the same name already exists...
         List<ResourceEntity> resourceEntities = QueryUtils.fetch(ResourceEntity.class,
-                  queries.searchResourceByName(resourceName), 0, -1);
+                  queries.searchResourceByName(resourceName, id), 0, -1);
         if (resourceEntities != null) {
             for (ResourceEntity resourceEntity : resourceEntities) {
                 if (resourceEntity.getName().equalsIgnoreCase(resourceName)) {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationService.java
@@ -52,7 +52,7 @@ public class ResourceValidationService {
         }
         // Check if a resource with the same name already exists...
         List<ResourceEntity> resourceEntities = QueryUtils.fetch(ResourceEntity.class,
-                  queries.searchResourceByName(resourceName, id), 0, -1);
+                  queries.searchOtherResourcesWithName(resourceName, id), 0, -1);
         if (resourceEntities != null) {
             for (ResourceEntity resourceEntity : resourceEntities) {
                 if (resourceEntity.getName().equalsIgnoreCase(resourceName)) {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourcesScreenQueries.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourcesScreenQueries.java
@@ -39,9 +39,10 @@ public class ResourcesScreenQueries {
 				.setParameter("resourceTypeName", resourceTypeName);
 	}
 	
-	public Query searchResourceByName(String resourceName) {
-		return entityManager.createQuery("from ResourceEntity as res where res.name like :resourceName")
-				.setParameter("resourceName", resourceName);
+	public Query searchResourceByName(String resourceName, Integer id) {
+		return entityManager.createQuery("from ResourceEntity as res where lower(res.name) like lower(:resourceName) and res.id != :id")
+				.setParameter("resourceName", resourceName)
+				.setParameter("id", id);
 	}
 
 	public Query searchResourceBySoftlinkIdAndHasNotResourceGroupId(String softlinkId, Integer resourceGroupId){

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourcesScreenQueries.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourcesScreenQueries.java
@@ -39,7 +39,7 @@ public class ResourcesScreenQueries {
 				.setParameter("resourceTypeName", resourceTypeName);
 	}
 	
-	public Query searchResourceByName(String resourceName, Integer id) {
+	public Query searchOtherResourcesWithName(String resourceName, Integer id) {
 		return entityManager.createQuery("from ResourceEntity as res where lower(res.name) like lower(:resourceName) and res.id != :id")
 				.setParameter("resourceName", resourceName)
 				.setParameter("id", id);

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationServiceIntegrationTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceValidationServiceIntegrationTest.java
@@ -67,14 +67,29 @@ public class ResourceValidationServiceIntegrationTest {
     @Test(expected = AMWException.class)
     public void testValidateResourceName() throws Exception {
         // given
-        String resourceName = "amw";
-        ResourceEntity resourceA = new ResourceEntityBuilder().withName(resourceName).build();
+        ResourceEntity resourceA = new ResourceEntityBuilder().withName("test").build();
+        ResourceEntity resourceB = new ResourceEntityBuilder().withName("amw").build();
+
+        entityManager.persist(resourceA);
+        entityManager.persist(resourceB);
+
+        assertNotNull(entityManager.find(ResourceEntity.class, resourceA.getId()));
+
+        // when
+        service.validateResourceName("amw", resourceA.getId());
+    }
+
+    @Test
+    public void testRenameResourceNameToSame() throws Exception {
+        // given
+        ResourceEntity resourceA = new ResourceEntityBuilder().withName("test").build();
+
         entityManager.persist(resourceA);
 
         assertNotNull(entityManager.find(ResourceEntity.class, resourceA.getId()));
 
         // when
-        service.validateResourceName(resourceName);
+        service.validateResourceName("test", resourceA.getId());
     }
 
     @Test
@@ -88,11 +103,11 @@ public class ResourceValidationServiceIntegrationTest {
         assertNotNull(entityManager.find(ResourceEntity.class, resourceA.getId()));
 
         // when
-        service.validateResourceName(newResourceName);
+        service.validateResourceName(newResourceName, resourceA.getId());
     }
 
     @Test
-    public void shouldAllowToAlterCaseOfResourceName() throws Exception {
+    public void shouldAllowToAlterCaseOfSameResource() throws Exception {
         // given
         String resourceName = "amw";
         String newResourceName = "AMW";
@@ -102,13 +117,32 @@ public class ResourceValidationServiceIntegrationTest {
         assertNotNull(entityManager.find(ResourceEntity.class, resourceA.getId()));
 
         // when
-        service.validateResourceName(newResourceName);
+        service.validateResourceName(newResourceName, resourceA.getId());
+    }
+
+    @Test(expected = AMWException.class)
+    public void shouldNotAllowToAlterCaseOfDifferentResource() throws AMWException {
+        // given
+
+        ResourceEntity resourceA = new ResourceEntityBuilder().withName("myapp").build();
+        entityManager.persist(resourceA);
+
+        ResourceEntity resourceB = new ResourceEntityBuilder().withName("myapp1").build();
+        entityManager.persist(resourceB);
+
+        service.validateResourceName("myApp", resourceB.getId());
     }
 
     @Test(expected = AMWException.class)
     public void testValidateResourceName_emptyName() throws Exception {
         // when
-        service.validateResourceName(null);
+        service.validateResourceName(null, null);
+    }
+
+    @Test(expected = AMWException.class)
+    public void testValidateResourceName_emptyId() throws Exception {
+        // when
+        service.validateResourceName("test", null);
     }
 
     @Test(expected = AMWException.class)


### PR DESCRIPTION
Issue #682 

Added validation to searchResourceByName() method so that renaming the same resource to uppercase or lowercase (eg, myapp to MyApp) is allowed, but not allowed for different resources. 

