### PR TITLE
fix: edit instance template exception

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/template/boundary/TemplateEditor.java
@@ -142,31 +142,37 @@ public class TemplateEditor {
 	public <T extends HasContexts<?>> void saveTemplateForRelation(TemplateDescriptorEntity template,
 																   Integer relationId,
 																   boolean resourceEdit) throws AMWException {
-		HasContexts<?> resourceRelation = null;
-		if (relationId != null) {
-			if (resourceEdit) {
-				AbstractResourceRelationEntity resRel = relationService.getResourceRelation(relationId);
-				resourceRelation = resRel;
-				permissionService.checkPermissionAndFireException(Permission.RESOURCE_TEMPLATE,
-						null,
-						Action.UPDATE,
-						resRel.getMasterResource().getResourceGroup(),
-						null,
-						"update templates for resource relations");
-			} else {
-				ResourceRelationTypeEntity resTypRel = relationService.getResourceTypeRelation(relationId);
-				resourceRelation = resTypRel;
-				permissionService.checkPermissionAndFireException(Permission.RESOURCETYPE_TEMPLATE,
-						null,
-						Action.UPDATE,
-						null,
-						resTypRel.getResourceTypeA(),
-						"update templates for resource type relations");
-			}
+		if (relationId == null) {
+			return;
 		}
+		HasContexts<?> resourceRelation = getResourceRelationAndCheckPermission(relationId, resourceEdit);
 		if (resourceRelation != null) {
 			saveTemplate(template, resourceRelation);
 		}
+	}
+
+	private HasContexts<?> getResourceRelationAndCheckPermission(Integer relationId, boolean resourceEdit) {
+		HasContexts<?> resourceRelation;
+		if (resourceEdit) {
+			AbstractResourceRelationEntity resRel = relationService.getResourceRelation(relationId);
+			resourceRelation = resRel;
+			permissionService.checkPermissionAndFireException(Permission.RESOURCE_TEMPLATE,
+					null,
+					Action.UPDATE,
+					resRel.getMasterResource().getResourceGroup(),
+					null,
+					"update templates for resource relations");
+		} else {
+			ResourceRelationTypeEntity resTypRel = relationService.getResourceTypeRelation(relationId);
+			resourceRelation = resTypRel;
+			permissionService.checkPermissionAndFireException(Permission.RESOURCETYPE_TEMPLATE,
+					null,
+					Action.UPDATE,
+					null,
+					resTypRel.getResourceTypeA(),
+					"update templates for resource type relations");
+		}
+		return resourceRelation;
 	}
 
 	public void saveTemplateForResource(TemplateDescriptorEntity template, ResourceEntity resourceEntity,

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -282,8 +282,7 @@ public class EditTemplateView implements Serializable {
 
     private void saveTemplate() throws AMWException {
         if (relationIdForTemplate != null) {
-            templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
-                    resourceId != null);
+            templateEditor.saveTemplateForRelation(template, relationIdForTemplate, resourceId != null);
             return;
         }
         if (resourceId == null) {

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -24,7 +24,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
-import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.shakedown.control.ShakedownStpService;
 import ch.puzzle.itc.mobiliar.business.shakedown.entity.ShakedownStpEntity;
 import ch.puzzle.itc.mobiliar.business.template.boundary.TemplateEditor;

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -284,12 +284,14 @@ public class EditTemplateView implements Serializable {
     private void saveTemplate() throws AMWException {
         if (relationIdForTemplate != null) {
             templateEditor.saveTemplateForRelation(template, relationIdForTemplate,
-                                                   resourceId != null);
-        } else if (resourceId == null) {
-            templateEditor.saveTemplateForResourceType(template, resourceTypeId, settings.isTestingMode());
-        } else {
-            templateEditor.saveTemplateForResource(template, resourceId, settings.isTestingMode());
+                    resourceId != null);
+            return;
         }
+        if (resourceId == null) {
+            templateEditor.saveTemplateForResourceType(template, resourceTypeId, settings.isTestingMode());
+            return;
+        }
+        templateEditor.saveTemplateForResource(template, resourceId, settings.isTestingMode());
     }
 
     public boolean canModifyTemplates() {

--- a/AMW_web/src/main/webapp/resources/mobi/editTemplate.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/editTemplate.xhtml
@@ -55,9 +55,11 @@
                                 <span class="meta ellipsisRight inlineBlock width100" title="#{instanceTemplate.targetPath}">#{instanceTemplate.targetPath}</span>
                             </h:column>
                             <h:column rendered="#{templateEditDataProvider.canRead}">
-                                <h:link outcome="editTemplateView" includeViewParams="true">
+                                <h:link outcome="editTemplateView" includeViewParams="false">
                                     <f:param name="rel" value="#{!cc.attrs.isRelation ? null : editResourceView.relationIdViewParam}"/>
+                                    <f:param name="id" value="#{editResourceView.resourceIdFromParam}" />
                                     <f:param name="templ" value="${instanceTemplate.id}" />
+                                    <f:viewParam name="lnWrap" value="#{editTemplateView.lineWrapping}" />
                                 Edit
                             </h:link>
                             </h:column>


### PR DESCRIPTION
Issue #704 

Modified component in `editTemplate.xhtml` to exclude relation id from the request. With this change, relationIdForTemplate remains null, and so modification of an instance template after deletion of relation will call the `saveTemplateForResource()`. Previously, since the request contained the relation id, modification of an instance template after deletion of relation was calling `saveTemplateForRelation()`, and resulting in the NullPointerException. 