### PR TITLE
new servers page with routing

### DIFF
--- a/AMW_angular/io/src/app/app.routes.ts
+++ b/AMW_angular/io/src/app/app.routes.ts
@@ -5,12 +5,14 @@ import { auditviewRoutes } from './auditview/auditview.routes';
 import { deploymentRoutes } from './deployment/deployment-routes';
 import { settingsRoutes } from './settings/settings.routes';
 import { deploymentsRoutes } from './deployments/deployments.routes';
+import { serversRoute } from './servers/servers.route';
 
 export const routes: Routes = [
   // default route only, the rest is done in module routing
   { path: '', component: DeploymentsComponent },
 
   ...appsRoutes,
+  ...serversRoute,
   ...settingsRoutes,
   ...auditviewRoutes,
   ...deploymentRoutes,

--- a/AMW_angular/io/src/app/layout/page/page.component.ts
+++ b/AMW_angular/io/src/app/layout/page/page.component.ts
@@ -10,7 +10,7 @@ import { RouterLink } from '@angular/router';
   template: `
     <div class="row">
       <div class="col-12 bg-dark-subtle pt-2">
-        <h4><ng-content select=".page-title"></ng-content></h4>
+        <h4 data-cy="page-title"><ng-content select=".page-title"></ng-content></h4>
       </div>
     </div>
     <div class="container mt-4">

--- a/AMW_angular/io/src/app/navigation/navigation.component.ts
+++ b/AMW_angular/io/src/app/navigation/navigation.component.ts
@@ -34,7 +34,7 @@ import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
             </li>
             <li class="nav-item"></li>
             <li>
-              <a class="nav-link" href="/AMW_web/pages/serverListView.xhtml">Servers</a>
+              <a class="nav-link" href="#/servers">Servers</a>
             </li>
 
             <li class="nav-item">

--- a/AMW_angular/io/src/app/servers/servers-page-component.spec.ts
+++ b/AMW_angular/io/src/app/servers/servers-page-component.spec.ts
@@ -1,0 +1,25 @@
+import { ServersPageComponent } from './servers-page.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+describe(ServersPageComponent.name, () => {
+  let component: ServersPageComponent;
+  let fixture: ComponentFixture<ServersPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ServersPageComponent],
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ServersPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(component.isLoading()).toBeFalse();
+  });
+});

--- a/AMW_angular/io/src/app/servers/servers-page.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-page.component.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-servers-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [],
+  template: ` <h1 data-cy="page-title">Servers</h1>`,
+})
+export class ServersPageComponent {}

--- a/AMW_angular/io/src/app/servers/servers-page.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-page.component.ts
@@ -1,10 +1,33 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { PageComponent } from '../layout/page/page.component';
+import { LoadingIndicatorComponent } from '../shared/elements/loading-indicator.component';
+import { AuthService } from '../auth/auth.service';
 
 @Component({
   selector: 'app-servers-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [],
-  template: ` <h1 data-cy="page-title">Servers</h1>`,
+  imports: [PageComponent, LoadingIndicatorComponent],
+  template: ` <app-loading-indicator [isLoading]="isLoading()"></app-loading-indicator>
+    <app-page>
+      <div class="page-title">Servers</div>
+      <div class="page-content">
+        {{ loadingPermissions() }}
+      </div></app-page
+    >`,
 })
-export class ServersPageComponent {}
+export class ServersPageComponent {
+  private authService = inject(AuthService);
+
+  isLoading = signal(false);
+
+  loadingPermissions = computed(() => {
+    if (this.authService.restrictions().length > 0) {
+      this.getUserPermissions();
+    } else {
+      return `<div>Could not load permissions</div>`;
+    }
+  });
+
+  private getUserPermissions() {}
+}

--- a/AMW_angular/io/src/app/servers/servers.route.ts
+++ b/AMW_angular/io/src/app/servers/servers.route.ts
@@ -1,0 +1,3 @@
+import { ServersPageComponent } from './servers-page.component';
+
+export const serversRoute = [{ path: 'servers', component: ServersPageComponent }];

--- a/AMW_e2e/cypress/e2e/servers/servers.cy.js
+++ b/AMW_e2e/cypress/e2e/servers/servers.cy.js
@@ -1,0 +1,10 @@
+describe("Servers Page", () => {
+  it("should navigate to the servers page", () => {
+    cy.visit("AMW_angular/#/servers", {
+      username: "admin",
+      password: "admin",
+    });
+
+    cy.get('[data-cy="page-title"]').contains("Servers");
+  });
+});


### PR DESCRIPTION
this change contains:

* Routing to the new page "servers"
* A page component with the basic setup/ layout for the servers page
* the servers link in the navigation (angular) now points to the new page
* e2e test that makes sure that the routing works as expected

An additional change was made to the PageComponent: a `data-cy` attribute `data-cy="page-title"`was added to the page title to simplify cypress e2e tests.