### PR TITLE
Node and js update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
     - name: Cache node
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.node
         key: ${{ runner.os }}-node-${{ hashFiles('**/pom.xml') }}
@@ -29,9 +29,10 @@ jobs:
       uses: nanasess/setup-chromedriver@master
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
+        distribution: adopt
 
     - name: Get the version
       id: get_version
@@ -46,13 +47,13 @@ jobs:
       run: AMW_docker/build.sh
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Login to GitHub Packages Docker Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -70,26 +71,12 @@ jobs:
 
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: ${{ steps.get_version.outputs.VERSION }}
-        release_name: Release ${{ steps.get_version.outputs.VERSION }}
+        tag: ${{ steps.get_version.outputs.VERSION }}
+        name: Release ${{ steps.get_version.outputs.VERSION }}
         body: |
           Release Changelog: <https://github.com/liimaorg/liima/blob/master/release-changelog.md>
           GitHub Packages: <https://github.com/orgs/liimaorg/packages?repo_name=liima>
           Docker Hub: <https://hub.docker.com/r/liimaorg/liima>
-        draft: false
-        prerelease: false
-
-    - name: Upload ear as Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./AMW_ear/target/AMW.ear
-        asset_name: AMW_ear-${{ steps.get_version.outputs.VERSION }}.ear
-        asset_content_type: application/octet-stream
+        artifacts: "./AMW_ear/target/AMW.ear"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
     - name: Cache node
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.node
         key: ${{ runner.os }}-node-${{ hashFiles('**/pom.xml') }}
@@ -32,9 +32,10 @@ jobs:
       uses: nanasess/setup-chromedriver@master
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
+        distribution: adopt
 
     - name: Build and test
       run: mvn --batch-mode clean install

--- a/AMW_angular/pom.xml
+++ b/AMW_angular/pom.xml
@@ -43,8 +43,8 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <version>1.13.3</version>
                 <configuration>
-                    <nodeVersion>v18.16.1</nodeVersion>
-                    <npmVersion>9.7.2</npmVersion>
+                    <nodeVersion>v20.11.1</nodeVersion>
+                    <npmVersion>10.4.0</npmVersion>
                     <workingDirectory>io</workingDirectory>
                     <installDirectory>${user.home}/.node</installDirectory>
                 </configuration>


### PR DESCRIPTION
Updated gh actions:
- actions/create-release and actions/upload-release-asset are no longer maintained
- Other actions cause this error: `Node.js 12/16 actions are deprecated`

Updated node and js in the pom of the JS frontend.