### PR TITLE
fix: allow to add node to AppServer with update resouce permission

### DIFF
--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/propertyEdit/RelationDataProvider.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/propertyEdit/RelationDataProvider.java
@@ -219,8 +219,7 @@ public class RelationDataProvider implements Serializable {
             resourceTypes = new ArrayList<>(resourceTypeDataProvider.getRootResourceTypes());
             Collections.sort(resourceTypes);
 
-            if (getResourceType().isApplicationServerResourceType()
-                    && permissionService.hasPermission(Permission.RESOURCE, Action.UPDATE, getResourceType())) {
+            if (getResourceType().isApplicationServerResourceType()) {
                 // The application server can additionally add nodes
                 resourceTypes = new ArrayList<>(resourceTypes);
                 resourceTypes.add(0, resourceTypeDataProvider.getByName(DefaultResourceTypeDefinition.NODE.name()));


### PR DESCRIPTION
Doesn't make sense, that you only can update nodes, when you have update permissions on all resource of type appserver.