### PR TITLE
fix: remove resources with functions

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntity.java
@@ -49,20 +49,16 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.hibernate.annotations.*;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Cascade;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 
 import javax.persistence.*;
-import javax.persistence.CascadeType;
-import javax.persistence.Entity;
-import javax.persistence.Table;
 import java.io.Serializable;
 import java.util.*;
 
-import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.CascadeType.MERGE;
-import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.*;
 
 /**
  * Entity implementation class for Entity: Resource

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntity.java
@@ -54,6 +54,7 @@ import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 
 import javax.persistence.*;
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.io.Serializable;
@@ -167,7 +168,7 @@ public class ResourceEntity extends HasContexts<ResourceContextEntity> implement
 	private Set<DeploymentEntity> deploymentsOfRuntime;
 
 
-	@OneToMany(mappedBy = "resource", cascade = PERSIST)
+	@OneToMany(mappedBy = "resource", cascade = ALL)
 	@Setter
 	private Set<AmwFunctionEntity> functions;
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntity.java
@@ -20,10 +20,10 @@
 
 package ch.puzzle.itc.mobiliar.business.resourcegroup.entity;
 
+import ch.puzzle.itc.mobiliar.business.database.control.Constants;
 import ch.puzzle.itc.mobiliar.business.environment.entity.HasContexts;
 import ch.puzzle.itc.mobiliar.business.function.entity.AmwFunctionEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationTypeEntity;
-import ch.puzzle.itc.mobiliar.business.database.control.Constants;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.CascadeType.REMOVE;
 
 /**

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntity.java
@@ -101,7 +101,7 @@ Comparable<ResourceTypeEntity> {
 	@OneToMany(mappedBy = "resourceTypeB", cascade = REMOVE)
 	Set<ResourceRelationTypeEntity> resourceRelationTypesB;
 
-	@OneToMany(mappedBy = "resourceType", cascade = PERSIST)
+	@OneToMany(mappedBy = "resourceType", cascade = ALL)
 	@Setter
 	private Set<AmwFunctionEntity> functions;
 

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntityPersistenceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceEntityPersistenceTest.java
@@ -1,0 +1,46 @@
+package ch.puzzle.itc.mobiliar.business.resourcegroup.entity;
+
+import ch.puzzle.itc.mobiliar.business.function.entity.AmwFunctionEntity;
+import ch.puzzle.itc.mobiliar.test.testrunner.PersistenceTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(PersistenceTestRunner.class)
+public class ResourceEntityPersistenceTest {
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Test
+    public void shouldDeleteResourceWithFunction() {
+        // given
+        ResourceGroupEntity resourceGroup = new ResourceGroupEntity();
+        AmwFunctionEntity function = new AmwFunctionEntity();
+        function.setName("function");
+        ResourceEntity resourceEntity = new ResourceEntity();
+        resourceEntity.setResourceGroup(resourceGroup);
+        resourceEntity.setName("entity");
+        resourceEntity.addFunction(function);
+        entityManager.persist(resourceEntity);
+        entityManager.flush();
+        Integer resourceEntityId = resourceEntity.getId();
+        Integer functionId = function.getId();
+        assertNotNull(entityManager.find(ResourceEntity.class, resourceEntityId));
+        assertNotNull(entityManager.find(AmwFunctionEntity.class, functionId));
+
+        // when
+        entityManager.remove(resourceEntity);
+        entityManager.flush();
+
+        // then
+        assertNull(entityManager.find(ResourceEntity.class, resourceEntityId));
+        assertNull(entityManager.find(AmwFunctionEntity.class, functionId));
+
+    }
+
+}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntityPersistenceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTypeEntityPersistenceTest.java
@@ -1,0 +1,45 @@
+package ch.puzzle.itc.mobiliar.business.resourcegroup.entity;
+
+import ch.puzzle.itc.mobiliar.business.function.entity.AmwFunctionEntity;
+import ch.puzzle.itc.mobiliar.test.testrunner.PersistenceTestRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import static org.junit.Assert.*;
+
+@RunWith(PersistenceTestRunner.class)
+public class ResourceTypeEntityPersistenceTest {
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    @Test
+    public void shouldDeleteResourceTypeWithFunction() {
+        // given
+        ResourceTypeEntity appType = new ResourceTypeEntity();
+        appType.setName("resourcetype");
+        AmwFunctionEntity function = new AmwFunctionEntity();
+        function.setName("function1");
+        function.setImplementation("test");
+        function.setResourceType(appType);
+        appType.addFunction(function);
+        entityManager.persist(appType);
+        Integer appTypeId = appType.getId();
+        Integer functionId = function.getId();
+        assertNotNull(entityManager.find(ResourceTypeEntity.class, appTypeId));
+        assertNotNull(entityManager.find(AmwFunctionEntity.class, functionId));
+
+        // when
+        entityManager.remove(appType);
+        entityManager.flush();
+
+        // then
+        assertNull(entityManager.find(ResourceTypeEntity.class, appTypeId));
+        assertNull(entityManager.find(AmwFunctionEntity.class, functionId));
+
+    }
+
+}


### PR DESCRIPTION
Issue #681 

Changed the `cascade` attributes of the @OneToMany annotations that were causing the exception during resource deletion 