### PR TITLE
Angular: make tables more similar, fix some UI bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test and build
 
 on:
   push:
-    branches: [ master, development, angular_fixes ]
+    branches: [ master, development ]
   pull_request:
-    branches: [ master, development, angular_fixes ]
+    branches: [ master, development ]
 
 jobs:
   build_and_test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test and build
 
 on:
   push:
-    branches: [ master, development ]
+    branches: [ master, development, angular_fixes ]
   pull_request:
-    branches: [ master, development ]
+    branches: [ master, development, angular_fixes ]
 
 jobs:
   build_and_test:

--- a/AMW_angular/io/package-lock.json
+++ b/AMW_angular/io/package-lock.json
@@ -6069,6 +6069,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/dev-server-core/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@web/dev-server-core/node_modules/lru-cache": {
       "version": "8.0.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
@@ -6090,6 +6106,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@web/dev-server-core/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@web/dev-server-rollup": {
@@ -6253,6 +6283,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/test-runner-core/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@web/test-runner-core/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6299,6 +6345,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/readdirp": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@web/test-runner-coverage-v8": {
@@ -7648,18 +7708,41 @@
       "license": "MIT"
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 8.10.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/chownr": {
@@ -14992,16 +15075,29 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">=8.6"
       },
       "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/reflect-metadata": {
@@ -15545,70 +15641,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/sass/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/sass/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/sass/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/sass/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/sax": {
@@ -18069,44 +18101,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
@@ -18140,32 +18134,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/rimraf": {

--- a/AMW_angular/io/src/app/apps/app-add/app-add.component.ts
+++ b/AMW_angular/io/src/app/apps/app-add/app-add.component.ts
@@ -51,6 +51,9 @@ export class AppAddComponent {
   }
 
   save() {
+    if (this.hasInvalidFields()) {
+      return
+    }
     const app: AppCreate = {
       appName: this.app.appName,
       appReleaseId: this.app.appReleaseId,

--- a/AMW_angular/io/src/app/apps/app-add/app-add.component.ts
+++ b/AMW_angular/io/src/app/apps/app-add/app-add.component.ts
@@ -52,7 +52,7 @@ export class AppAddComponent {
 
   save() {
     if (this.hasInvalidFields()) {
-      return
+      return;
     }
     const app: AppCreate = {
       appName: this.app.appName,

--- a/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.html
+++ b/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.html
@@ -3,10 +3,8 @@
   <div class="form-horizontal mx-2">
     <div class="needs-validation mb-3">
       <label for="name" class="form-label">Applicationserver</label>
-      <input type="text" class="form-control" id="name" [(ngModel)]="appServer.name" required/>
-      <div class="invalid-feedback">
-        Please enter a name
-      </div>
+      <input type="text" class="form-control" id="name" [(ngModel)]="appServer.name" required />
+      <div class="invalid-feedback">Please enter a name</div>
     </div>
     <div class="mb-3">
       <label class="form-label">Release</label>

--- a/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.html
+++ b/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.html
@@ -1,9 +1,12 @@
 <app-modal-header [title]="'Create application server'" (cancel)="cancel()"></app-modal-header>
 <div class="modal-body">
   <div class="form-horizontal mx-2">
-    <div class="mb-3">
+    <div class="needs-validation mb-3">
       <label for="name" class="form-label">Applicationserver</label>
-      <input type="text" class="form-control" id="name" [(ngModel)]="appServer.name" />
+      <input type="text" class="form-control" id="name" [(ngModel)]="appServer.name" required/>
+      <div class="invalid-feedback">
+        Please enter a name
+      </div>
     </div>
     <div class="mb-3">
       <label class="form-label">Release</label>

--- a/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.ts
+++ b/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.ts
@@ -24,7 +24,7 @@ export class AppServerAddComponent {
   }
 
   hasInvalidFields(): boolean {
-    return this.appServer.name === '' || this.appServer.release?.id === null || this.appServer.release?.name === '';
+    return this.appServer.name === '' || this.appServer.release?.id == null;
   }
 
   cancel() {
@@ -32,6 +32,10 @@ export class AppServerAddComponent {
   }
 
   save() {
+    if (this.hasInvalidFields()) {
+      document.querySelectorAll('.needs-validation')[0].classList.add('was-validated');
+      return
+    }
     const appServer: AppServer = {
       name: this.appServer.name,
       release: this.appServer.release,

--- a/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.ts
+++ b/AMW_angular/io/src/app/apps/app-server-add/app-server-add.component.ts
@@ -34,7 +34,7 @@ export class AppServerAddComponent {
   save() {
     if (this.hasInvalidFields()) {
       document.querySelectorAll('.needs-validation')[0].classList.add('was-validated');
-      return
+      return;
     }
     const appServer: AppServer = {
       name: this.appServer.name,

--- a/AMW_angular/io/src/app/apps/apps-filter/apps-filter.component.html
+++ b/AMW_angular/io/src/app/apps/apps-filter/apps-filter.component.html
@@ -1,9 +1,4 @@
-<div class="container border-bottom border-light-subtle pb-4">
-  <div class="row mb-3">
-    <div class="col-sm">
-      <b>Add Filter</b>
-    </div>
-  </div>
+<div class="container pb-2">
   <div class="row justify-content-between align-items-end">
     <div class="col-sm-4">
       <label for="appName" class="form-label">Application/AS name</label>

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list-component.ts
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list-component.ts
@@ -1,16 +1,14 @@
-import { Component, Input } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { PaginationComponent } from '../../shared/pagination/pagination.component';
+import { Component, input } from '@angular/core';
 import { App } from '../app';
 
 @Component({
   selector: 'app-apps-list',
   standalone: true,
-  imports: [AsyncPipe, PaginationComponent],
+  imports: [],
   templateUrl: './apps-list.component.html',
   styleUrl: './apps-list.component.scss',
 })
 export class AppsListComponent {
-  @Input() apps: App[];
-  @Input() even: boolean;
+  apps = input.required<App[]>();
+  even = input.required<boolean>();
 }

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
@@ -1,16 +1,16 @@
-@if (apps && apps.length > 0) {
-<table class="table table-sm table-borderless mb-0">
-  <tbody>
-    @for (app of apps; track app) {
-    <tr [class.table-light]="!even">
-      <td class="align-middle ps-2 w-90 border-0 py-2">
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
-      </td>
-      <td class="align-middle ps-4 w-10 border-0 py-2">
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
-      </td>
-    </tr>
-    }
-  </tbody>
-</table>
+@if (apps() && apps().length > 0) {
+  <table class="table table-sm mb-0">
+    <tbody>
+      @for (app of apps(); track app) {
+        <tr [class.table-light]="!even()">
+          <td>
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
+          </td>
+          <td class="text-end pe-0">
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
 }

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
@@ -1,16 +1,16 @@
 @if (apps() && apps().length > 0) {
-  <table class="table table-sm mb-0">
-    <tbody>
-      @for (app of apps(); track app) {
-        <tr [class.table-light]="!even()">
-          <td>
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
-          </td>
-          <td class="text-end pe-0">
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
-          </td>
-        </tr>
-      }
-    </tbody>
-  </table>
+<table class="table table-sm mb-0">
+  <tbody>
+    @for (app of apps(); track app) {
+    <tr [class.table-light]="!even()">
+      <td>
+        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
+      </td>
+      <td class="text-end pe-0">
+        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
+      </td>
+    </tr>
+    }
+  </tbody>
+</table>
 }

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.spec.ts
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppsListComponent } from './apps-list-component';
+import { ComponentRef } from '@angular/core';
 
 describe('AppsListComponent', () => {
   let component: AppsListComponent;
+  let componentRef: ComponentRef<AppsListComponent>;
   let fixture: ComponentFixture<AppsListComponent>;
 
   beforeEach(async () => {
@@ -13,6 +15,9 @@ describe('AppsListComponent', () => {
 
     fixture = TestBed.createComponent(AppsListComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('apps', []);
+    componentRef.setInput('even', true);
     fixture.detectChanges();
   });
 

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -1,30 +1,30 @@
 <div class="table-responsive">
-  <table class="table table-sm table-borderless">
+  <table class="table table-sm">
     <thead class="table-light">
       <tr>
-        <th class="w-90">App Name</th>
-        <th class="w-10">Release</th>
+        <th scope="col">App Name</th>
+        <th scope="col" class="text-end">Release</th>
       </tr>
     </thead>
     <tbody>
-      @for (appServer of appServers; track appServer; let even = $even) {
+      @for (appServer of appServers(); track appServer; let even = $even) {
         <tr [class.table-light]="!even">
-          <td class="align-middle w-90">
+          <td class="border-0">
             @if (!appServer.deletable) {
             <div id="appServer.id">{{ appServer.name }}</div>
             } @else {
             <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
             {{ appServer.runtimeName }} ] }
           </td>
-          <td class="align-middle w-10">
+          <td class="text-end border-0">
             <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{
               appServer.release.name
             }}</a>
           </td>
         </tr>
         @if (appServer.apps && appServer.apps.length > 0) {
-        <tr class="py-0 borderless" [class.table-light]="!even">
-          <td colspan="2" class="py-0 border-0">
+        <tr [class.table-light]="!even">
+          <td colspan="2" class="border-0 ps-4 py-0">
             <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
           </td>
         </tr>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -17,7 +17,7 @@
             {{ appServer.runtimeName }} ] }
           </td>
           <td class="text-end border-0">
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{
               appServer.release.name
             }}</a>
           </td>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -1,5 +1,4 @@
 <div class="table-responsive">
-  @if (appServers && appServers.length > 0) {
   <table class="table table-sm table-borderless">
     <thead class="table-light">
       <tr>
@@ -9,31 +8,32 @@
     </thead>
     <tbody>
       @for (appServer of appServers; track appServer; let even = $even) {
-
-      <tr [class.table-light]="!even">
-        <td class="align-middle w-90">
-          @if (!appServer.deletable) {
-          <div id="appServer.id">{{ appServer.name }}</div>
-          } @else {
-          <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
-          {{ appServer.runtimeName }} ] }
-        </td>
-        <td class="align-middle w-10">
-          <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{
-            appServer.release.name
-          }}</a>
-        </td>
-      </tr>
-      @if (appServer.apps && appServer.apps.length > 0) {
-      <tr class="py-0 borderless" [class.table-light]="!even">
-        <td colspan="2" class="py-0 border-0">
-          <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
-        </td>
-      </tr>
-      } }
+        <tr [class.table-light]="!even">
+          <td class="align-middle w-90">
+            @if (!appServer.deletable) {
+            <div id="appServer.id">{{ appServer.name }}</div>
+            } @else {
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
+            {{ appServer.runtimeName }} ] }
+          </td>
+          <td class="align-middle w-10">
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{
+              appServer.release.name
+            }}</a>
+          </td>
+        </tr>
+        @if (appServer.apps && appServer.apps.length > 0) {
+        <tr class="py-0 borderless" [class.table-light]="!even">
+          <td colspan="2" class="py-0 border-0">
+            <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
+          </td>
+        </tr>
+        }
+      } @empty {
+        <tr>
+          <td colspan="2" class="text-center">No results found in database</td>
+        </tr>
+      }
     </tbody>
   </table>
-  } @else {
-  <div class="empty-container">No results found in database</div>
-  }
 </div>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -8,31 +8,28 @@
     </thead>
     <tbody>
       @for (appServer of appServers(); track appServer; let even = $even) {
-        <tr [class.table-light]="!even">
-          <td class="border-0">
-            @if (!appServer.deletable) {
-            <div id="appServer.id">{{ appServer.name }}</div>
-            } @else {
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
-            {{ appServer.runtimeName }} ] }
-          </td>
-          <td class="text-end border-0">
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{
-              appServer.release.name
-            }}</a>
-          </td>
-        </tr>
-        @if (appServer.apps && appServer.apps.length > 0) {
-        <tr [class.table-light]="!even">
-          <td colspan="2" class="border-0 ps-4 py-0">
-            <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
-          </td>
-        </tr>
-        }
-      } @empty {
-        <tr>
-          <td colspan="2" class="text-center">No results found in database</td>
-        </tr>
+      <tr [class.table-light]="!even">
+        <td class="border-0">
+          @if (!appServer.deletable) {
+          <div id="appServer.id">{{ appServer.name }}</div>
+          } @else {
+          <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
+          {{ appServer.runtimeName }} ] }
+        </td>
+        <td class="text-end border-0">
+          <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.release.name }}</a>
+        </td>
+      </tr>
+      @if (appServer.apps && appServer.apps.length > 0) {
+      <tr [class.table-light]="!even">
+        <td colspan="2" class="border-0 ps-4 py-0">
+          <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
+        </td>
+      </tr>
+      } } @empty {
+      <tr>
+        <td colspan="2" class="text-center">No results found in database</td>
+      </tr>
       }
     </tbody>
   </table>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.spec.ts
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppsServersListComponent } from './apps-servers-list.component';
+import { ComponentRef } from '@angular/core';
 
 describe('AppsListComponent', () => {
   let component: AppsServersListComponent;
+  let componentRef: ComponentRef<AppsServersListComponent>;
   let fixture: ComponentFixture<AppsServersListComponent>;
 
   beforeEach(async () => {
@@ -13,6 +15,8 @@ describe('AppsListComponent', () => {
 
     fixture = TestBed.createComponent(AppsServersListComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('appServers', []);
     fixture.detectChanges();
   });
 

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.ts
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.ts
@@ -1,16 +1,14 @@
-import { Component, Input } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { PaginationComponent } from '../../shared/pagination/pagination.component';
+import { Component, input } from '@angular/core';
 import { AppServer } from '../app-server';
 import { AppsListComponent } from '../apps-list/apps-list-component';
 
 @Component({
   selector: 'app-apps-servers-list',
   standalone: true,
-  imports: [AsyncPipe, AppsListComponent, PaginationComponent],
+  imports: [AppsListComponent],
   templateUrl: './apps-servers-list.component.html',
   styleUrl: './apps-servers-list.component.scss',
 })
 export class AppsServersListComponent {
-  @Input() appServers: AppServer[];
+  appServers = input.required<AppServer[]>();
 }

--- a/AMW_angular/io/src/app/apps/apps.component.html
+++ b/AMW_angular/io/src/app/apps/apps.component.html
@@ -37,17 +37,6 @@
         <div class="card-body">
           <app-apps-servers-list [appServers]="appServers()"></app-apps-servers-list>
         </div>
-        <div class="card-footer py-1">
-          <div class="row bg-light align-items-center">
-            <app-pagination
-              [currentPage]="currentPage()"
-              [lastPage]="lastPage()"
-              (doSetMax)="setMaxResultsPerPage($event)"
-              (doSetOffset)="setNewOffset($event)"
-            >
-            </app-pagination>
-          </div>
-        </div>
         }
       </div>
     </div>

--- a/AMW_angular/io/src/app/apps/apps.component.html
+++ b/AMW_angular/io/src/app/apps/apps.component.html
@@ -2,56 +2,53 @@
 <app-page>
   <div class="page-title">Apps</div>
   <div class="page-content">
-    <div>
-      <div class="container">
-        <div class="card row mt-2 mb-3">
-          <div class="card-header">
-            <div class="row justify-content-between align-items-center">
-              <div class="col-sm">
-                <b>Application servers and applications</b>
-              </div>
-              <div class="col-sm">
-                @if (permissions().canCreateApp) {
-                <app-button
-                  [variant]="'primary'"
-                  [additionalClasses]="'float-end'"
-                  [dataCy]="'button-add-app'"
-                  (click)="addApp()"
-                >
-                  <app-icon icon="plus-circle"></app-icon>
-                  Add Application
-                </app-button>
-                } @if (permissions().canCreateAppServer) {
-                <app-button [variant]="'primary'" [additionalClasses]="'float-end'" (click)="addServer()">
-                  <app-icon icon="plus-circle"></app-icon>
-                  Add Application Server
-                </app-button>
-                }
-              </div>
+    <div class="container">
+      <div class="card row mt-2 mb-2">
+        <div class="card-header">
+          <div class="row justify-content-between align-items-center">
+            <div class="col-sm">
+              <app-apps-filter
+                [releases]="releases()"
+                [upcoming]="upcomingRelease() ? upcomingRelease().id : null"
+                (filterEvent)="updateFilter($event)"
+              ></app-apps-filter>
             </div>
-          </div>
-          @if (permissions().canViewAppList) {
-          <div class="card-body">
-            <app-apps-filter
-              [releases]="releases()"
-              [upcoming]="upcomingRelease() ? upcomingRelease().id : null"
-              (filterEvent)="updateFilter($event)"
-            ></app-apps-filter>
-            <app-apps-servers-list [appServers]="appServers()"></app-apps-servers-list>
-          </div>
-          <div class="card-footer py-1">
-            <div class="row bg-light align-items-center">
-              <app-pagination
-                [currentPage]="currentPage()"
-                [lastPage]="lastPage()"
-                (doSetMax)="setMaxResultsPerPage($event)"
-                (doSetOffset)="setNewOffset($event)"
+            <div class="col-sm">
+              @if (permissions().canCreateApp) {
+              <app-button
+                [variant]="'primary'"
+                [additionalClasses]="'float-end'"
+                [dataCy]="'button-add-app'"
+                (click)="addApp()"
               >
-              </app-pagination>
+                <app-icon icon="plus-circle"></app-icon>
+                Add Application
+              </app-button>
+              } @if (permissions().canCreateAppServer) {
+              <app-button [variant]="'primary'" [additionalClasses]="'float-end'" (click)="addServer()">
+                <app-icon icon="plus-circle"></app-icon>
+                Add Application Server
+              </app-button>
+              }
             </div>
           </div>
-          }
         </div>
+        @if (permissions().canViewAppList) {
+        <div class="card-body">
+          <app-apps-servers-list [appServers]="appServers()"></app-apps-servers-list>
+        </div>
+        <div class="card-footer py-1">
+          <div class="row bg-light align-items-center">
+            <app-pagination
+              [currentPage]="currentPage()"
+              [lastPage]="lastPage()"
+              (doSetMax)="setMaxResultsPerPage($event)"
+              (doSetOffset)="setNewOffset($event)"
+            >
+            </app-pagination>
+          </div>
+        </div>
+        }
       </div>
     </div>
   </div>

--- a/AMW_angular/io/src/app/apps/apps.component.spec.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppsComponent } from './apps.component';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { RouterModule } from '@angular/router';
 
 describe('AppsComponent', () => {
   let component: AppsComponent;
@@ -10,7 +11,7 @@ describe('AppsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppsComponent],
+      imports: [AppsComponent, RouterModule.forRoot([], { useHash: true })],
       providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
     }).compileComponents();
 

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -23,6 +23,7 @@ import { Resource } from '../resource/resource';
 import { AppCreate } from './app-create';
 import { ButtonComponent } from '../shared/button/button.component';
 import { ResourceTypesService } from '../resource/resource-types.service';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-apps',
@@ -48,6 +49,8 @@ export class AppsComponent implements OnInit, OnDestroy {
   private resourceService = inject(ResourceService);
   private resourceTypesService = inject(ResourceTypesService);
   private toastService = inject(ToastService);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
 
   upcomingRelease: Signal<Release> = toSignal(this.releaseService.getUpcomingRelease());
 
@@ -100,6 +103,15 @@ export class AppsComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.error$.pipe(takeUntil(this.destroy$)).subscribe((msg) => {
       msg !== '' ? this.toastService.error(msg) : null;
+    });
+
+    this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe((params) => {
+      if (params.filter) {
+        this.filter.set(params.filter);
+      }
+      if (params.releaseId) {
+        this.releaseId.set(params.releaseId);
+      }
     });
   }
 
@@ -175,6 +187,10 @@ export class AppsComponent implements OnInit, OnDestroy {
       update = true;
     }
     if (update) {
+      this.router.navigate([], {
+        relativeTo: this.route,
+        queryParams: { filter: this.filter(), releaseId: this.releaseId() },
+      });
       this.appsService.refreshData();
     }
   }

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject, OnDestroy, OnInit, signal, Signal } from '@angular/core';
-import { BehaviorSubject, of, skip, Subject, take } from 'rxjs';
+import { BehaviorSubject, skip, Subject, take } from 'rxjs';
 import { LoadingIndicatorComponent } from '../shared/elements/loading-indicator.component';
 import { IconComponent } from '../shared/icon/icon.component';
 import { PageComponent } from '../layout/page/page.component';
@@ -8,7 +8,7 @@ import { AuthService } from '../auth/auth.service';
 import { ReleasesService } from '../settings/releases/releases.service';
 import { AppsService } from './apps.service';
 import { Release } from '../settings/releases/release';
-import { switchMap, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { ToastService } from '../shared/elements/toast/toast.service';
 import { AppServer } from './app-server';
 import { AppsServersListComponent } from './apps-servers-list/apps-servers-list.component';
@@ -17,7 +17,6 @@ import { AppServerAddComponent } from './app-server-add/app-server-add.component
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AppAddComponent } from './app-add/app-add.component';
 import { ResourceService } from '../resource/resource.service';
-import { Resource } from '../resource/resource';
 import { AppCreate } from './app-create';
 import { ButtonComponent } from '../shared/button/button.component';
 import { ResourceTypesService } from '../resource/resource-types.service';
@@ -131,7 +130,7 @@ export class AppsComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.appsService.refreshData();
-          this.appServerResourceType$.subscribe((asResourceType) => {
+          this.appServerResourceType$.pipe(takeUntil(this.destroy$)).subscribe((asResourceType) => {
             this.resourceService.setTypeForResourceGroupList(asResourceType);
           });
         },

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -12,7 +12,6 @@ import { switchMap, takeUntil } from 'rxjs/operators';
 import { ToastService } from '../shared/elements/toast/toast.service';
 import { AppServer } from './app-server';
 import { AppsServersListComponent } from './apps-servers-list/apps-servers-list.component';
-import { PaginationComponent } from '../shared/pagination/pagination.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AppServerAddComponent } from './app-server-add/app-server-add.component';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
@@ -33,7 +32,6 @@ import { ActivatedRoute, Router } from '@angular/router';
     IconComponent,
     LoadingIndicatorComponent,
     PageComponent,
-    PaginationComponent,
     ButtonComponent,
   ],
   templateUrl: './apps.component.html',
@@ -66,7 +64,7 @@ export class AppsComponent implements OnInit, OnDestroy {
 
   showLoader = signal(false);
   isLoading = computed(() => {
-    return this.appServers() === undefined || this.showLoader();
+    return this.appServers() === undefined || this.appServers() === null || this.showLoader();
   });
 
   permissions = computed(() => {
@@ -80,9 +78,6 @@ export class AppsComponent implements OnInit, OnDestroy {
       return { canCreateApp: false, canCreateAppServer: false, canViewAppList: false };
     }
   });
-
-  currentPage = computed(() => Math.floor(this.appsService.offset() / this.appsService.limit()) + 1);
-  lastPage = computed(() => Math.ceil(this.appsService.count() / this.appsService.limit()));
 
   constructor() {
     toObservable(this.upcomingRelease)
@@ -155,17 +150,6 @@ export class AppsComponent implements OnInit, OnDestroy {
         },
       });
     this.showLoader.set(false);
-  }
-
-  setMaxResultsPerPage(max: number) {
-    this.appsService.limit.set(max);
-    this.appsService.offset.set(0);
-    this.appsService.refreshData();
-  }
-
-  setNewOffset(offset: number) {
-    this.appsService.offset.set(offset);
-    this.appsService.refreshData();
   }
 
   updateFilter(values: { filter: string; releaseId: number }) {

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -134,6 +134,7 @@ export class AppsComponent implements OnInit, OnDestroy {
           this.appsService.refreshData();
         },
       });
+    this.showLoader.set(false);
   }
 
   saveApp(app: AppCreate) {
@@ -148,6 +149,7 @@ export class AppsComponent implements OnInit, OnDestroy {
           this.appsService.refreshData();
         },
       });
+    this.showLoader.set(false);
   }
 
   setMaxResultsPerPage(max: number) {

--- a/AMW_angular/io/src/app/apps/apps.routes.ts
+++ b/AMW_angular/io/src/app/apps/apps.routes.ts
@@ -1,3 +1,3 @@
 import { AppsComponent } from './apps.component';
 
-export const appsRoutes = [{ path: 'apps', component: AppsComponent }];
+export const appsRoutes = [{ path: 'apps', component: AppsComponent, title: 'Apps - Liima' }];

--- a/AMW_angular/io/src/app/apps/apps.service.ts
+++ b/AMW_angular/io/src/app/apps/apps.service.ts
@@ -38,15 +38,15 @@ export class AppsService extends BaseService {
     if (!releaseId) return of([]);
 
     let urlParams = '';
-    if (offset != null) {
+    if (offset !== null) {
       urlParams = `start=${offset}&`;
     }
 
-    if (limit != null) {
+    if (limit !== null) {
       urlParams += `limit=${limit}&`;
     }
 
-    if (filter != null) {
+    if (filter !== undefined && filter !== null && filter !== '') {
       urlParams += `appServerName=${filter}&`;
     }
 

--- a/AMW_angular/io/src/app/apps/apps.service.ts
+++ b/AMW_angular/io/src/app/apps/apps.service.ts
@@ -14,17 +14,14 @@ export class AppsService extends BaseService {
 
   private reload$ = new Subject<AppServer[]>();
 
-  offset = signal(0);
-  limit = signal(10);
   filter = signal<string>(null);
   releaseId: WritableSignal<number | undefined> = signal(undefined);
   private apps$: Observable<AppServer[]> = this.reload$.pipe(
+    switchMap(() => this.getApps(this.filter(), this.releaseId())),
     startWith(null),
-    switchMap(() => this.getApps(this.offset(), this.limit(), this.filter(), this.releaseId())),
     shareReplay(1),
   );
-  count = signal(0);
-  apps = toSignal(this.apps$, { initialValue: [] as AppServer[] });
+  apps = toSignal(this.apps$, { initialValue: null as AppServer[] });
 
   constructor() {
     super();
@@ -34,18 +31,10 @@ export class AppsService extends BaseService {
     this.reload$.next([]);
   }
 
-  private getApps(offset: number, limit: number, filter: string, releaseId: number | undefined) {
+  private getApps(filter: string, releaseId: number | undefined) {
     if (!releaseId) return of([]);
 
     let urlParams = '';
-    if (offset !== null) {
-      urlParams = `start=${offset}&`;
-    }
-
-    if (limit !== null) {
-      urlParams += `limit=${limit}&`;
-    }
-
     if (filter !== undefined && filter !== null && filter !== '') {
       urlParams += `appServerName=${filter}&`;
     }
@@ -58,11 +47,6 @@ export class AppsService extends BaseService {
       .pipe(catchError(this.handleError))
       .pipe(
         map((response: HttpResponse<AppServer[]>) => {
-          if (response.body.length <= 0) {
-            this.count.set(0);
-          } else {
-            this.count.set(Number(response.headers.get('x-total-count')));
-          }
           return response.body;
         }),
       );

--- a/AMW_angular/io/src/app/apps/apps.service.ts
+++ b/AMW_angular/io/src/app/apps/apps.service.ts
@@ -15,7 +15,7 @@ export class AppsService extends BaseService {
   private reload$ = new Subject<AppServer[]>();
 
   offset = signal(0);
-  limit = signal(20);
+  limit = signal(10);
   filter = signal<string>(null);
   releaseId: WritableSignal<number | undefined> = signal(undefined);
   private apps$: Observable<AppServer[]> = this.reload$.pipe(

--- a/AMW_angular/io/src/app/auditview/auditview.routes.ts
+++ b/AMW_angular/io/src/app/auditview/auditview.routes.ts
@@ -1,6 +1,6 @@
 import { AuditviewComponent } from './auditview.component';
 
 export const auditviewRoutes = [
-  { path: 'auditview', component: AuditviewComponent },
-  { path: 'auditview/:resourceId', component: AuditviewComponent },
+  { path: 'auditview', component: AuditviewComponent, title: 'Audit View - Liima' },
+  { path: 'auditview/:resourceId', component: AuditviewComponent, title: 'Audit View - Liima' },
 ];

--- a/AMW_angular/io/src/app/auditview/auditview.routes.ts
+++ b/AMW_angular/io/src/app/auditview/auditview.routes.ts
@@ -1,6 +1,7 @@
 import { AuditviewComponent } from './auditview.component';
 
+const AUDIT_VIEW_TITLE = 'Audit View - Liima';
 export const auditviewRoutes = [
-  { path: 'auditview', component: AuditviewComponent, title: 'Audit View - Liima' },
-  { path: 'auditview/:resourceId', component: AuditviewComponent, title: 'Audit View - Liima' },
+  { path: 'auditview', component: AuditviewComponent, title: AUDIT_VIEW_TITLE },
+  { path: 'auditview/:resourceId', component: AuditviewComponent, title: AUDIT_VIEW_TITLE },
 ];

--- a/AMW_angular/io/src/app/core/amw-constants.ts
+++ b/AMW_angular/io/src/app/core/amw-constants.ts
@@ -7,3 +7,4 @@ export const ENVIRONMENT = {
 // used for date-fns
 export const DATE_TIME_FORMAT = 'dd.MM.yyyy HH:mm';
 export const DATE_FORMAT = 'dd.MM.yyyy';
+export const ISO_FORMAT = 'yyyy-MM-dd';

--- a/AMW_angular/io/src/app/deployment/deployment-routes.ts
+++ b/AMW_angular/io/src/app/deployment/deployment-routes.ts
@@ -1,10 +1,11 @@
 import { DeploymentComponent } from './deployment.component';
 
 export const deploymentRoutes = [
-  { path: 'deployment', component: DeploymentComponent },
-  { path: 'deployment/:deploymentId', component: DeploymentComponent },
+  { path: 'deployment', component: DeploymentComponent, title: 'Deployment - Liima' },
+  { path: 'deployment/:deploymentId', component: DeploymentComponent, title: 'Deployment - Liima' },
   {
     path: 'deployment/:appserverName/:releaseName',
     component: DeploymentComponent,
+    title: 'Deployment - Liima',
   },
 ];

--- a/AMW_angular/io/src/app/deployment/deployment-routes.ts
+++ b/AMW_angular/io/src/app/deployment/deployment-routes.ts
@@ -1,11 +1,12 @@
 import { DeploymentComponent } from './deployment.component';
 
+const DEPLOYMENT_TITLE = 'Deployment - Liima';
 export const deploymentRoutes = [
-  { path: 'deployment', component: DeploymentComponent, title: 'Deployment - Liima' },
-  { path: 'deployment/:deploymentId', component: DeploymentComponent, title: 'Deployment - Liima' },
+  { path: 'deployment', component: DeploymentComponent, title: DEPLOYMENT_TITLE },
+  { path: 'deployment/:deploymentId', component: DeploymentComponent, title: DEPLOYMENT_TITLE },
   {
     path: 'deployment/:appserverName/:releaseName',
     component: DeploymentComponent,
-    title: 'Deployment - Liima',
+    title: DEPLOYMENT_TITLE,
   },
 ];

--- a/AMW_angular/io/src/app/deployment/deployment.component.html
+++ b/AMW_angular/io/src/app/deployment/deployment.component.html
@@ -10,14 +10,13 @@
       }
       <span class="form-horizontal">
         <h1 class="offset-2 mb-4">@if (isRedeployment) { Redeployment } @else { Create new deployment }</h1>
-        @if (appservers.length > 0) {
+        @if (appservers().length > 0) {
         <div class="form-group row">
           <label for="selectApplicationserver" class="col-sm-2 fw-bold text-end">Applicationserver</label>
           <div class="col-sm-10 col-md-5">
             <ng-select
-              daty-cy="app-server-select"
               id="selectApplicationserver"
-              [items]="appservers"
+              [items]="appservers()"
               bindLabel="name"
               placeholder=""
               [(ngModel)]="selectedAppserver"

--- a/AMW_angular/io/src/app/deployment/deployment.component.spec.ts
+++ b/AMW_angular/io/src/app/deployment/deployment.component.spec.ts
@@ -18,7 +18,7 @@ import { Environment } from './environment';
 import { EnvironmentService } from './environment.service';
 import { DateTimeModel } from '../shared/date-time-picker/date-time.model';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 
 @Component({
   template: '',
@@ -74,13 +74,6 @@ describe('DeploymentComponent (create deployment)', () => {
     expect(component.isReadyForDeployment()).toBeFalsy();
   });
 
-  it('should call resourceService on ngOnInit', () => {
-    spyOn(resourceService, 'getByType').and.returnValue(of([]));
-    expect(resourceService.getByType).not.toHaveBeenCalled();
-    component.ngOnInit();
-    expect(resourceService.getByType).toHaveBeenCalled();
-  });
-
   it('should call environmentService on ngOnInit', () => {
     spyOn(environmentService, 'getAll').and.returnValue(of([]));
     expect(environmentService.getAll).not.toHaveBeenCalled();
@@ -114,14 +107,7 @@ describe('DeploymentComponent (create deployment)', () => {
     ];
     component.appserverName = 'testServer';
     component.releaseName = 'testRelease';
-    spyOn(resourceService, 'getByType').and.returnValue(
-      of([
-        {
-          name: 'testServer',
-          releases: testReleases,
-        } as Resource,
-      ]),
-    );
+    component.appservers = signal([{ name: 'testServer', releases: testReleases } as Resource]);
     spyOn(resourceService, 'getDeployableReleases').and.returnValue(of(testReleases));
     // when
     component.initAppservers();
@@ -134,14 +120,7 @@ describe('DeploymentComponent (create deployment)', () => {
     const testReleases: Release[] = [{ id: 1, release: 'testRelease' } as Release];
     component.appserverName = 'testServer';
     component.releaseName = 'missingRelease';
-    spyOn(resourceService, 'getByType').and.returnValue(
-      of([
-        {
-          name: 'testServer',
-          releases: testReleases,
-        } as Resource,
-      ]),
-    );
+    component.appservers = signal([{ name: 'testServer', releases: testReleases } as Resource]);
     // when
     component.initAppservers();
     // then

--- a/AMW_angular/io/src/app/deployment/environment.ts
+++ b/AMW_angular/io/src/app/deployment/environment.ts
@@ -18,3 +18,20 @@ export interface EnvironmentTree {
   selected: boolean;
   disabled: boolean;
 }
+
+export class EnvironmentTreeUtils {
+  static searchById(tree: EnvironmentTree[], id: number): EnvironmentTree | undefined {
+    for (const node of tree) {
+      if (node.id === id) {
+        return node;
+      }
+      if (node.children && node.children.length > 0) {
+        const result = EnvironmentTreeUtils.searchById(node.children, id); // Recursive call
+        if (result) {
+          return result;
+        }
+      }
+    }
+    return undefined;
+  }
+}

--- a/AMW_angular/io/src/app/deployments/deployments.routes.ts
+++ b/AMW_angular/io/src/app/deployments/deployments.routes.ts
@@ -6,6 +6,7 @@ export const deploymentsRoutes = [
   {
     path: 'deployments',
     component: DeploymentContainerComponent,
+    title: 'Deployments - Liima',
     children: [
       { path: '', component: DeploymentsComponent },
       { path: ':deploymentId/logs', component: DeploymentLogsComponent },

--- a/AMW_angular/io/src/app/resource/resource-types.service.ts
+++ b/AMW_angular/io/src/app/resource/resource-types.service.ts
@@ -30,6 +30,10 @@ export class ResourceTypesService extends BaseService {
     return this.http.get<ResourceType[]>(`${this.getBaseUrl()}/resources/resourceTypes`);
   }
 
+  getResourceTypeByName(name: string): Observable<ResourceType> {
+    return this.http.get<ResourceType>(`${this.getBaseUrl()}/resources/resourceTypes/${name}`);
+  }
+
   getPredefinedResourceTypes(): Observable<ResourceType[]> {
     return this.http.get<ResourceType[]>(`${this.getBaseUrl()}/resources/predefinedResourceTypes`);
   }

--- a/AMW_angular/io/src/app/resource/resource.service.ts
+++ b/AMW_angular/io/src/app/resource/resource.service.ts
@@ -20,7 +20,9 @@ export class ResourceService extends BaseService {
   private resourceType$: Subject<ResourceType> = new Subject<ResourceType>();
 
   private resourceGroupListForType$: Observable<Resource[]> = this.resourceType$.pipe(
-    switchMap((resourceType: ResourceType) => this.getGroupsForType(resourceType)),
+    switchMap((resourceType: ResourceType) => {
+      return this.getGroupsForType(resourceType);
+    }),
     startWith(null),
     shareReplay(1),
   );

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
@@ -4,17 +4,17 @@
     <div class="card-header">
       <div class="d-flex justify-content-between align-items-center">
         <h2>
-        {{ resourceType().name }}
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&resTypId={{ resourceType().id }}">
-          <app-button [variant]="'link'"justify-content-start>
-            <app-icon icon="pencil"></app-icon>
+          {{ resourceType().name }}
+          <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&resTypId={{ resourceType().id }}">
+            <app-button [variant]="'link'" justify-content-start>
+              <app-icon icon="pencil"></app-icon>
+            </app-button>
+          </a>
+          @if (permissions().canDeleteResourceType && !resourceType().isDefaultResourceType) {
+          <app-button [variant]="'link'" [additionalClasses]="'link-danger'" (click)="deleteResourceType()">
+            <app-icon icon="trash"></app-icon>
           </app-button>
-        </a>
-        @if (permissions().canDeleteResourceType && !resourceType().isDefaultResourceType) {
-        <app-button [variant]="'link'" [additionalClasses]="'link-danger'" (click)="deleteResourceType()">
-          <app-icon icon="trash"></app-icon>
-        </app-button>
-        }
+          }
         </h2>
         @if (permissions().canCreateResource && !resourceType().isApplication) {
         <app-button [variant]="'primary'" (click)="addResource()" [additionalClasses]="'float-end'">
@@ -32,7 +32,8 @@
         [data]="resourceGroupListTableData()"
         [canDelete]="false"
         [canEdit]="permissions().canReadResources"
-        (edit)="openEditResourcePage($event.id)">
+        (edit)="openEditResourcePage($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
@@ -25,36 +25,15 @@
       </div>
     </div>
     <div class="card-body">
-      <table class="table table-sm table-striped">
-        <thead>
-          <tr>
-            <th scope="col" class="w-100">Resource name</th>
-            <th scope="col">Release</th>
-            <th scope="col">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          @for (resource of resourceGroupList(); track resource.id) {
-          <tr>
-            <td>{{ resource.name }}</td>
-            <td>{{ resource.defaultRelease ? resource.defaultRelease.release : '' }}</td>
-            <td class="align-items-center">
-              <a
-                href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{
-                  resource.defaultResourceId ? resource.defaultResourceId : resource.id
-                }}"
-              >
-                <app-button [variant]="'link'" [size]="'sm'"> <app-icon icon="pencil"></app-icon></app-button>
-              </a>
-            </td>
-          </tr>
-          } @empty {
-          <tr>
-            <td colspan="4" class="text-center">No resources defined</td>
-          </tr>
-          }
-        </tbody>
-      </table>
+      <app-table
+        [entityName]="'resources'"
+        [headers]="resourcesHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="resourceGroupListTableData()"
+        [canDelete]="false"
+        [canEdit]="permissions().canReadResources"
+        (edit)="openEditResourcePage($event.id)">
+      </app-table>
     </div>
   </div>
   }

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.html
@@ -1,51 +1,61 @@
 <div class="container">
   @if (resourceType() && permissions().canReadResources) {
-  <h1>
-    {{ resourceType().name }}
-    <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&resTypId={{ resourceType().id }}">
-      <app-button [variant]="'link'">
-        <app-icon icon="pencil"></app-icon>
-      </app-button>
-    </a>
-    @if (permissions().canDeleteResourceType && !resourceType().isDefaultResourceType) {
-    <app-button [variant]="'link'" [additionalClasses]="'link-danger'" (click)="deleteResourceType()">
-      <app-icon icon="trash"></app-icon>
-    </app-button>
-    }
-  </h1>
-  @if (permissions().canCreateResource && !resourceType().isApplication) {
-  <div class="row my-3">
-    <app-button [variant]="'primary'" (click)="addResource()">
-      <app-icon icon="plus-circle"></app-icon>
-      New Resource
-    </app-button>
+  <div class="card">
+    <div class="card-header">
+      <div class="d-flex justify-content-between align-items-center">
+        <h2>
+        {{ resourceType().name }}
+        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&resTypId={{ resourceType().id }}">
+          <app-button [variant]="'link'"justify-content-start>
+            <app-icon icon="pencil"></app-icon>
+          </app-button>
+        </a>
+        @if (permissions().canDeleteResourceType && !resourceType().isDefaultResourceType) {
+        <app-button [variant]="'link'" [additionalClasses]="'link-danger'" (click)="deleteResourceType()">
+          <app-icon icon="trash"></app-icon>
+        </app-button>
+        }
+        </h2>
+        @if (permissions().canCreateResource && !resourceType().isApplication) {
+        <app-button [variant]="'primary'" (click)="addResource()" [additionalClasses]="'float-end'">
+          <app-icon icon="plus-circle"></app-icon>
+          New Resource
+        </app-button>
+        }
+      </div>
+    </div>
+    <div class="card-body">
+      <table class="table table-sm table-striped">
+        <thead>
+          <tr>
+            <th scope="col" class="w-100">Resource name</th>
+            <th scope="col">Release</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (resource of resourceGroupList(); track resource.id) {
+          <tr>
+            <td>{{ resource.name }}</td>
+            <td>{{ resource.defaultRelease ? resource.defaultRelease.release : '' }}</td>
+            <td class="align-items-center">
+              <a
+                href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{
+                  resource.defaultResourceId ? resource.defaultResourceId : resource.id
+                }}"
+              >
+                <app-button [variant]="'link'" [size]="'sm'"> <app-icon icon="pencil"></app-icon></app-button>
+              </a>
+            </td>
+          </tr>
+          } @empty {
+          <tr>
+            <td colspan="4" class="text-center">No resources defined</td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
   </div>
-  }
-  <table class="table table-sm table-striped">
-    <thead>
-      <tr>
-        <th class="w-80">Resource name</th>
-        <th class="w-10">Release</th>
-        <th class="w-10" style="text-align: center">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (resource of resourceGroupList(); track resource.id) {
-      <tr>
-        <td class="w-80 align-middle">{{ resource.name }}</td>
-        <td class="w-10 align-middle">{{ resource.defaultRelease ? resource.defaultRelease.release : '' }}</td>
-        <td class="w-10 align-middle" style="text-align: center">
-          <a
-            href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{
-              resource.defaultResourceId ? resource.defaultResourceId : resource.id
-            }}"
-          >
-            <app-button [variant]="'primary'" [size]="'sm'"> <app-icon icon="pencil"></app-icon></app-button>
-          </a>
-        </td>
-      </tr>
-      }
-    </tbody>
-  </table>
   }
 </div>

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.scss
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.scss
@@ -1,6 +1,0 @@
-table .w-10 {
-  width: 10%;
-}
-table .w-80 {
-  width: 80%;
-}

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.ts
@@ -16,7 +16,6 @@ import { TableComponent, TableColumnType } from '../../shared/table/table.compon
   selector: 'app-resources-list',
   standalone: true,
   templateUrl: './resources-list.component.html',
-  styleUrl: './resources-list.component.scss',
   imports: [ButtonComponent, IconComponent, TableComponent],
 })
 export class ResourcesListComponent {
@@ -91,7 +90,7 @@ export class ResourcesListComponent {
   }
 
   openEditResourcePage(id: number) {
-    let resource = this.resourceGroupList().find((res) => res.id === id);
+    const resource = this.resourceGroupList().find((res) => res.id === id);
     const dynamicUrl = `/AMW_web/pages/editResourceView.xhtml?ctx=1&id=${
       resource.defaultResourceId ? resource.defaultResourceId : resource.id
     }`;

--- a/AMW_angular/io/src/app/resources/resources-list/resources-list.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-list/resources-list.component.ts
@@ -10,13 +10,14 @@ import { ResourceAddComponent } from '../resource-add/resource-add.component';
 import { Release } from '../../settings/releases/release';
 import { AuthService } from '../../auth/auth.service';
 import { ResourceTypeDeleteComponent } from '../resource-type-delete/resource-type-delete.component';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 @Component({
   selector: 'app-resources-list',
   standalone: true,
   templateUrl: './resources-list.component.html',
   styleUrl: './resources-list.component.scss',
-  imports: [ButtonComponent, IconComponent],
+  imports: [ButtonComponent, IconComponent, TableComponent],
 })
 export class ResourcesListComponent {
   private modalService = inject(NgbModal);
@@ -27,6 +28,16 @@ export class ResourcesListComponent {
   releases = input.required<Release[]>();
   resourceToAdd = output<any>();
   resourceTypeToDelete = output<ResourceType>();
+  resourceGroupListTableData = computed(
+    () =>
+      this.resourceGroupList()?.map((resource) => {
+        return {
+          id: resource.id,
+          name: resource.name,
+          defaultRelease: resource.defaultRelease.release,
+        };
+      }),
+  );
 
   permissions = computed(() => {
     if (this.authService.restrictions().length > 0) {
@@ -60,5 +71,30 @@ export class ResourcesListComponent {
     modalRef.componentInstance.resourceTypeToDelete
       .pipe(takeUntil(this.destroy$))
       .subscribe((resourceType: ResourceType) => this.resourceTypeToDelete.emit(resourceType));
+  }
+
+  resourcesHeader(): TableColumnType<{
+    id: number;
+    name: string;
+    defaultRelease: string;
+  }>[] {
+    return [
+      {
+        key: 'name',
+        columnTitle: 'Release name',
+      },
+      {
+        key: 'defaultRelease',
+        columnTitle: 'Release',
+      },
+    ];
+  }
+
+  openEditResourcePage(id: number) {
+    let resource = this.resourceGroupList().find((res) => res.id === id);
+    const dynamicUrl = `/AMW_web/pages/editResourceView.xhtml?ctx=1&id=${
+      resource.defaultResourceId ? resource.defaultResourceId : resource.id
+    }`;
+    window.location.href = dynamicUrl;
   }
 }

--- a/AMW_angular/io/src/app/resources/resources-page.component.html
+++ b/AMW_angular/io/src/app/resources/resources-page.component.html
@@ -36,15 +36,19 @@
               style="display: inline-block"
               (click)="toggleChildrenAndOrLoadResourcesList(resourceType)"
             >
-              @if (resourceType.hasChildren) { @if (isExpanded(resourceType)) {
-              <app-icon icon="dash"></app-icon>
-              } @else {
-              <app-icon icon="plus"></app-icon>
-              } }
+              @if (resourceType.hasChildren) {
+              <span style="margin-left: -1.3rem">
+                @if (isExpanded(resourceType)) {
+                <app-icon icon="dash"></app-icon>
+                } @else {
+                <app-icon icon="plus"></app-icon>
+                }
+              </span>
+              }
               {{ resourceType.name }}
             </a>
             @if (resourceType.hasChildren && isExpanded(resourceType) ) {
-            <ul class="nav flex-column ps-4">
+            <ul class="nav flex-column ps-3">
               @for (child of resourceType.children; track child.name) {
               <li class="nav-item">
                 <a

--- a/AMW_angular/io/src/app/resources/resources.route.ts
+++ b/AMW_angular/io/src/app/resources/resources.route.ts
@@ -1,3 +1,3 @@
 import { ResourcesPageComponent } from './resources-page.component';
 
-export const resourcesRoute = [{ path: 'resources', component: ResourcesPageComponent }];
+export const resourcesRoute = [{ path: 'resources', component: ResourcesPageComponent, title: 'Resources - Liima' }];

--- a/AMW_angular/io/src/app/servers/servers-filter/servers-filter.component.html
+++ b/AMW_angular/io/src/app/servers/servers-filter/servers-filter.component.html
@@ -2,14 +2,14 @@
   <div class="row g-2 mb-2">
     <div class="col-md-3">
       <label for="appServer" class="form-label">AppServer</label>
-      <input type="text" class="form-control" id="appServer" [ngbTypeahead]="search" [(ngModel)]="appServer"/>
+      <input type="text" class="form-control" id="appServer" [ngbTypeahead]="search" [(ngModel)]="appServer" />
     </div>
     <div class="col-md-3">
       <label class="form-label">Runtime</label>
       <select class="form-select" [(ngModel)]="selectedRuntimeName">
         <option [value]="'All'">All</option>
         @for (runtime of runtimes(); track runtime.id) {
-          <option [value]="runtime.name">{{ runtime.name }}</option>
+        <option [value]="runtime.name">{{ runtime.name }}</option>
         }
       </select>
     </div>
@@ -18,7 +18,7 @@
       <select class="form-select in" [(ngModel)]="selectedEnvironmentName">
         <option [value]="'All'">All</option>
         @for (env of environments(); track env.id) {
-          <option [value]="env.name">{{ env.name }}</option>
+        <option [value]="env.name">{{ env.name }}</option>
         }
       </select>
     </div>
@@ -26,11 +26,11 @@
   <div class="row g-4 mb-4">
     <div class="col-md-3">
       <label for="host" class="form-label">Host</label>
-      <input type="text" class="form-control" id="host" [(ngModel)]="host"/>
+      <input type="text" class="form-control" id="host" [(ngModel)]="host" />
     </div>
     <div class="col-md-3">
       <label for="node" class="form-label">Node</label>
-      <input type="text" class="form-control" id="node" [(ngModel)]="node"/>
+      <input type="text" class="form-control" id="node" [(ngModel)]="node" />
     </div>
     <div class="col-md-3 d-flex align-items-end">
       <app-button [variant]="'primary'" (click)="searchServerFilter()">Search</app-button>

--- a/AMW_angular/io/src/app/servers/servers-filter/servers-filter.component.html
+++ b/AMW_angular/io/src/app/servers/servers-filter/servers-filter.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="row g-4 mb-4">
+  <div class="row g-2 mb-2">
     <div class="col-md-3">
       <label for="appServer" class="form-label">AppServer</label>
       <input type="text" class="form-control" id="appServer" [ngbTypeahead]="search" [(ngModel)]="appServer"/>

--- a/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
+++ b/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
@@ -1,50 +1,5 @@
-<div class="table-responsive">
-  <table class="table table-sm table-borderless">
-    <thead class="table-light">
-      <tr>
-        <th>Host</th>
-        <th>Env</th>
-        <th>AppServer</th>
-        <th>AppServer Release</th>
-        <th>Runtime</th>
-        <th>Node</th>
-        <th>Node Release</th>
-      </tr>
-      </thead>
-    <tbody>
-    @for (server of servers(); track server; let even = $even) {
-    <tr [class.table-light]="!even">
-      <td>
-        <a href="{{ linkToHostUrl() }}={{ server.host }}">{{ server.host }}</a>
-      </td>
-      <td>{{ server.environment }}</td>
-      <td>
-        @if(canReadAppServer()) {
-        <a
-          href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.appServerId }}"
-        >{{ server.appServer }}</a
-        >
-        } @else {
-        {{ server.appServer }} }
-      </td>
-      <td>{{ server.appServerRelease }}</td>
-      <td>{{ server.runtime }}</td>
-      <td>
-        @if (canReadResources()) {
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.nodeId }}">{{
-          server.node
-          }}</a>
-        } @else {
-        {{ server.node }}
-        }
-      </td>
-      <td>{{ server.nodeRelease }}</td>
-    </tr>
-    } @empty {
-    <tr>
-      <td colspan="7" class="text-center">No results found</td>
-    </tr>
-    }
-    </tbody>
-  </table>
-</div>
+<app-table
+  [entityName]="'servers'"
+  [headers]="serversHeader()"
+  [data]="serversTableData()">
+</app-table>

--- a/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
+++ b/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
@@ -1,5 +1,1 @@
-<app-table
-  [entityName]="'servers'"
-  [headers]="serversHeader()"
-  [data]="serversTableData()">
-</app-table>
+<app-table [entityName]="'servers'" [headers]="serversHeader()" [data]="serversTableData()"> </app-table>

--- a/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
+++ b/AMW_angular/io/src/app/servers/servers-list/servers-list.component.html
@@ -1,0 +1,50 @@
+<div class="table-responsive">
+  <table class="table table-sm table-borderless">
+    <thead class="table-light">
+      <tr>
+        <th>Host</th>
+        <th>Env</th>
+        <th>AppServer</th>
+        <th>AppServer Release</th>
+        <th>Runtime</th>
+        <th>Node</th>
+        <th>Node Release</th>
+      </tr>
+      </thead>
+    <tbody>
+    @for (server of servers(); track server; let even = $even) {
+    <tr [class.table-light]="!even">
+      <td>
+        <a href="{{ linkToHostUrl() }}={{ server.host }}">{{ server.host }}</a>
+      </td>
+      <td>{{ server.environment }}</td>
+      <td>
+        @if(canReadAppServer()) {
+        <a
+          href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.appServerId }}"
+        >{{ server.appServer }}</a
+        >
+        } @else {
+        {{ server.appServer }} }
+      </td>
+      <td>{{ server.appServerRelease }}</td>
+      <td>{{ server.runtime }}</td>
+      <td>
+        @if (canReadResources()) {
+        <a href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.nodeId }}">{{
+          server.node
+          }}</a>
+        } @else {
+        {{ server.node }}
+        }
+      </td>
+      <td>{{ server.nodeRelease }}</td>
+    </tr>
+    } @empty {
+    <tr>
+      <td colspan="7" class="text-center">No results found</td>
+    </tr>
+    }
+    </tbody>
+  </table>
+</div>

--- a/AMW_angular/io/src/app/servers/servers-list/servers-list.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-list/servers-list.component.ts
@@ -7,54 +7,7 @@ import { Server } from '../server';
   standalone: true,
   imports: [AppsListComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `<div class="table-responsive">
-    @if (servers() && servers().length > 0) {
-    <table class="table table-sm table-borderless">
-      <thead class="table-light">
-        <tr>
-          <th>Host</th>
-          <th>Env</th>
-          <th>AppServer</th>
-          <th>AppServer Release</th>
-          <th>Runtime</th>
-          <th>Node</th>
-          <th>Node Release</th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (server of servers(); track server; let even = $even) {
-        <tr [class.table-light]="!even">
-          <td>
-            <a href="{{ linkToHostUrl() }}={{ server.host }}">{{ server.host }}</a>
-          </td>
-          <td>{{ server.environment }}</td>
-          <td>
-            @if(canReadAppServer()) {
-            <a
-              href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.appServerId }}"
-              >{{ server.appServer }}</a
-            >
-            } @else {
-            {{ server.appServer }} }
-          </td>
-          <td>{{ server.appServerRelease }}</td>
-          <td>{{ server.runtime }}</td>
-          <td>
-            @if (canReadResources()) {
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx={{ server.environmentId }}&id={{ server.nodeId }}">{{
-              server.node
-            }}</a>
-            } @else {
-            {{ server.node }}
-            }
-          </td>
-          <td>{{ server.nodeRelease }}</td>
-        </tr>
-        }
-      </tbody>
-    </table>
-    }
-  </div>`,
+  templateUrl: "./servers-list.component.html"
 })
 export class ServersListComponent {
   servers = input.required<Server[]>();

--- a/AMW_angular/io/src/app/servers/servers-list/servers-list.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-list/servers-list.component.ts
@@ -1,17 +1,89 @@
-import { ChangeDetectionStrategy, Component, inject, input, Signal } from '@angular/core';
-import { AppsListComponent } from '../../apps/apps-list/apps-list-component';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { Server } from '../server';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 @Component({
   selector: 'app-servers-list',
   standalone: true,
-  imports: [AppsListComponent],
+  imports: [TableComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  templateUrl: "./servers-list.component.html"
+  templateUrl: './servers-list.component.html',
 })
 export class ServersListComponent {
   servers = input.required<Server[]>();
   canReadAppServer = input.required<boolean>();
   canReadResources = input.required<boolean>();
   linkToHostUrl = input.required<string>();
+
+  serversTableData = computed(
+    () =>
+      this.servers()?.map((server) => {
+        return {
+          host: server.host,
+          hostLinkUrl: this.linkToHostUrl() + '=' + server.host,
+          environment: server.environment,
+          appServer: server.appServer,
+          appServerLinkUrl: this.canReadAppServer()
+            ? '/AMW_web/pages/editResourceView.xhtml?ctx=' + server.environmentId + '&id=' + server.appServerId
+            : null,
+          appServerRelease: server.appServerRelease,
+          runtime: server.runtime,
+          node: server.node,
+          nodeLinkUrl: this.canReadResources()
+            ? '/AMW_web/pages/editResourceView.xhtml?ctx=' + server.environmentId + '&id=' + server.nodeId
+            : null,
+          nodeRelease: server.nodeRelease,
+        };
+      }),
+  );
+
+  serversHeader(): TableColumnType<{
+    host: string;
+    hostLinkUrl: string;
+    appServer: string;
+    appServerLinkUrl: string;
+    appServerRelease: string;
+    runtime: string;
+    node: string;
+    nodeLinkUrl: string;
+    nodeRelease: string;
+    environment: string;
+  }>[] {
+    return [
+      {
+        key: 'host',
+        columnTitle: 'Host',
+        cellType: 'link',
+        urlKey: 'hostLinkUrl',
+      },
+      {
+        key: 'environment',
+        columnTitle: 'Env',
+      },
+      {
+        key: 'appServer',
+        columnTitle: 'AppServer',
+        cellType: 'link',
+        urlKey: 'appServerLinkUrl',
+      },
+      {
+        key: 'appServerRelease',
+        columnTitle: 'AppServer Release',
+      },
+      {
+        key: 'runtime',
+        columnTitle: 'Runtime',
+      },
+      {
+        key: 'node',
+        columnTitle: 'Node',
+        cellType: 'link',
+        urlKey: 'nodeLinkUrl',
+      },
+      {
+        key: 'nodeRelease',
+        columnTitle: 'Node Release',
+      },
+    ];
+  }
 }

--- a/AMW_angular/io/src/app/servers/servers-page-component.spec.ts
+++ b/AMW_angular/io/src/app/servers/servers-page-component.spec.ts
@@ -2,6 +2,7 @@ import { ServersPageComponent } from './servers-page.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { RouterModule } from '@angular/router';
 
 describe(ServersPageComponent.name, () => {
   let component: ServersPageComponent;
@@ -9,7 +10,7 @@ describe(ServersPageComponent.name, () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ServersPageComponent],
+      imports: [ServersPageComponent, RouterModule.forRoot([], { useHash: true })],
       providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
     }).compileComponents();
 

--- a/AMW_angular/io/src/app/servers/servers-page.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-page.component.ts
@@ -16,23 +16,29 @@ import { ServerFilter } from './servers-filter/server-filter';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [PageComponent, LoadingIndicatorComponent, ServersListComponent, ServersFilterComponent],
-  template: ` <app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
+  template: `<app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
     <app-page>
       <div class="page-title">Servers</div>
       <div class="page-content">
         <div class="container">
-          <app-servers-filter
-            [environments]="environments()"
-            [runtimes]="runtimes()"
-            [appServerSuggestions]="appServerSuggestions()"
-            (searchFilter)="searchFilter($event)"
-          />
-          <app-servers-list
-            [servers]="servers()"
-            [canReadAppServer]="permissions().canReadAppServer"
-            [canReadResources]="permissions().canReadResources"
-            [linkToHostUrl]="linkToHostUrl()"
-          />
+          <div class="card row mt-1 mb-1">
+            <div class="card-header">
+              <app-servers-filter
+                [environments]="environments()"
+                [runtimes]="runtimes()"
+                [appServerSuggestions]="appServerSuggestions()"
+                (searchFilter)="searchFilter($event)"
+              />
+            </div>
+            <div class="card-body">
+              <app-servers-list
+                [servers]="servers()"
+                [canReadAppServer]="permissions().canReadAppServer"
+                [canReadResources]="permissions().canReadResources"
+                [linkToHostUrl]="linkToHostUrl()"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </app-page>`,
@@ -59,7 +65,7 @@ export class ServersPageComponent {
     const config = this.configuration();
     const vmDetailUrl = pluck(ENVIRONMENT.AMW_VM_DETAILS_URL, config);
     const vmUrlParam = pluck(ENVIRONMENT.AMW_VM_URL_PARAM, config);
-    return `${vmDetailUrl}?${vmUrlParam}=`;
+    return `${vmDetailUrl}?${vmUrlParam}`;
   });
 
   permissions = computed(() => {

--- a/AMW_angular/io/src/app/servers/servers-page.component.ts
+++ b/AMW_angular/io/src/app/servers/servers-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, OnInit } from '@angular/core';
 import { PageComponent } from '../layout/page/page.component';
 import { LoadingIndicatorComponent } from '../shared/elements/loading-indicator.component';
 import { AuthService } from '../auth/auth.service';
@@ -10,6 +10,7 @@ import { Config, pluck } from '../shared/configuration';
 import { ServersFilterComponent } from './servers-filter/servers-filter.component';
 import { EnvironmentService } from '../deployment/environment.service';
 import { ServerFilter } from './servers-filter/server-filter';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-servers-page',
@@ -43,11 +44,13 @@ import { ServerFilter } from './servers-filter/server-filter';
       </div>
     </app-page>`,
 })
-export class ServersPageComponent {
+export class ServersPageComponent implements OnInit {
   private authService = inject(AuthService);
   private serversService = inject(ServersService);
   private environmentsService = inject(EnvironmentService);
   private configurationService = inject(ConfigurationService);
+  private router = inject(Router);
+  private route = inject(ActivatedRoute);
 
   isLoading: boolean = false;
 
@@ -59,6 +62,14 @@ export class ServersPageComponent {
     return this.serversService.servers();
   });
   configuration: Signal<Config[]> = this.configurationService.configuration;
+
+  ngOnInit() {
+    this.route.queryParams.subscribe((params: ServerFilter) => {
+      if (params) {
+        this.serversService.setServerFilter(params);
+      }
+    });
+  }
 
   linkToHostUrl = computed(() => {
     if (!this.configuration()) return;
@@ -84,6 +95,7 @@ export class ServersPageComponent {
 
   searchFilter($event: ServerFilter) {
     this.isLoading = true;
+    this.router.navigate(['/servers'], { queryParams: $event });
     this.serversService.setServerFilter($event);
   }
 }

--- a/AMW_angular/io/src/app/servers/servers.route.ts
+++ b/AMW_angular/io/src/app/servers/servers.route.ts
@@ -1,3 +1,3 @@
 import { ServersPageComponent } from './servers-page.component';
 
-export const serversRoute = [{ path: 'servers', component: ServersPageComponent }];
+export const serversRoute = [{ path: 'servers', component: ServersPageComponent, title: 'Servers - Liima' }];

--- a/AMW_angular/io/src/app/settings/application-info/application-info.component.html
+++ b/AMW_angular/io/src/app/settings/application-info/application-info.component.html
@@ -1,7 +1,6 @@
 <app-loading-indicator [isLoading]="isLoading()"></app-loading-indicator>
 
 <div class="container">
-  <h1>Application Information</h1>
   <div class="card row mt-2 mb-3">
     <div class="card-header"><b>Application Information</b></div>
     <div class="card-body">

--- a/AMW_angular/io/src/app/settings/application-info/application-info.component.html
+++ b/AMW_angular/io/src/app/settings/application-info/application-info.component.html
@@ -5,11 +5,8 @@
     <div class="card-header"><b>Application Information</b></div>
     <div class="card-body">
       @if (appVersions().length > 0) {
-        <app-table
-          [entityName]="'application information'"
-          [headers]="appVersionsHeader()"
-          [data]="appVersions()">
-        </app-table>
+      <app-table [entityName]="'application information'" [headers]="appVersionsHeader()" [data]="appVersions()">
+      </app-table>
       }
     </div>
   </div>
@@ -19,11 +16,12 @@
     <div class="card-header"><b>Application Configuration</b></div>
     <div class="card-body">
       @if (appConfigs().length > 0) {
-        <app-table
-          [entityName]="'application configuration'"
-          [headers]="appConfigsHeader()"
-          [data]="appConfigsTableData()">
-        </app-table>
+      <app-table
+        [entityName]="'application configuration'"
+        [headers]="appConfigsHeader()"
+        [data]="appConfigsTableData()"
+      >
+      </app-table>
       }
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/application-info/application-info.component.html
+++ b/AMW_angular/io/src/app/settings/application-info/application-info.component.html
@@ -4,27 +4,13 @@
   <div class="card row mt-2 mb-3">
     <div class="card-header"><b>Application Information</b></div>
     <div class="card-body">
-      <div class="table-responsive">
-        @if (appVersions().length > 0) {
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            @for (item of appVersions(); track item.key) {
-            <tr>
-              <td>{{ item.key }}</td>
-              <td>{{ item.value }}</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-        }
-      </div>
+      @if (appVersions().length > 0) {
+        <app-table
+          [entityName]="'application information'"
+          [headers]="appVersionsHeader()"
+          [data]="appVersions()">
+        </app-table>
+      }
     </div>
   </div>
 </div>
@@ -32,31 +18,13 @@
   <div class="card row">
     <div class="card-header"><b>Application Configuration</b></div>
     <div class="card-body">
-      <div class="table-responsive">
-        @if (appConfigs().length > 0) {
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th>Key</th>
-              <th>ENV</th>
-              <th>Value</th>
-              <th>DefaultValue</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            @for (item of appConfigs(); track item.key.value) {
-            <tr>
-              <td>{{ item.key.value }}</td>
-              <td>{{ item.key.env }}</td>
-              <td>{{ item.value }}</td>
-              <td>{{ item.defaultValue }}</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-        }
-      </div>
+      @if (appConfigs().length > 0) {
+        <app-table
+          [entityName]="'application configuration'"
+          [headers]="appConfigsHeader()"
+          [data]="appConfigsTableData()">
+        </app-table>
+      }
     </div>
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/application-info/application-info.component.ts
+++ b/AMW_angular/io/src/app/settings/application-info/application-info.component.ts
@@ -1,20 +1,71 @@
 import { Component, computed, inject } from '@angular/core';
 import { LoadingIndicatorComponent } from '../../shared/elements/loading-indicator.component';
-import { AsyncPipe } from '@angular/common';
 import { SettingService } from '../../setting/setting.service';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AppInformation } from '../../setting/app-information';
 import { AppConfiguration } from '../../setting/app-configuration';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 @Component({
   selector: 'app-application-info',
   standalone: true,
-  imports: [LoadingIndicatorComponent, AsyncPipe],
+  imports: [LoadingIndicatorComponent, TableComponent],
   templateUrl: './application-info.component.html',
 })
 export class ApplicationInfoComponent {
   private settingService = inject(SettingService);
   appVersions = toSignal(this.settingService.getAppInformation(), { initialValue: [] as AppInformation[] });
   appConfigs = toSignal(this.settingService.getAllAppSettings(), { initialValue: [] as AppConfiguration[] });
+
+  appConfigsTableData = computed(() =>
+    this.appConfigs().map((config) => {
+      return {
+        keyValue: config.key.value,
+        keyEnv: config.key.env,
+        value: config.value,
+        defaultValue: config.defaultValue,
+      };
+    }),
+  );
+
   isLoading = computed(() => !this.appVersions().length || !this.appConfigs().length);
+
+  appVersionsHeader(): TableColumnType<AppInformation>[] {
+    return [
+      {
+        key: 'key',
+        columnTitle: 'Key',
+      },
+      {
+        key: 'value',
+        columnTitle: 'Value',
+      },
+    ];
+  }
+
+  appConfigsHeader(): TableColumnType<{
+    keyValue: string;
+    keyEnv: string;
+    value: string;
+    defaultValue: string;
+  }>[] {
+    return [
+      {
+        key: 'keyValue',
+        columnTitle: 'Key',
+      },
+      {
+        key: 'keyEnv',
+        columnTitle: 'ENV',
+      },
+      {
+        key: 'value',
+        columnTitle: 'Value',
+      },
+      {
+        key: 'defaultValue',
+        columnTitle: 'Default value',
+      },
+    ];
+  }
 }

--- a/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
+++ b/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
@@ -16,34 +16,14 @@
       </div>
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th class="text-end">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (paramKey of paramKeys; track paramKey) {
-            <tr>
-              <td class="align-middle">{{ paramKey.name }}</td>
-              <td class="text-end">
-                @if (canDelete()) {
-                <app-button [variant]="'link'" [size]="'sm'" [additionalClasses]="'me-0 link-danger'" (click)="deleteKey(paramKey.id)"
-                  ><app-icon icon="trash"></app-icon
-                ></app-button>
-                }
-              </td>
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="2" class="text-center">No deployment parameters defined</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'deployment parameters'"
+        [headers]="deploymentParameterHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="paramKeys"
+        [canDelete]="canDelete()"
+        (delete)="deleteKey($event.id)">
+      </app-table>
     </div>
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
+++ b/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
@@ -5,12 +5,12 @@
         <div class="col-sm"></div>
         @if (canCreate()) {
         <div class="col-sm-3">
-            <input id="keyName" type="text" class="form-control" [(ngModel)]="keyName" (keyup.enter)="addKey()" />
+          <input id="keyName" type="text" class="form-control" [(ngModel)]="keyName" (keyup.enter)="addKey()" />
         </div>
         <div class="col-md-auto">
           <app-button [variant]="'primary'" (click)="addKey()"
-              ><app-icon icon="plus-circle"></app-icon> Add key</app-button
-            >
+            ><app-icon icon="plus-circle"></app-icon> Add key</app-button
+          >
         </div>
         }
       </div>
@@ -22,7 +22,8 @@
         [dataCyNameKey]="'name'"
         [data]="paramKeys"
         [canDelete]="canDelete()"
-        (delete)="deleteKey($event.id)">
+        (delete)="deleteKey($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
+++ b/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.html
@@ -1,38 +1,49 @@
 <div class="container">
-  <h1>Deployment Parameter Keys</h1>
-  <div class="row mt-2 py-4">
-    <div class="col-6 ms-auto">
-      <div class="input-group">
+  <div class="card row mt-2 mb-3">
+    <div class="card-header">
+      <div class="row justify-content-between align-items-center">
+        <div class="col-sm"></div>
         @if (canCreate()) {
-        <input id="keyName" type="text" class="form-control" [(ngModel)]="keyName" (keyup.enter)="addKey()" />
-        <app-button [variant]="'primary'" (click)="addKey()"
-          ><app-icon icon="plus-circle"></app-icon> Add key</app-button
-        >
+        <div class="col-sm-3">
+            <input id="keyName" type="text" class="form-control" [(ngModel)]="keyName" (keyup.enter)="addKey()" />
+        </div>
+        <div class="col-md-auto">
+          <app-button [variant]="'primary'" (click)="addKey()"
+              ><app-icon icon="plus-circle"></app-icon> Add key</app-button
+            >
+        </div>
         }
       </div>
     </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-sm table-striped">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th class="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (paramKey of paramKeys; track paramKey) {
+            <tr>
+              <td class="align-middle">{{ paramKey.name }}</td>
+              <td class="text-end">
+                @if (canDelete()) {
+                <app-button [variant]="'link'" [size]="'sm'" [additionalClasses]="'me-0 link-danger'" (click)="deleteKey(paramKey.id)"
+                  ><app-icon icon="trash"></app-icon
+                ></app-button>
+                }
+              </td>
+            </tr>
+            } @empty {
+            <tr>
+              <td colspan="2" class="text-center">No deployment parameters defined</td>
+            </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
-
-  <table class="table table-sm table-striped table-bordered">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Delete</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (paramKey of paramKeys; track paramKey) {
-      <tr>
-        <td class="align-middle">{{ paramKey.name }}</td>
-        <td>
-          @if (canDelete()) {
-          <app-button [variant]="'danger'" [size]="'sm'" [additionalClasses]="'me-0'" (click)="deleteKey(paramKey.id)"
-            ><app-icon icon="trash"></app-icon
-          ></app-button>
-          }
-        </td>
-      </tr>
-      }
-    </tbody>
-  </table>
 </div>

--- a/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.ts
+++ b/AMW_angular/io/src/app/settings/deployment-parameter/deployment-parameter.component.ts
@@ -7,13 +7,14 @@ import { AuthService, isAllowed } from '../../auth/auth.service';
 import { Subject } from 'rxjs';
 import { ToastService } from '../../shared/elements/toast/toast.service';
 import { ButtonComponent } from '../../shared/button/button.component';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 type Key = { id: number; name: string };
 
 @Component({
   selector: 'app-deployment-parameter',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, FormsModule, IconComponent, ButtonComponent],
+  imports: [CommonModule, ReactiveFormsModule, FormsModule, IconComponent, ButtonComponent, TableComponent],
   templateUrl: './deployment-parameter.component.html',
   styleUrl: './deployment-parameter.component.scss',
 })
@@ -67,5 +68,14 @@ export class DeploymentParameterComponent implements OnInit, OnDestroy {
       this.paramKeys = this.paramKeys.filter((key) => key.id !== keyId);
       this.toastService.success('Key deleted.');
     });
+  }
+
+  deploymentParameterHeader(): TableColumnType<Key>[] {
+    return [
+      {
+        key: 'name',
+        columnTitle: 'Name',
+      },
+    ];
   }
 }

--- a/AMW_angular/io/src/app/settings/environments/environment-edit/environment-edit.component.html
+++ b/AMW_angular/io/src/app/settings/environments/environment-edit/environment-edit.component.html
@@ -3,25 +3,20 @@
   <div class="modal-body">
     <div class="needs-validation mb-3">
       <label for="name" class="form-label">Name</label>
-      <input type="text" class="form-control" id="name" [(ngModel)]="environment.name" required pattern=".*\S+.*">
-      <div class="invalid-feedback">
-        Please enter a name
-      </div>
+      <input type="text" class="form-control" id="name" [(ngModel)]="environment.name" required pattern=".*\S+.*" />
+      <div class="invalid-feedback">Please enter a name</div>
     </div>
     @if (!isDomain()) {
-      <div class="mb-3">
-        <label for="nameAlias" class="form-label">Alias</label>
-        <input type="text" class="form-control" id="nameAlias" [(ngModel)]="environment.nameAlias"/>
-      </div>
+    <div class="mb-3">
+      <label for="nameAlias" class="form-label">Alias</label>
+      <input type="text" class="form-control" id="nameAlias" [(ngModel)]="environment.nameAlias" />
+    </div>
     }
   </div>
   <div class="modal-footer">
     <app-button [variant]="'light'" (click)="cancel()">Cancel</app-button>
     @if (permissions().canSave) {
-      <app-button [variant]="'primary'"
-                  [disabled]="!isValidForm()"
-                  (click)="save()">Save
-      </app-button>
+    <app-button [variant]="'primary'" [disabled]="!isValidForm()" (click)="save()">Save </app-button>
     }
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/environments/environments-page.component.html
+++ b/AMW_angular/io/src/app/settings/environments/environments-page.component.html
@@ -9,20 +9,20 @@
     >
   }
   @for (domain of environmentTree(); track domain.id) {
-  <div class="card">
+  <div class="card mb-5">
     <div class="card-header">
       <div class="d-flex justify-content-between align-items-center">
         <h3>{{ domain.name }}
           @if (permissions().canEdit) {
             <app-button [variant]="'link'"
-                        (click)="editContext(domain)">
+                        (click)="editContext(domain.id)">
               <app-icon icon="pencil"></app-icon>
             </app-button>
           }
           @if (permissions().canDelete) {
             <app-button [variant]="'link'"
                         [additionalClasses]="'link-danger'"
-                        (click)="deleteContext(domain)">
+                        (click)="deleteContext(domain.id)">
               <app-icon icon="trash"></app-icon>
             </app-button>
           }
@@ -40,46 +40,16 @@
       </div>
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th scope="col" class="w-25">Environment name</th>
-              <th scope="col" class="w-100">Environment alias</th>
-              <th scope="col" class="text-center">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (env of domain.children; track env.id) {
-            <tr>
-              <td>{{ env.name }}</td>
-              <td>{{ env.nameAlias ? env.nameAlias : '-' }}</td>
-              <td class="text-nowrap text-center">
-                @if (permissions().canEdit) {
-                  <app-button [variant]="'link'"
-                              [size]="'sm'"
-                              (click)="editContext(env)">
-                    <app-icon icon="pencil"></app-icon>
-                  </app-button>
-                }
-                @if (permissions().canDelete) {
-                  <app-button [variant]="'link'"
-                              [size]="'sm'"
-                              [additionalClasses]="'link-danger'"
-                              (click)="deleteContext(env)">
-                    <app-icon icon="trash"></app-icon>
-                  </app-button>
-                }
-              </td>
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="3" class="text-center">No environments added yet</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'environments'"
+        [headers]="environmentHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="domain.children"
+        [canDelete]="permissions().canDelete"
+        [canEdit]="permissions().canEdit"
+        (edit)="editContext($event.id)"
+        (delete)="deleteContext($event.id)">
+      </app-table>
     </div>
   </div>
   }

--- a/AMW_angular/io/src/app/settings/environments/environments-page.component.html
+++ b/AMW_angular/io/src/app/settings/environments/environments-page.component.html
@@ -1,41 +1,35 @@
 <div class="container">
   @if (permissions().canAdd) {
-    <app-button [variant]="'primary'"
-                [additionalClasses]="'mt-3 mb-4'"
-                (click)="addDomain()">
-      <app-icon icon="plus-circle"></app-icon>
-      Add Domain
-    </app-button
-    >
-  }
-  @for (domain of environmentTree(); track domain.id) {
+  <app-button [variant]="'primary'" [additionalClasses]="'mt-3 mb-4'" (click)="addDomain()">
+    <app-icon icon="plus-circle"></app-icon>
+    Add Domain
+  </app-button>
+  } @for (domain of environmentTree(); track domain.id) {
   <div class="card mb-5">
     <div class="card-header">
       <div class="d-flex justify-content-between align-items-center">
-        <h3>{{ domain.name }}
+        <h3>
+          {{ domain.name }}
           @if (permissions().canEdit) {
-            <app-button [variant]="'link'"
-                        (click)="editContext(domain.id)">
-              <app-icon icon="pencil"></app-icon>
-            </app-button>
-          }
-          @if (permissions().canDelete) {
-            <app-button [variant]="'link'"
-                        [additionalClasses]="'link-danger'"
-                        (click)="deleteContext(domain.id)">
-              <app-icon icon="trash"></app-icon>
-            </app-button>
+          <app-button [variant]="'link'" (click)="editContext(domain.id)">
+            <app-icon icon="pencil"></app-icon>
+          </app-button>
+          } @if (permissions().canDelete) {
+          <app-button [variant]="'link'" [additionalClasses]="'link-danger'" (click)="deleteContext(domain.id)">
+            <app-icon icon="trash"></app-icon>
+          </app-button>
           }
         </h3>
         @if (permissions().canAdd) {
-        <app-button style="padding: 0;"
-                    [variant]="'primary'"
-                    [additionalClasses]="'float-end'"
-                    (click)="addEnvironment(domain)">
+        <app-button
+          style="padding: 0"
+          [variant]="'primary'"
+          [additionalClasses]="'float-end'"
+          (click)="addEnvironment(domain)"
+        >
           <app-icon icon="plus-circle"></app-icon>
           Add Environment
-        </app-button
-        >
+        </app-button>
         }
       </div>
     </div>
@@ -48,7 +42,8 @@
         [canDelete]="permissions().canDelete"
         [canEdit]="permissions().canEdit"
         (edit)="editContext($event.id)"
-        (delete)="deleteContext($event.id)">
+        (delete)="deleteContext($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/environments/environments-page.component.html
+++ b/AMW_angular/io/src/app/settings/environments/environments-page.component.html
@@ -1,5 +1,4 @@
 <div class="container">
-  <h1>Environments</h1>
   @if (permissions().canAdd) {
     <app-button [variant]="'primary'"
                 [additionalClasses]="'mt-3 mb-4'"
@@ -10,53 +9,62 @@
     >
   }
   @for (domain of environmentTree(); track domain.id) {
-    <div class="row">
-      <div class="col">
-        <h3>{{ domain.name }}</h3>
-      </div>
-      <div class="col">
-        @if (permissions().canDelete) {
-          <app-button [variant]="'danger'"
-                      [isOutlined]="true"
-                      [additionalClasses]="'float-end'"
-                      (click)="deleteContext(domain)">
-            <app-icon icon="trash"></app-icon>
-            Delete domain
-          </app-button>
+  <div class="card">
+    <div class="card-header">
+      <div class="d-flex justify-content-between align-items-center">
+        <h3>{{ domain.name }}
+          @if (permissions().canEdit) {
+            <app-button [variant]="'link'"
+                        (click)="editContext(domain)">
+              <app-icon icon="pencil"></app-icon>
+            </app-button>
+          }
+          @if (permissions().canDelete) {
+            <app-button [variant]="'link'"
+                        [additionalClasses]="'link-danger'"
+                        (click)="deleteContext(domain)">
+              <app-icon icon="trash"></app-icon>
+            </app-button>
+          }
+        </h3>
+        @if (permissions().canAdd) {
+        <app-button style="padding: 0;"
+                    [variant]="'primary'"
+                    [additionalClasses]="'float-end'"
+                    (click)="addEnvironment(domain)">
+          <app-icon icon="plus-circle"></app-icon>
+          Add Environment
+        </app-button
+        >
         }
-        @if (permissions().canEdit) {
-          <app-button [variant]="'primary'"
-                      [isOutlined]="true"
-                      [additionalClasses]="'float-end'"
-                      (click)="editContext(domain)">
-            <app-icon icon="pencil"></app-icon>
-            Edit domain
-          </app-button>
-        }
       </div>
-      @if (domain.children.length > 0) {
-        <table class="table table-group-divider mb-3">
+    </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-sm table-striped">
           <thead>
-          <tr>
-            <th scope="col">Environment name</th>
-            <th scope="col">Environment alias</th>
-            <th class="text-end" scope="col">Actions</th>
-          </tr>
-          </thead>
-          @for (env of domain.children; track env.id) {
-            <tbody>
             <tr>
-              <th>{{ env.name }}</th>
+              <th scope="col" class="w-25">Environment name</th>
+              <th scope="col" class="w-100">Environment alias</th>
+              <th scope="col" class="text-center">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (env of domain.children; track env.id) {
+            <tr>
+              <td>{{ env.name }}</td>
               <td>{{ env.nameAlias ? env.nameAlias : '-' }}</td>
-              <td class="text-end mb-5">
+              <td class="text-nowrap text-center">
                 @if (permissions().canEdit) {
                   <app-button [variant]="'link'"
+                              [size]="'sm'"
                               (click)="editContext(env)">
                     <app-icon icon="pencil"></app-icon>
                   </app-button>
                 }
                 @if (permissions().canDelete) {
                   <app-button [variant]="'link'"
+                              [size]="'sm'"
                               [additionalClasses]="'link-danger'"
                               (click)="deleteContext(env)">
                     <app-icon icon="trash"></app-icon>
@@ -64,33 +72,15 @@
                 }
               </td>
             </tr>
-            </tbody>
-          }
+            } @empty {
+            <tr>
+              <td colspan="3" class="text-center">No environments added yet</td>
+            </tr>
+            }
+          </tbody>
         </table>
-        @if (permissions().canAdd) {
-          <app-button style="padding: 0;"
-                      [variant]="'primary'"
-                      [additionalClasses]="'mb-5'"
-                      (click)="addEnvironment(domain)">
-            <app-icon icon="plus-circle"></app-icon>
-            Add Environment
-          </app-button
-          >
-        }
-      } @else {
-        <div class="table-group-divider p-0">
-          <p class="p-2 mb-3">No environments added yet.</p>
-          @if (permissions().canAdd) {
-            <app-button [variant]="'primary'"
-                        [additionalClasses]="'mb-5'"
-                        (click)="addEnvironment(domain)">
-              <app-icon icon="plus-circle"></app-icon>
-              Add Environment
-            </app-button
-            >
-          }
-        </div>
-      }
+      </div>
     </div>
+  </div>
   }
 </div>

--- a/AMW_angular/io/src/app/settings/functions/function-edit.component.html
+++ b/AMW_angular/io/src/app/settings/functions/function-edit.component.html
@@ -1,9 +1,12 @@
 <app-modal-header [title]="getTitle()" (cancel)="cancel()"></app-modal-header>
 <div class="modal-body">
   <div class="form-horizontal mx-2">
-    <div class="mb-3">
+    <div class="needs-validation mb-3">
       <label for="name" class="form-label align-self-center">Function name</label>
-      <input type="text" class="form-control" id="name" [(ngModel)]="function.name" />
+      <input type="text" class="form-control" id="name" [(ngModel)]="function.name" required pattern=".*\S+.*"/>
+      <div class="invalid-feedback">
+        Please enter a function name
+      </div>
     </div>
 
     <div class="mb-3">
@@ -78,7 +81,7 @@
   >
     <app-button
       [variant]="'primary'"
-      [disabled]="function.name.length === 0 || function.content.length === 0"
+      [disabled]="hasInvalidFields()"
       [dataCy]="'button-save'"
       (click)="save()"
       >Save changes

--- a/AMW_angular/io/src/app/settings/functions/function-edit.component.html
+++ b/AMW_angular/io/src/app/settings/functions/function-edit.component.html
@@ -3,10 +3,8 @@
   <div class="form-horizontal mx-2">
     <div class="needs-validation mb-3">
       <label for="name" class="form-label align-self-center">Function name</label>
-      <input type="text" class="form-control" id="name" [(ngModel)]="function.name" required pattern=".*\S+.*"/>
-      <div class="invalid-feedback">
-        Please enter a function name
-      </div>
+      <input type="text" class="form-control" id="name" [(ngModel)]="function.name" required pattern=".*\S+.*" />
+      <div class="invalid-feedback">Please enter a function name</div>
     </div>
 
     <div class="mb-3">
@@ -79,11 +77,7 @@
     data-toggle="tooltip"
     [title]="!function.name || !function.content ? 'Please provide function name and content' : ''"
   >
-    <app-button
-      [variant]="'primary'"
-      [disabled]="hasInvalidFields()"
-      [dataCy]="'button-save'"
-      (click)="save()"
+    <app-button [variant]="'primary'" [disabled]="hasInvalidFields()" [dataCy]="'button-save'" (click)="save()"
       >Save changes
     </app-button>
   </span>

--- a/AMW_angular/io/src/app/settings/functions/function-edit.component.ts
+++ b/AMW_angular/io/src/app/settings/functions/function-edit.component.ts
@@ -62,7 +62,15 @@ export class FunctionEditComponent implements OnInit {
     this.functionsService.refreshData();
   }
 
+  hasInvalidFields(): boolean {
+    return this.function.name.length === 0 || this.function.content.length === 0;
+  }
+
   save() {
+    if (this.hasInvalidFields()) {
+      document.querySelectorAll('.needs-validation')[0].classList.add('was-validated');
+      return;
+    }
     if (this.revision) this.function.content = this.diffValue.original;
     this.saveFunction.emit(this.function);
     this.activeModal.close();

--- a/AMW_angular/io/src/app/settings/functions/functions.component.html
+++ b/AMW_angular/io/src/app/settings/functions/functions.component.html
@@ -1,40 +1,33 @@
 <div class="container">
-  <h1>Functions</h1>
-  <div class="card row mt-2 mb-3">
+  <div class="card">
     <div class="card-header">
-      <div class="row justify-content-between align-items-center">
-        <div class="col-sm"></div>
-        <div class="col-sm">
-          @if (permissions().canManage) {
-          <app-button
-            [variant]="'primary'"
-            [additionalClasses]="'float-end'"
-            [dataCy]="'button-add'"
-            (click)="addFunction()"
-            ><app-icon icon="plus-circle"></app-icon> Add function</app-button
-          >
-          }
-        </div>
-      </div>
+      @if (permissions().canManage) {
+      <app-button
+        [variant]="'primary'"
+        [additionalClasses]="'float-end'"
+        [dataCy]="'button-add'"
+        (click)="addFunction()"
+        ><app-icon icon="plus-circle"></app-icon> Add function</app-button
+      >
+      }
     </div>
     <div class="card-body">
       <div class="table-responsive">
         <table class="table table-sm table-striped">
           <thead>
             <tr>
-              <th>Function Name</th>
-              <th class="text-center">Edit</th>
-              <th class="text-center">Delete</th>
+              <th scope="col" class="w-100">Function Name</th>
+              <th scope="col" class="text-center">Actions</th>
             </tr>
           </thead>
           <tbody>
             @for (function of functions(); track function; let idx = $index) {
             <tr>
               <td class="align-middle">{{ function.name }}</td>
-              <td class="text-center">
+              <td class="text-nowrap text-center">
                 @if (permissions().canView) {
                 <app-button
-                  [variant]="'primary'"
+                  [variant]="'link'"
                   [size]="'sm'"
                   [dataCy]="'button-edit'"
                   [additionalClasses]="'me-0'"
@@ -43,19 +36,21 @@
                   <app-icon icon="pencil"></app-icon
                 ></app-button>
                 }
-              </td>
-              <td class="text-center">
                 @if (permissions().canManage) {
                 <app-button
-                  [variant]="'danger'"
+                  [variant]="'link'"
                   [size]="'sm'"
-                  [additionalClasses]="'me-0'"
+                  [additionalClasses]="'me-0 link-danger'"
                   [dataCy]="'icon-delete'"
                   (click)="deleteFunction(function)"
                   ><app-icon icon="trash"></app-icon
                 ></app-button>
                 }
               </td>
+            </tr>
+            } @empty {
+            <tr>
+              <td colspan="2" class="text-center">No functions defined</td>
             </tr>
             }
           </tbody>

--- a/AMW_angular/io/src/app/settings/functions/functions.component.html
+++ b/AMW_angular/io/src/app/settings/functions/functions.component.html
@@ -12,50 +12,16 @@
       }
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th scope="col" class="w-100">Function Name</th>
-              <th scope="col" class="text-center">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (function of functions(); track function; let idx = $index) {
-            <tr>
-              <td class="align-middle">{{ function.name }}</td>
-              <td class="text-nowrap text-center">
-                @if (permissions().canView) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [dataCy]="'button-edit'"
-                  [additionalClasses]="'me-0'"
-                  (click)="editFunction(function)"
-                >
-                  <app-icon icon="pencil"></app-icon
-                ></app-button>
-                }
-                @if (permissions().canManage) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [additionalClasses]="'me-0 link-danger'"
-                  [dataCy]="'icon-delete'"
-                  (click)="deleteFunction(function)"
-                  ><app-icon icon="trash"></app-icon
-                ></app-button>
-                }
-              </td>
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="2" class="text-center">No functions defined</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'functions'"
+        [headers]="functionsTableHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="functions()"
+        [canDelete]="permissions().canManage"
+        [canEdit]="permissions().canView"
+        (edit)="editFunction($event.id)"
+        (delete)="deleteFunction($event.id)">
+      </app-table>
     </div>
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/functions/functions.component.html
+++ b/AMW_angular/io/src/app/settings/functions/functions.component.html
@@ -20,7 +20,8 @@
         [canDelete]="permissions().canManage"
         [canEdit]="permissions().canView"
         (edit)="editFunction($event.id)"
-        (delete)="deleteFunction($event.id)">
+        (delete)="deleteFunction($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/functions/functions.component.ts
+++ b/AMW_angular/io/src/app/settings/functions/functions.component.ts
@@ -1,9 +1,6 @@
 import { Component, inject, Signal, computed, OnDestroy } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { LoadingIndicatorComponent } from '../../shared/elements/loading-indicator.component';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { IconComponent } from '../../shared/icon/icon.component';
-import { PaginationComponent } from '../../shared/pagination/pagination.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AuthService } from '../../auth/auth.service';
 import { takeUntil } from 'rxjs/operators';
@@ -13,19 +10,12 @@ import { FunctionsService } from './functions.service';
 import { FunctionEditComponent } from './function-edit.component';
 import { FunctionDeleteComponent } from './function-delete.component';
 import { ButtonComponent } from '../../shared/button/button.component';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 @Component({
   selector: 'app-functions',
   standalone: true,
-  imports: [
-    AsyncPipe,
-    IconComponent,
-    LoadingIndicatorComponent,
-    PaginationComponent,
-    FunctionEditComponent,
-    FunctionDeleteComponent,
-    ButtonComponent,
-  ],
+  imports: [IconComponent, ButtonComponent, TableComponent],
   templateUrl: './functions.component.html',
 })
 export class FunctionsComponent implements OnDestroy {
@@ -72,11 +62,11 @@ export class FunctionsComponent implements OnDestroy {
       .subscribe((functionData: AppFunction) => this.saveNew(functionData));
   }
 
-  editFunction(functionData: AppFunction) {
+  editFunction(id: number) {
     const modalRef = this.modalService.open(FunctionEditComponent, {
       size: 'xl',
     });
-    modalRef.componentInstance.function = functionData;
+    modalRef.componentInstance.function = this.functions().find((item) => item.id === id);
     modalRef.componentInstance.canManage = this.permissions().canManage;
     modalRef.componentInstance.saveFunction
       .pipe(takeUntil(this.destroy$))
@@ -105,9 +95,9 @@ export class FunctionsComponent implements OnDestroy {
       });
   }
 
-  deleteFunction(functionData: AppFunction) {
+  deleteFunction(id: number) {
     const modalRef = this.modalService.open(FunctionDeleteComponent);
-    modalRef.componentInstance.function = functionData;
+    modalRef.componentInstance.function = this.functions().find((item) => item.id === id);
     modalRef.componentInstance.deleteFunction
       .pipe(takeUntil(this.destroy$))
       .subscribe((functionData: AppFunction) => this.delete(functionData));
@@ -122,5 +112,14 @@ export class FunctionsComponent implements OnDestroy {
         error: (e) => this.error$.next(e),
         complete: () => this.functionsService.refreshData(),
       });
+  }
+
+  functionsTableHeader(): TableColumnType<Function>[] {
+    return [
+      {
+        key: 'name',
+        columnTitle: 'Functions Name',
+      },
+    ];
   }
 }

--- a/AMW_angular/io/src/app/settings/permission/permission.component.html
+++ b/AMW_angular/io/src/app/settings/permission/permission.component.html
@@ -68,8 +68,7 @@
         (saveRestriction)="persistRestriction()"
       ></app-restriction-edit>
 
-      }
-      @if (create) {
+      } @if (create) {
 
       <app-restriction-add
         [roleName]="selectedRoleName"
@@ -94,8 +93,8 @@
       <div class="card row offset-1">
         @if (!restriction && !create) {
         <div class="card-header">
-          <app-button [variant]="'primary'" [additionalClasses]="'float-end'"  (click)="addRestriction()"
-          ><app-icon icon="plus-circle"></app-icon> Add permission
+          <app-button [variant]="'primary'" [additionalClasses]="'float-end'" (click)="addRestriction()"
+            ><app-icon icon="plus-circle"></app-icon> Add permission
           </app-button>
         </div>
         }

--- a/AMW_angular/io/src/app/settings/permission/permission.component.html
+++ b/AMW_angular/io/src/app/settings/permission/permission.component.html
@@ -1,7 +1,6 @@
 <app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
 
 <div class="container">
-  <h1>Roles and Permissions</h1>
   <ul ngbNav #nav="ngbNav" [(activeId)]="restrictionType" class="nav-tabs mt-2 pt-4">
     <li [ngbNavItem]="'role'">
       <!-- TODO: convert this button-->
@@ -54,13 +53,7 @@
   <div class="form-group">
     <label class="col-sm-1"></label>
     <div class="col">
-      @if (selectedRoleName || selectedUserNames.length > 0) { @if (!restriction && !create) {
-
-      <app-button [variant]="'primary'" [additionalClasses]="'offset-1'" (click)="addRestriction()"
-        ><app-icon icon="plus-circle"></app-icon> Add permission
-      </app-button>
-
-      } @if (restriction) {
+      @if (restriction) {
 
       <app-restriction-edit
         class="bg-light"
@@ -75,7 +68,8 @@
         (saveRestriction)="persistRestriction()"
       ></app-restriction-edit>
 
-      } @if (create) {
+      }
+      @if (create) {
 
       <app-restriction-add
         [roleName]="selectedRoleName"
@@ -90,21 +84,31 @@
         (saveRestrictions)="createRestrictions($event)"
       ></app-restriction-add>
 
-      } }
+      }
     </div>
   </div>
-
-  @if (assignedRestrictions.length > 0) {
+  @if (selectedRoleName || selectedUserNames.length > 0) {
   <div class="form-group">
     <label class="col-sm-1"></label>
     <div class="col">
-      <app-restriction-list
-        [restrictions]="assignedRestrictions"
-        [resourceGroups]="resourceGroups"
-        [delegationMode]="delegationMode"
-        (deleteRestriction)="removeRestriction($event)"
-        (editRestriction)="modifyRestriction($event)"
-      ></app-restriction-list>
+      <div class="card row offset-1">
+        @if (!restriction && !create) {
+        <div class="card-header">
+          <app-button [variant]="'primary'" [additionalClasses]="'float-end'"  (click)="addRestriction()"
+          ><app-icon icon="plus-circle"></app-icon> Add permission
+          </app-button>
+        </div>
+        }
+        <div class="card-body">
+          <app-restriction-list
+            [restrictions]="assignedRestrictions"
+            [resourceGroups]="resourceGroups"
+            [delegationMode]="delegationMode"
+            (deleteRestriction)="removeRestriction($event)"
+            (editRestriction)="modifyRestriction($event)"
+          ></app-restriction-list>
+        </div>
+      </div>
     </div>
   </div>
   }

--- a/AMW_angular/io/src/app/settings/permission/permission.component.spec.ts
+++ b/AMW_angular/io/src/app/settings/permission/permission.component.spec.ts
@@ -328,10 +328,18 @@ describe('PermissionComponent without any params (default: type Role)', () => {
 
   it('should create a copy of the original Restriction on modifyRestriction', () => {
     // given
+    component.assignedRestrictions = [
+      {
+        id: 123,
+        contextName: 'B',
+        permission: { name: 'aPermission' },
+      } as Restriction,
+    ];
+
     expect(component.restriction).toBeNull();
     expect(component.backupRestriction).toBeNull();
     // when
-    component.modifyRestriction({ id: 123 } as Restriction);
+    component.modifyRestriction(123);
     // then
     expect(component.restriction).not.toBeNull();
     expect(component.restriction.id).toBe(123);

--- a/AMW_angular/io/src/app/settings/permission/permission.component.ts
+++ b/AMW_angular/io/src/app/settings/permission/permission.component.ts
@@ -20,7 +20,6 @@ import { FormsModule } from '@angular/forms';
 import {
   NgbNav,
   NgbNavItem,
-  NgbNavItemRole,
   NgbNavLinkButton,
   NgbNavLinkBase,
   NgbNavContent,
@@ -38,7 +37,6 @@ import { ResourceTypesService } from '../../resource/resource-types.service';
     LoadingIndicatorComponent,
     NgbNav,
     NgbNavItem,
-    NgbNavItemRole,
     NgbNavLinkButton,
     NgbNavLinkBase,
     NgbNavContent,
@@ -67,8 +65,6 @@ export class PermissionComponent implements OnInit {
     { id: null, name: null, hasChildren: false, children: [], isApplication: false, isDefaultResourceType: false },
   ];
 
-  defaultNavItem: string = 'Roles';
-  // role | user
   restrictionType: string = 'role';
   delegationMode: boolean = false;
   assignedRestrictions: Restriction[] = [];
@@ -161,10 +157,11 @@ export class PermissionComponent implements OnInit {
     this.create = false;
   }
 
-  modifyRestriction(restriction: Restriction) {
+  modifyRestriction(restrictionId: number) {
     // reset restriction list, discard unsaved changes
     this.clearMessages();
     this.resetPermissionList();
+    const restriction = this.assignedRestrictions.find((r) => r.id === restrictionId);
     this.backupRestriction = { ...restriction };
     this.restriction = restriction;
   }

--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
@@ -1,51 +1,47 @@
-<div class="card row offset-1">
-  <div class="card-header">Assigned</div>
-  <div class="card-body">
-    @if (restrictions.length > 0) {
-    <table class="table table-sm">
-      <thead>
-        <tr>
-          <th>Permission</th>
-          <th>Global</th>
-          <th>Action</th>
-          <th>Environment</th>
-          <th>Res. Group</th>
-          <th>Res. Type</th>
-          <th>Res. Type Cat.</th>
-          <th></th>
-        </tr>
-      </thead>
+<table class="table table-sm">
+  <thead>
+    <tr>
+      <th>Permission</th>
+      <th>Global</th>
+      <th>Action</th>
+      <th>Environment</th>
+      <th>Res. Group</th>
+      <th>Res. Type</th>
+      <th>Res. Type Cat.</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
 
-      <tbody>
-        @for (restriction of restrictions; track restriction) {
-        <tr>
-          <td>{{ restriction.permission.name }}</td>
-          <td>
-            @if (restriction.permission.old) {
-            <app-icon icon="check"></app-icon>
-            }
-          </td>
-          <td>{{ restriction.action }}</td>
-          <td>{{ restriction.contextName }}</td>
-          <td>{{ getGroupName(restriction.resourceGroupId) }}</td>
-          <td>{{ restriction.resourceTypeName }}</td>
-          <td>{{ restriction.resourceTypePermission }}</td>
-          <td>
-            @if (!delegationMode) {
-
-            <app-button [variant]="'primary'" [size]="'sm'" (click)="modifyRestriction(restriction)"
-              ><app-icon icon="pencil"></app-icon>
-            </app-button>
-            <app-button [variant]="'danger'" [size]="'sm'" (click)="removeRestriction(restriction.id)"
-              ><app-icon icon="trash"></app-icon>
-            </app-button>
-
-            }
-          </td>
-        </tr>
+  <tbody>
+    @for (restriction of restrictions; track restriction) {
+    <tr>
+      <td>{{ restriction.permission.name }}</td>
+      <td>
+        @if (restriction.permission.old) {
+        <app-icon icon="check"></app-icon>
         }
-      </tbody>
-    </table>
+      </td>
+      <td>{{ restriction.action }}</td>
+      <td>{{ restriction.contextName }}</td>
+      <td>{{ getGroupName(restriction.resourceGroupId) }}</td>
+      <td>{{ restriction.resourceTypeName }}</td>
+      <td>{{ restriction.resourceTypePermission }}</td>
+      <td>
+        @if (!delegationMode) {
+        <app-button [variant]="'link'" [size]="'sm'" (click)="modifyRestriction(restriction)"
+          ><app-icon icon="pencil"></app-icon>
+        </app-button>
+        <app-button [variant]="'link'" [size]="'sm'" (click)="removeRestriction(restriction.id)"
+                    [additionalClasses]="'me-0 link-danger'"
+          ><app-icon icon="trash"></app-icon>
+        </app-button>
+        }
+      </td>
+    </tr>
+    } @empty {
+    <tr>
+      <td colspan="8" class="text-center">No restrictions defined</td>
+    </tr>
     }
-  </div>
-</div>
+  </tbody>
+</table>

--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
@@ -6,5 +6,6 @@
   [canDelete]="!delegationMode()"
   [canEdit]="!delegationMode()"
   (edit)="modifyRestriction($event.id)"
-  (delete)="removeRestriction($event.id)">
+  (delete)="removeRestriction($event.id)"
+>
 </app-table>

--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.html
@@ -1,47 +1,10 @@
-<table class="table table-sm">
-  <thead>
-    <tr>
-      <th>Permission</th>
-      <th>Global</th>
-      <th>Action</th>
-      <th>Environment</th>
-      <th>Res. Group</th>
-      <th>Res. Type</th>
-      <th>Res. Type Cat.</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-
-  <tbody>
-    @for (restriction of restrictions; track restriction) {
-    <tr>
-      <td>{{ restriction.permission.name }}</td>
-      <td>
-        @if (restriction.permission.old) {
-        <app-icon icon="check"></app-icon>
-        }
-      </td>
-      <td>{{ restriction.action }}</td>
-      <td>{{ restriction.contextName }}</td>
-      <td>{{ getGroupName(restriction.resourceGroupId) }}</td>
-      <td>{{ restriction.resourceTypeName }}</td>
-      <td>{{ restriction.resourceTypePermission }}</td>
-      <td>
-        @if (!delegationMode) {
-        <app-button [variant]="'link'" [size]="'sm'" (click)="modifyRestriction(restriction)"
-          ><app-icon icon="pencil"></app-icon>
-        </app-button>
-        <app-button [variant]="'link'" [size]="'sm'" (click)="removeRestriction(restriction.id)"
-                    [additionalClasses]="'me-0 link-danger'"
-          ><app-icon icon="trash"></app-icon>
-        </app-button>
-        }
-      </td>
-    </tr>
-    } @empty {
-    <tr>
-      <td colspan="8" class="text-center">No restrictions defined</td>
-    </tr>
-    }
-  </tbody>
-</table>
+<app-table
+  [entityName]="'restrictions'"
+  [headers]="restrictionsHeader()"
+  [dataCyNameKey]="'permissionName'"
+  [data]="restrictionsTableData()"
+  [canDelete]="!delegationMode()"
+  [canEdit]="!delegationMode()"
+  (edit)="modifyRestriction($event.id)"
+  (delete)="removeRestriction($event.id)">
+</app-table>

--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
@@ -1,38 +1,98 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
 import { Restriction } from './restriction';
 import * as _ from 'lodash';
 import { Resource } from '../../resource/resource';
-import { IconComponent } from '../../shared/icon/icon.component';
-import { ButtonComponent } from '../../shared/button/button.component';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
 
 @Component({
   selector: 'app-restriction-list',
   templateUrl: './restriction-list.component.html',
   standalone: true,
-  imports: [IconComponent, ButtonComponent],
+  imports: [TableComponent],
 })
 export class RestrictionListComponent {
-  @Input() delegationMode: boolean;
-  @Input() restrictions: Restriction[] = [];
-  @Input() resourceGroups: Resource[] = [];
-  @Output() deleteRestriction: EventEmitter<number> = new EventEmitter<number>();
-  @Output() editRestriction: EventEmitter<Restriction> = new EventEmitter<Restriction>();
+  delegationMode = input.required<boolean>();
+  restrictions = input.required<Restriction[]>();
+  resourceGroups = input.required<Resource[]>();
+  deleteRestriction = output<number>();
+  editRestriction = output<number>();
+  restrictionsTableData = computed(() =>
+    this.restrictions().map((res) => {
+      return {
+        id: res.id,
+        permissionName: res.permission.name,
+        permissionGlobal: res.permission.old,
+        action: res.action,
+        contextName: res.contextName,
+        resourceGroupName: this.getGroupName(res.resourceGroupId),
+        resourceTypeName: res.resourceTypeName,
+        resourceTypePermission: res.resourceTypePermission,
+      };
+    }),
+  );
 
   removeRestriction(id: number) {
     this.deleteRestriction.emit(id);
   }
 
-  modifyRestriction(restriction: Restriction) {
-    this.editRestriction.emit(restriction);
+  modifyRestriction(restrictionId: number) {
+    this.editRestriction.emit(restrictionId);
   }
 
   getGroupName(id: number): string {
     if (id) {
-      const resource = _.find(this.resourceGroups, { id });
+      const resource = _.find(this.resourceGroups(), { id });
       if (resource) {
         return resource['name'];
       }
     }
     return null;
+  }
+
+  restrictionsHeader(): TableColumnType<{
+    id: number;
+    permissionName: string;
+    permissionGlobal: boolean;
+    action: string;
+    contextName: string;
+    resourceGroupName: number;
+    resourceTypeName: string;
+    resourceTypePermission: string;
+  }>[] {
+    return [
+      {
+        key: 'permissionName',
+        columnTitle: 'Permission',
+      },
+      {
+        key: 'permissionGlobal',
+        columnTitle: 'Global',
+        cellType: 'icon',
+        iconMapping: [
+          { value: true, icon: 'check' },
+          { value: false, icon: null },
+        ],
+      },
+      {
+        key: 'action',
+        columnTitle: 'Action',
+      },
+      {
+        key: 'contextName',
+        columnTitle: 'Environment',
+      },
+      {
+        key: 'resourceGroupName',
+        columnTitle: 'Res. Group',
+      },
+      {
+        key: 'resourceTypeName',
+        columnTitle: 'Res. Type',
+      },
+      {
+        key: 'resourceTypePermission',
+        columnTitle: 'Res. Type Cat.',
+      },
+    ];
   }
 }

--- a/AMW_angular/io/src/app/settings/property-types/property-types.component.html
+++ b/AMW_angular/io/src/app/settings/property-types/property-types.component.html
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="card">
     <div class="card-header">
-      @if (canAdd()) {
+      @if (permissions().canAdd) {
       <app-button
         [variant]="'primary'"
         [additionalClasses]="'float-end'"
@@ -13,60 +13,16 @@
       }
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th scope="col">Property Name</th>
-              <th scope="col">Encrypted</th>
-              <th scope="col" class="w-50">Validation</th>
-              <th scope="col" class="w-25">Tags</th>
-              <th scope="col" class="text-center">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (property of propertyTypes(); track property.id) {
-            <tr>
-              <td>{{ property.name }}</td>
-              @if (canDisplay()) {
-              <td>{{ property.encrypted ? 'Yes' : 'No' }}</td>
-              <td>{{ property.validationRegex }}</td>
-              <td>
-                @for (tag of property.propertyTags; track tag.name) {
-                <span class="badge bg-light text-dark rounded-pill">{{ tag.name }}</span>
-                }
-              </td>
-              <td class="text-nowrap text-center">
-                @if (canEditName()) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [dataCy]="'edit-' + property.name"
-                  (click)="editModal(property)"
-                  ><app-icon icon="pencil"></app-icon
-                ></app-button>
-                }
-                @if (canDelete()) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [additionalClasses]="'link-danger'"
-                  [dataCy]="'delete-' + property.name"
-                  (click)="deleteModal(property)"
-                  ><app-icon icon="trash"></app-icon
-                ></app-button>
-                }
-              </td>
-              }
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="5" class="">No property types defined</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'property types'"
+        [headers]="propertyTypesHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="propertyTypesTableData()"
+        [canDelete]="permissions().canDisplay && permissions().canDelete"
+        [canEdit]="permissions().canDisplay && permissions().canEditName"
+        (edit)="editModal($event.id)"
+        (delete)="deleteModal($event.id)">
+      </app-table>
     </div>
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/property-types/property-types.component.html
+++ b/AMW_angular/io/src/app/settings/property-types/property-types.component.html
@@ -1,69 +1,56 @@
 <app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
 <div class="container">
-  <h1>Property Types</h1>
-  <div class="card row mt-2 mb-3">
+  <div class="card">
     <div class="card-header">
-      <div class="row justify-content-between align-items-center">
-        <div class="col-sm"></div>
-
-        <div class="col-sm">
-          @if (canAdd()) {
-          <app-button
-            [variant]="'primary'"
-            [additionalClasses]="'float-end'"
-            [dataCy]="'button-add'"
-            (click)="addModal()"
-            ><app-icon icon="plus-circle"></app-icon> Add property type</app-button
-          >
-          }
-        </div>
-      </div>
+      @if (canAdd()) {
+      <app-button
+        [variant]="'primary'"
+        [additionalClasses]="'float-end'"
+        [dataCy]="'button-add'"
+        (click)="addModal()"
+        ><app-icon icon="plus-circle"></app-icon> Add property type</app-button
+      >
+      }
     </div>
     <div class="card-body">
       <div class="table-responsive">
         <table class="table table-sm table-striped">
           <thead>
             <tr>
-              <th>Property Name</th>
-              <th>Encrypted</th>
-              <th>Validation</th>
-              <th>Tags</th>
-              <th>Edit</th>
-              <th>Delete</th>
+              <th scope="col">Property Name</th>
+              <th scope="col">Encrypted</th>
+              <th scope="col" class="w-50">Validation</th>
+              <th scope="col" class="w-25">Tags</th>
+              <th scope="col" class="text-center">Actions</th>
             </tr>
           </thead>
           <tbody>
             @for (property of propertyTypes(); track property.id) {
             <tr>
-              <td class="align-middle">{{ property.name }}</td>
+              <td>{{ property.name }}</td>
               @if (canDisplay()) {
-              <td class="align-middle">{{ property.encrypted ? 'Yes' : 'No' }}</td>
-              <td class="align-middle">{{ property.validationRegex }}</td>
-              <td class="align-middle">
-                <div>
-                  @for (tag of property.propertyTags; track tag.name) {
-                  <span class="badge bg-light text-dark rounded-pill">{{ tag.name }}</span>
-                  }
-                </div>
+              <td>{{ property.encrypted ? 'Yes' : 'No' }}</td>
+              <td>{{ property.validationRegex }}</td>
+              <td>
+                @for (tag of property.propertyTags; track tag.name) {
+                <span class="badge bg-light text-dark rounded-pill">{{ tag.name }}</span>
+                }
               </td>
-              <td class="text-center">
+              <td class="text-nowrap text-center">
                 @if (canEditName()) {
                 <app-button
-                  [variant]="'primary'"
+                  [variant]="'link'"
                   [size]="'sm'"
-                  [additionalClasses]="'me-0'"
                   [dataCy]="'edit-' + property.name"
                   (click)="editModal(property)"
                   ><app-icon icon="pencil"></app-icon
                 ></app-button>
                 }
-              </td>
-              <td class="text-center">
                 @if (canDelete()) {
                 <app-button
-                  [variant]="'danger'"
+                  [variant]="'link'"
                   [size]="'sm'"
-                  [additionalClasses]="'me-0'"
+                  [additionalClasses]="'link-danger'"
                   [dataCy]="'delete-' + property.name"
                   (click)="deleteModal(property)"
                   ><app-icon icon="trash"></app-icon
@@ -71,6 +58,10 @@
                 }
               </td>
               }
+            </tr>
+            } @empty {
+            <tr>
+              <td colspan="5" class="">No property types defined</td>
             </tr>
             }
           </tbody>

--- a/AMW_angular/io/src/app/settings/property-types/property-types.component.html
+++ b/AMW_angular/io/src/app/settings/property-types/property-types.component.html
@@ -3,11 +3,7 @@
   <div class="card">
     <div class="card-header">
       @if (permissions().canAdd) {
-      <app-button
-        [variant]="'primary'"
-        [additionalClasses]="'float-end'"
-        [dataCy]="'button-add'"
-        (click)="addModal()"
+      <app-button [variant]="'primary'" [additionalClasses]="'float-end'" [dataCy]="'button-add'" (click)="addModal()"
         ><app-icon icon="plus-circle"></app-icon> Add property type</app-button
       >
       }
@@ -21,7 +17,8 @@
         [canDelete]="permissions().canDisplay && permissions().canDelete"
         [canEdit]="permissions().canDisplay && permissions().canEditName"
         (edit)="editModal($event.id)"
-        (delete)="deleteModal($event.id)">
+        (delete)="deleteModal($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/releases/release-edit.component.html
+++ b/AMW_angular/io/src/app/settings/releases/release-edit.component.html
@@ -34,5 +34,5 @@
 </div>
 <div class="modal-footer">
   <app-button [variant]="'light'" (click)="cancel()">Cancel</app-button>
-  <app-button [variant]="'primary'" [disabled]="hasInvalidDate()" (click)="save()">Save changes</app-button>
+  <app-button [variant]="'primary'" [disabled]="hasInvalidDate()" (click)="save()">{{ getTitle() }}</app-button>
 </div>

--- a/AMW_angular/io/src/app/settings/releases/release-edit.component.ts
+++ b/AMW_angular/io/src/app/settings/releases/release-edit.component.ts
@@ -44,6 +44,9 @@ export class ReleaseEditComponent implements OnInit {
   }
 
   save() {
+    if (this.hasInvalidDate()) {
+      return
+    }
     if (this.installationDate.toEpoch() != null) {
       const release: Release = {
         name: this.release.name,

--- a/AMW_angular/io/src/app/settings/releases/release-edit.component.ts
+++ b/AMW_angular/io/src/app/settings/releases/release-edit.component.ts
@@ -27,7 +27,7 @@ export class ReleaseEditComponent implements OnInit {
 
   ngOnInit(): void {
     if (this.release) {
-      this.installationDate = DateModel.fromEpoch(this.release.installationInProductionAt);
+      this.installationDate = DateModel.fromLocalString(this.release.installationInProductionAt);
     }
   }
 
@@ -45,14 +45,14 @@ export class ReleaseEditComponent implements OnInit {
 
   save() {
     if (this.hasInvalidDate()) {
-      return
+      return;
     }
     if (this.installationDate.toEpoch() != null) {
       const release: Release = {
         name: this.release.name,
         mainRelease: this.release.mainRelease,
         description: this.release.description,
-        installationInProductionAt: this.installationDate.toEpoch(),
+        installationInProductionAt: this.installationDate.toISOFormat(),
         id: this.release.id ? this.release.id : null,
         default: false,
         v: this.release.v ? this.release.v : null,

--- a/AMW_angular/io/src/app/settings/releases/release.ts
+++ b/AMW_angular/io/src/app/settings/releases/release.ts
@@ -2,7 +2,7 @@ export interface Release {
   name: string;
   mainRelease: boolean;
   description: string;
-  installationInProductionAt: number;
+  installationInProductionAt: string;
   id: number;
   v: number;
   default: boolean;

--- a/AMW_angular/io/src/app/settings/releases/releases.component.html
+++ b/AMW_angular/io/src/app/settings/releases/releases.component.html
@@ -15,7 +15,6 @@
     </div>
     <div class="card-body">
       <div class="table-responsive">
-        @if ((results$ | async)?.length > 0) {
         <table class="table table-sm table-striped">
           <thead>
             <tr>
@@ -63,7 +62,6 @@
             }
           </tbody>
         </table>
-        }
       </div>
     </div>
     <div class="card-footer py-1">

--- a/AMW_angular/io/src/app/settings/releases/releases.component.html
+++ b/AMW_angular/io/src/app/settings/releases/releases.component.html
@@ -1,6 +1,5 @@
 <app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
 <div class="container">
-  <h1>Releases</h1>
   <div class="card row mt-2 mb-3">
     <div class="card-header">
       <div class="row justify-content-between align-items-center">
@@ -20,26 +19,24 @@
         <table class="table table-sm table-striped">
           <thead>
             <tr>
-              <th>Release Name</th>
-              <th>Main Release</th>
-              <th>Description</th>
-              <th>Date</th>
-              <th class="text-center">Edit</th>
-              <th class="text-center">Delete</th>
+              <th class="w-25">Release Name</th>
+              <th class="w-25">Main Release</th>
+              <th class="w-25">Description</th>
+              <th class="w-25">Date</th>
+              <th class="text-center">Actions</th>
             </tr>
           </thead>
-
           <tbody>
             @for (item of results$ | async; track item) {
             <tr>
-              <td class="align-middle">{{ item.name }}</td>
-              <td class="align-middle">{{ item.mainRelease }}</td>
-              <td class="align-middle">{{ item.description }}</td>
-              <td class="align-middle">{{ item.installationInProductionAt | date: dateFormat }}</td>
-              <td class="text-center">
+              <td>{{ item.name }}</td>
+              <td>{{ item.mainRelease }}</td>
+              <td>{{ item.description }}</td>
+              <td>{{ item.installationInProductionAt | date: dateFormat }}</td>
+              <td class="text-nowrap align-items-center">
                 @if (item.default !== true && canEdit()) {
                 <app-button
-                  [variant]="'primary'"
+                  [variant]="'link'"
                   [size]="'sm'"
                   [additionalClasses]="'me-0'"
                   (click)="editRelease(item)"
@@ -47,19 +44,21 @@
                   <app-icon icon="pencil"></app-icon
                 ></app-button>
                 }
-              </td>
-              <td class="text-center">
                 @if (item.default !== true && canDelete()) {
                 <app-button
-                  [variant]="'danger'"
+                  [variant]="'link'"
                   [size]="'sm'"
-                  [additionalClasses]="'me-0'"
+                  [additionalClasses]="'me-0 link-danger'"
                   (click)="deleteRelease(item)"
                 >
                   <app-icon icon="trash"></app-icon
                 ></app-button>
                 }
               </td>
+            </tr>
+            } @empty {
+            <tr>
+              <td colspan="5" class="text-center">No releases defined</td>
             </tr>
             }
           </tbody>

--- a/AMW_angular/io/src/app/settings/releases/releases.component.html
+++ b/AMW_angular/io/src/app/settings/releases/releases.component.html
@@ -14,55 +14,17 @@
       </div>
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th class="w-25">Release Name</th>
-              <th class="w-25">Main Release</th>
-              <th class="w-25">Description</th>
-              <th class="w-25">Date</th>
-              <th class="text-center">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (item of results(); track item.id) {
-            <tr>
-              <td>{{ item.name }}</td>
-              <td>{{ item.mainRelease }}</td>
-              <td>{{ item.description }}</td>
-              <td>{{ item.installationInProductionAt | date: dateFormat }}</td>
-              <td class="text-nowrap align-items-center">
-                @if (item.default !== true && permissions().canEdit) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [additionalClasses]="'me-0'"
-                  (click)="editRelease(item)"
-                >
-                  <app-icon icon="pencil"></app-icon
-                ></app-button>
-                }
-                @if (item.default !== true && permissions().canDelete) {
-                <app-button
-                  [variant]="'link'"
-                  [size]="'sm'"
-                  [additionalClasses]="'me-0 link-danger'"
-                  (click)="deleteRelease(item)"
-                >
-                  <app-icon icon="trash"></app-icon
-                ></app-button>
-                }
-              </td>
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="5" class="text-center">No releases defined</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'releases'"
+        [headers]="releasesHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="resultTableData()"
+        [readonlyFlag]="'readonly'"
+        [canDelete]="permissions().canDelete"
+        [canEdit]="permissions().canEdit"
+        (edit)="editRelease($event.id)"
+        (delete)="deleteRelease($event.id)">
+      </app-table>
     </div>
     <div class="card-footer py-1">
       <div class="row bg-light align-items-center">

--- a/AMW_angular/io/src/app/settings/releases/releases.component.html
+++ b/AMW_angular/io/src/app/settings/releases/releases.component.html
@@ -23,7 +23,8 @@
         [canDelete]="permissions().canDelete"
         [canEdit]="permissions().canEdit"
         (edit)="editRelease($event.id)"
-        (delete)="deleteRelease($event.id)">
+        (delete)="deleteRelease($event.id)"
+      >
       </app-table>
     </div>
     <div class="card-footer py-1">

--- a/AMW_angular/io/src/app/settings/releases/releases.component.html
+++ b/AMW_angular/io/src/app/settings/releases/releases.component.html
@@ -1,10 +1,10 @@
-<app-loading-indicator [isLoading]="isLoading"></app-loading-indicator>
+<app-loading-indicator [isLoading]="isLoading()"></app-loading-indicator>
 <div class="container">
   <div class="card row mt-2 mb-3">
     <div class="card-header">
       <div class="row justify-content-between align-items-center">
         <div class="col-sm">
-          @if (canCreate()) {
+          @if (permissions().canCreate) {
           <app-button [variant]="'primary'" [additionalClasses]="'float-end'" (click)="addRelease()">
             <app-icon icon="plus-circle"></app-icon>
             Add release</app-button
@@ -26,14 +26,14 @@
             </tr>
           </thead>
           <tbody>
-            @for (item of results$ | async; track item) {
+            @for (item of results(); track item.id) {
             <tr>
               <td>{{ item.name }}</td>
               <td>{{ item.mainRelease }}</td>
               <td>{{ item.description }}</td>
               <td>{{ item.installationInProductionAt | date: dateFormat }}</td>
               <td class="text-nowrap align-items-center">
-                @if (item.default !== true && canEdit()) {
+                @if (item.default !== true && permissions().canEdit) {
                 <app-button
                   [variant]="'link'"
                   [size]="'sm'"
@@ -43,7 +43,7 @@
                   <app-icon icon="pencil"></app-icon
                 ></app-button>
                 }
-                @if (item.default !== true && canDelete()) {
+                @if (item.default !== true && permissions().canDelete) {
                 <app-button
                   [variant]="'link'"
                   [size]="'sm'"
@@ -67,8 +67,8 @@
     <div class="card-footer py-1">
       <div class="row bg-light align-items-center">
         <app-pagination
-          [currentPage]="currentPage"
-          [lastPage]="lastPage"
+          [currentPage]="currentPage()"
+          [lastPage]="lastPage()"
           (doSetMax)="setMaxResultsPerPage($event)"
           (doSetOffset)="setNewOffset($event)"
         >

--- a/AMW_angular/io/src/app/settings/releases/releases.service.ts
+++ b/AMW_angular/io/src/app/settings/releases/releases.service.ts
@@ -1,9 +1,9 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Signal } from '@angular/core';
 import { BaseService } from '../../base/base.service';
 import { HttpClient } from '@angular/common/http';
-import { map, catchError } from 'rxjs/operators';
+import { map, catchError, switchMap, shareReplay } from 'rxjs/operators';
 import { Release } from './release';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 import { ResourceEntity } from './resource-entity';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -11,6 +11,23 @@ import { toSignal } from '@angular/core/rxjs-interop';
 export class ReleasesService extends BaseService {
   private allReleases$ = this.getAllReleases();
   allReleases = toSignal(this.allReleases$, { initialValue: [] as Release[] });
+
+  private offsetMaxResults$: BehaviorSubject<{ offset: number; maxResults: number }> = new BehaviorSubject<{
+    offset: number;
+    maxResults: number;
+  }>({
+    offset: 0,
+    maxResults: 10,
+  });
+
+  private releases$: Observable<Release[]> = this.offsetMaxResults$.pipe(
+    switchMap((offsetMaxResults: { offset: number; maxResults: number }) =>
+      this.getReleases(offsetMaxResults.offset, offsetMaxResults.maxResults),
+    ),
+    shareReplay(1),
+  );
+
+  releases: Signal<Release[]> = toSignal(this.releases$, { initialValue: [] as Release[] });
 
   constructor(private http: HttpClient) {
     super();
@@ -81,5 +98,9 @@ export class ReleasesService extends BaseService {
         headers: this.getHeaders(),
       })
       .pipe(catchError(this.handleError));
+  }
+
+  setOffsetAndMaxResultsForReleases(offsetMAxResult: { offset: number; maxResults: number }): void {
+    this.offsetMaxResults$.next(offsetMAxResult);
   }
 }

--- a/AMW_angular/io/src/app/settings/settings.component.ts
+++ b/AMW_angular/io/src/app/settings/settings.component.ts
@@ -6,7 +6,6 @@ import { PageComponent } from '../layout/page/page.component';
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
-  styleUrl: './settings.component.scss',
   standalone: true,
   imports: [RouterLink, RouterLinkActive, RouterOutlet, PageComponent],
 })

--- a/AMW_angular/io/src/app/settings/settings.routes.ts
+++ b/AMW_angular/io/src/app/settings/settings.routes.ts
@@ -7,16 +7,17 @@ import { DeploymentParameterComponent } from './deployment-parameter/deployment-
 import { PropertyTypesComponent } from './property-types/property-types.component';
 import { FunctionsComponent } from './functions/functions.component';
 import { EnvironmentsPageComponent } from './environments/environments-page.component';
+import { Routes } from '@angular/router';
 
-export const settingsRoutes = [
+export const settingsRoutes: Routes = [
   {
     path: 'settings',
     component: SettingsComponent,
-    title: 'Settings',
+    title: 'Settings - Liima',
     children: [
-      { path: '', component: EnvironmentsPageComponent },
+      { path: '', redirectTo: 'environments', pathMatch: 'full' },
       { path: 'releases', component: ReleasesComponent },
-      { title: 'Settings - Tags', path: 'tags', component: TagsComponent },
+      { path: 'tags', component: TagsComponent },
       {
         path: 'permission/delegation/:actingUser',
         component: PermissionComponent,

--- a/AMW_angular/io/src/app/settings/tags/tags.component.html
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.html
@@ -5,12 +5,18 @@
         <div class="col-sm"></div>
         @if (canCreate()) {
         <div class="col-sm-3">
-          <input id="tagName" type="text float-end" class="form-control" [(ngModel)]="tagName" (keyup.enter)="addTag()" />
+          <input
+            id="tagName"
+            type="text float-end"
+            class="form-control"
+            [(ngModel)]="tagName"
+            (keyup.enter)="addTag()"
+          />
         </div>
         <div class="col-md-auto">
-            <app-button [variant]="'primary'" [dataCy]="'button-add'" (click)="addTag()" [additionalClasses]="'float-end'"
-              ><app-icon icon="plus-circle"></app-icon> Add tag</app-button
-            >
+          <app-button [variant]="'primary'" [dataCy]="'button-add'" (click)="addTag()" [additionalClasses]="'float-end'"
+            ><app-icon icon="plus-circle"></app-icon> Add tag</app-button
+          >
         </div>
         }
       </div>
@@ -22,7 +28,8 @@
         [dataCyNameKey]="'name'"
         [data]="tags()"
         [canDelete]="canDelete()"
-        (delete)="deleteTag($event.id)">
+        (delete)="deleteTag($event.id)"
+      >
       </app-table>
     </div>
   </div>

--- a/AMW_angular/io/src/app/settings/tags/tags.component.html
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.html
@@ -16,35 +16,14 @@
       </div>
     </div>
     <div class="card-body">
-      <div class="table-responsive">
-        <table class="table table-sm table-striped">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th class="text-end">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (tag of tags(); track tag) {
-            <tr>
-              <td>{{ tag.name }}</td>
-              <td class="text-end">
-                @if (canDelete()) {
-                <app-button [variant]="'link'" [additionalClasses]="'link-danger'"
-                            [size]="'sm'" [dataCy]="'delete-' + tag.name" (click)="deleteTag(tag.id)"
-                  ><app-icon icon="trash"></app-icon
-                ></app-button>
-                }
-              </td>
-            </tr>
-            } @empty {
-            <tr>
-              <td colspan="2" class="text-center">No tags defined</td>
-            </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+      <app-table
+        [entityName]="'tags'"
+        [headers]="tagsHeader()"
+        [dataCyNameKey]="'name'"
+        [data]="tags()"
+        [canDelete]="canDelete()"
+        (delete)="deleteTag($event.id)">
+      </app-table>
     </div>
   </div>
 </div>

--- a/AMW_angular/io/src/app/settings/tags/tags.component.html
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.html
@@ -1,38 +1,50 @@
 <div class="container">
-  <h1>{{ pageTitle }}</h1>
-  <div class="row mt-2 py-4">
-    <div class="col-6 ms-auto">
-      <div class="input-group">
+  <div class="card row mt-2 mb-3">
+    <div class="card-header">
+      <div class="row justify-content-between align-items-center">
+        <div class="col-sm"></div>
         @if (canCreate()) {
-        <input id="tagName" type="text" class="form-control" [(ngModel)]="tagName" (keyup.enter)="addTag()" />
-        <app-button [variant]="'primary'" [dataCy]="'button-add'" (click)="addTag()"
-          ><app-icon icon="plus-circle"></app-icon> Add tag</app-button
-        >
+        <div class="col-sm-3">
+          <input id="tagName" type="text float-end" class="form-control" [(ngModel)]="tagName" (keyup.enter)="addTag()" />
+        </div>
+        <div class="col-md-auto">
+            <app-button [variant]="'primary'" [dataCy]="'button-add'" (click)="addTag()" [additionalClasses]="'float-end'"
+              ><app-icon icon="plus-circle"></app-icon> Add tag</app-button
+            >
+        </div>
         }
       </div>
     </div>
+    <div class="card-body">
+      <div class="table-responsive">
+        <table class="table table-sm table-striped">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th class="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (tag of tags(); track tag) {
+            <tr>
+              <td>{{ tag.name }}</td>
+              <td class="text-end">
+                @if (canDelete()) {
+                <app-button [variant]="'link'" [additionalClasses]="'link-danger'"
+                            [size]="'sm'" [dataCy]="'delete-' + tag.name" (click)="deleteTag(tag.id)"
+                  ><app-icon icon="trash"></app-icon
+                ></app-button>
+                }
+              </td>
+            </tr>
+            } @empty {
+            <tr>
+              <td colspan="2" class="text-center">No tags defined</td>
+            </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
-
-  <table class="table table-sm table-striped table-bordered">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Delete</th>
-      </tr>
-    </thead>
-    <tbody>
-      @for (tag of tags(); track tag) {
-      <tr>
-        <td>{{ tag.name }}</td>
-        <td>
-          @if (canDelete()) {
-          <app-button [variant]="'danger'" [size]="'sm'" [dataCy]="'delete-' + tag.name" (click)="deleteTag(tag.id)"
-            ><app-icon icon="trash"></app-icon
-          ></app-button>
-          }
-        </td>
-      </tr>
-      }
-    </tbody>
-  </table>
 </div>

--- a/AMW_angular/io/src/app/settings/tags/tags.component.scss
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.scss
@@ -1,4 +1,0 @@
-.table td,
-.table th {
-  vertical-align: middle;
-}

--- a/AMW_angular/io/src/app/settings/tags/tags.component.ts
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.ts
@@ -6,13 +6,15 @@ import { AuthService, isAllowed } from '../../auth/auth.service';
 import { ToastService } from '../../shared/elements/toast/toast.service';
 import { TagsService } from './tags.service';
 import { ButtonComponent } from '../../shared/button/button.component';
+import { TableComponent, TableColumnType } from '../../shared/table/table.component';
+import { Tag } from './tag';
 
 @Component({
   selector: 'app-tags',
   templateUrl: './tags.component.html',
   styleUrl: './tags.component.scss',
   standalone: true,
-  imports: [FormsModule, IconComponent, ButtonComponent],
+  imports: [FormsModule, IconComponent, ButtonComponent, TableComponent],
 })
 export class TagsComponent implements OnInit, OnDestroy {
   private tagsService = inject(TagsService);
@@ -50,5 +52,14 @@ export class TagsComponent implements OnInit, OnDestroy {
   deleteTag(tagId: number): void {
     this.tagsService.delete(tagId);
     this.toastService.success('Tag deleted.');
+  }
+
+  tagsHeader(): TableColumnType<Tag>[] {
+    return [
+      {
+        key: 'name',
+        columnTitle: 'Name',
+      },
+    ];
   }
 }

--- a/AMW_angular/io/src/app/settings/tags/tags.component.ts
+++ b/AMW_angular/io/src/app/settings/tags/tags.component.ts
@@ -19,7 +19,6 @@ export class TagsComponent implements OnInit, OnDestroy {
   private authService = inject(AuthService);
   private toastService = inject(ToastService);
 
-  pageTitle = 'Tags';
   tagName = signal('');
   tags = this.tagsService.tags;
   canCreate = signal<boolean>(false);

--- a/AMW_angular/io/src/app/shared/configuration.ts
+++ b/AMW_angular/io/src/app/shared/configuration.ts
@@ -1,5 +1,5 @@
 export type Config = { key: { value: string; env: string }; value: string; defaultValue: string };
 
 export function pluck(key: string, config: Config[]): string {
-  return config.filter((c) => c.key.value === key).map((c) => c.value)[0];
+  return config.filter((c) => c.key.value === key).map((c) => c.key.value)[0];
 }

--- a/AMW_angular/io/src/app/shared/date-picker/date.model.ts
+++ b/AMW_angular/io/src/app/shared/date-picker/date.model.ts
@@ -1,6 +1,6 @@
 import { NgbTimeStruct, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap';
 import * as datefns from 'date-fns';
-import { DATE_FORMAT } from 'src/app/core/amw-constants';
+import { DATE_FORMAT, ISO_FORMAT } from 'src/app/core/amw-constants';
 
 export interface NgbDateTimeStruct extends NgbDateStruct, NgbTimeStruct {}
 
@@ -70,5 +70,9 @@ export class DateModel implements NgbDateStruct {
 
   public toJSON(): string {
     return this.toString();
+  }
+
+  public toISOFormat(): string {
+    return datefns.format(this.thisToDate(), ISO_FORMAT);
   }
 }

--- a/AMW_angular/io/src/app/shared/icon/icon.component.css
+++ b/AMW_angular/io/src/app/shared/icon/icon.component.css
@@ -2,8 +2,7 @@
   height: 17px;
   width: 17px;
   display: inline-block;
-  vertical-align: middle
-
+  vertical-align: middle;
 }
 
 .icon {

--- a/AMW_angular/io/src/app/shared/modal-header/modal-header.component.ts
+++ b/AMW_angular/io/src/app/shared/modal-header/modal-header.component.ts
@@ -7,7 +7,7 @@ import { Component, input, output } from '@angular/core';
   template: `<div class="modal-header">
     <h5 class="modal-title">{{ title() }}</h5>
     <button type="button" class="btn btn-light close" aria-label="Close" (click)="onCancel()">
-      <span aria-hidden="true">&times;</span>
+      <span>&times;</span>
     </button>
   </div> `,
 })

--- a/AMW_angular/io/src/app/shared/pagination/pagination.component.html
+++ b/AMW_angular/io/src/app/shared/pagination/pagination.component.html
@@ -3,36 +3,36 @@
 
   <nav>
     <ul class="pagination pointer m-1">
-      <li class="page-item {{ currentPage < 2 ? 'disabled' : '' }}" aria-label="first" (click)="toPage(1)">
+      <li class="page-item {{ currentPage() < 2 ? 'disabled' : '' }}" aria-label="first" (click)="toPage(1)">
         <a class="page-link" aria-hidden="true">&laquo;</a>
       </li>
       <li
-        class="page-item {{ currentPage < 2 ? 'disabled' : '' }}"
+        class="page-item {{ currentPage() < 2 ? 'disabled' : '' }}"
         aria-label="previous"
-        (click)="toPage(currentPage - 1)"
+        (click)="toPage(currentPage() - 1)"
       >
         <a class="page-link" aria-hidden="true">&lt;</a>
       </li>
       @for (page of pages(); track page) {
-      <li class="page-item {{ currentPage === page ? 'active' : '' }}">
+      <li class="page-item {{ currentPage() === page ? 'active' : '' }}">
         <a class="page-link" (click)="toPage(page)"
-          >{{ page }} @if (currentPage === page) {
+          >{{ page }} @if (currentPage() === page) {
           <span class="visually-hidden">(current)</span>
           }</a
         >
       </li>
       }
       <li
-        class="page-item {{ currentPage === lastPage ? 'disabled' : '' }}"
+        class="page-item {{ currentPage() === lastPage() ? 'disabled' : '' }}"
         aria-label="next"
-        (click)="toPage(currentPage + 1)"
+        (click)="toPage(currentPage() + 1)"
       >
         <a class="page-link"><span aria-hidden="true">&gt;</span></a>
       </li>
       <li
-        class="page-item {{ currentPage === lastPage ? 'disabled' : '' }}"
+        class="page-item {{ currentPage() === lastPage() ? 'disabled' : '' }}"
         aria-label="last"
-        (click)="toPage(lastPage)"
+        (click)="toPage(lastPage())"
       >
         <a class="page-link"><span aria-hidden="true">&raquo;</span></a>
       </li>

--- a/AMW_angular/io/src/app/shared/pagination/pagination.component.spec.ts
+++ b/AMW_angular/io/src/app/shared/pagination/pagination.component.spec.ts
@@ -1,152 +1,142 @@
-import { Component } from '@angular/core';
+import { ComponentRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { inject, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { PaginationComponent } from './pagination.component';
-
-@Component({
-  template: '',
-  standalone: true,
-  imports: [CommonModule],
-})
-class DummyComponent {}
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 describe('PaginationComponent', () => {
-  // provide our implementations or mocks to the dependency injector
-  beforeEach(() =>
-    TestBed.configureTestingModule({
-      imports: [
-        CommonModule,
-        RouterTestingModule.withRoutes([{ path: 'deployments', component: DummyComponent }]),
-        DummyComponent,
-      ],
-      providers: [PaginationComponent],
-    }),
-  );
+  let component: PaginationComponent;
+  let componentRef: ComponentRef<PaginationComponent>;
+  let fixture: ComponentFixture<PaginationComponent>;
 
-  it('should return no page numbers if there is just one page', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = 1;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PaginationComponent, CommonModule, RouterTestingModule.withRoutes([])],
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
+    }).compileComponents();
 
-      // when
-      const pages = paginationComponent.pages();
+    fixture = TestBed.createComponent(PaginationComponent);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 3);
+    fixture.detectChanges();
+  });
 
-      // then
-      expect(pages).toBeUndefined();
-    },
-  ));
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 
-  it('should return two page numbers if last page is 2', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = 2;
-
-      // when
-      const pages = paginationComponent.pages();
-
-      // then
-      expect(pages.length).toEqual(2);
-      expect(pages).toEqual([1, 2]);
-    },
-  ));
-
-  it('should not return the right pages', inject([PaginationComponent], (paginationComponent: PaginationComponent) => {
+  it('should return no page numbers if there is just one page', () => {
     // given
-    paginationComponent.currentPage = 5;
-    paginationComponent.paginatorItems = 5;
-    paginationComponent.lastPage = paginationComponent.paginatorItems + 10;
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 1);
 
     // when
-    const pages = paginationComponent.pages();
+    const pages = component.pages();
 
     // then
-    expect(pages.length).toEqual(paginationComponent.paginatorItems);
+    expect(pages).toBeUndefined();
+  });
+
+  it('should return two page numbers if last page is 2', () => {
+    // given
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 2);
+
+    // when
+    const pages = component.pages();
+
+    // then
+    expect(pages.length).toEqual(2);
+    expect(pages).toEqual([1, 2]);
+  });
+
+  it('should not return the right pages', () => {
+    // given
+    component.paginatorItems = 5;
+
+    componentRef.setInput('currentPage', 5);
+    componentRef.setInput('lastPage', component.paginatorItems + 10);
+
+    // when
+    const pages = component.pages();
+
+    // then
+    expect(pages.length).toEqual(component.paginatorItems);
     expect(pages).toEqual([3, 4, 5, 6, 7]);
-  }));
+  });
 
-  it('should emit the right offset on toPage', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = paginationComponent.paginatorItems + 10;
-      spyOn(paginationComponent.doSetOffset, 'emit');
+  it('should emit the right offset on toPage', () => {
+    // given
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', component.paginatorItems + 10);
 
-      // when
-      paginationComponent.toPage(2);
+    spyOn(component.doSetOffset, 'emit');
 
-      // then
-      expect(paginationComponent.doSetOffset.emit).toHaveBeenCalledWith(10);
-    },
-  ));
+    // when
+    component.toPage(2);
 
-  it('should emit the right results offset when navigating to first page', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 2;
-      paginationComponent.lastPage = 10;
-      spyOn(paginationComponent.doSetOffset, 'emit');
+    // then
+    expect(component.doSetOffset.emit).toHaveBeenCalledWith(10);
+  });
 
-      // when
-      paginationComponent.toPage(1);
+  it('should emit the right results offset when navigating to first page', () => {
+    // given
+    componentRef.setInput('currentPage', 2);
+    componentRef.setInput('lastPage', 10);
 
-      // then
-      expect(paginationComponent.doSetOffset.emit).toHaveBeenCalledWith(0);
-    },
-  ));
+    spyOn(component.doSetOffset, 'emit');
 
-  it('should emit the right results offset when navigating to second page', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = 10;
-      spyOn(paginationComponent.doSetOffset, 'emit');
+    // when
+    component.toPage(1);
 
-      // when
-      paginationComponent.toPage(2);
+    // then
+    expect(component.doSetOffset.emit).toHaveBeenCalledWith(0);
+  });
 
-      // then
-      expect(paginationComponent.doSetOffset.emit).toHaveBeenCalledWith(10);
-    },
-  ));
+  it('should emit the right results offset when navigating to second page', () => {
+    // given
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 10);
 
-  it('should emit the right results offset depending on maxResults when navigating to second page', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = 10;
-      paginationComponent.maxResults = 50;
-      spyOn(paginationComponent.doSetOffset, 'emit');
+    spyOn(component.doSetOffset, 'emit');
 
-      // when
-      paginationComponent.toPage(2);
+    // when
+    component.toPage(2);
 
-      // then
-      expect(paginationComponent.doSetOffset.emit).toHaveBeenCalledWith(50);
-    },
-  ));
+    // then
+    expect(component.doSetOffset.emit).toHaveBeenCalledWith(10);
+  });
 
-  it('should emit the right results offset when navigating to last page', inject(
-    [PaginationComponent],
-    (paginationComponent: PaginationComponent) => {
-      // given
-      paginationComponent.currentPage = 1;
-      paginationComponent.lastPage = 10;
-      spyOn(paginationComponent.doSetOffset, 'emit');
+  it('should emit the right results offset depending on maxResults when navigating to second page', () => {
+    // given
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 10);
 
-      // when
-      paginationComponent.toPage(10);
+    component.maxResults = 50;
+    spyOn(component.doSetOffset, 'emit');
 
-      // then
-      expect(paginationComponent.doSetOffset.emit).toHaveBeenCalledWith(90);
-    },
-  ));
+    // when
+    component.toPage(2);
+
+    // then
+    expect(component.doSetOffset.emit).toHaveBeenCalledWith(50);
+  });
+
+  it('should emit the right results offset when navigating to last page', () => {
+    // given
+    componentRef.setInput('currentPage', 1);
+    componentRef.setInput('lastPage', 10);
+
+    spyOn(component.doSetOffset, 'emit');
+
+    // when
+    component.toPage(10);
+
+    // then
+    expect(component.doSetOffset.emit).toHaveBeenCalledWith(90);
+  });
 });

--- a/AMW_angular/io/src/app/shared/pagination/pagination.component.ts
+++ b/AMW_angular/io/src/app/shared/pagination/pagination.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, EventEmitter, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 @Component({
@@ -8,29 +8,27 @@ import { FormsModule } from '@angular/forms';
   imports: [FormsModule],
 })
 export class PaginationComponent {
-  @Input() currentPage: number;
-  @Input() lastPage: number;
-  @Output() doSetOffset: EventEmitter<number> = new EventEmitter<number>();
-  @Output() doSetMax: EventEmitter<number> = new EventEmitter<number>();
+  currentPage = input.required<number>();
+  lastPage = input.required<number>();
+  doSetOffset = output<number>();
+  doSetMax = output<number>();
 
   paginatorItems: number = 5;
 
   maxResults: number = 10;
 
-  constructor() {}
-
   pages(): number[] {
-    if (this.lastPage > 1) {
+    if (this.lastPage() > 1) {
       const itemsBefore: number = Math.floor(this.paginatorItems / 2);
-      const start: number = this.currentPage > itemsBefore ? this.currentPage - itemsBefore : 1;
+      const start: number = this.currentPage() > itemsBefore ? this.currentPage() - itemsBefore : 1;
       const end: number = start + this.paginatorItems - 1;
-      return this.range(start, end < this.lastPage ? end : this.lastPage);
+      return this.range(start, end < this.lastPage() ? end : this.lastPage());
     }
     return;
   }
 
   toPage(page: number) {
-    if (page <= this.lastPage && page !== this.currentPage) {
+    if (page <= this.lastPage() && page !== this.currentPage()) {
       page = page > 0 ? page - 1 : 0;
       this.doSetOffset.emit(page * this.maxResults);
     }

--- a/AMW_angular/io/src/app/shared/table/table.component.html
+++ b/AMW_angular/io/src/app/shared/table/table.component.html
@@ -1,84 +1,73 @@
 <div class="table-responsive">
-  <table class="table table-sm">
+  <table class="table table-sm table-fixed w-100">
     <thead class="table-light">
-    <tr>
-      @for (header of headers(); track header) {
+      <tr>
+        @for (header of headers(); track header) {
         <th scope="col">{{ header.columnTitle }}</th>
-      }
-      @if (hasAction()) {
+        } @if (hasAction()) {
         <th class="text-end" scope="col">Actions</th>
-      }
-    </tr>
+        }
+      </tr>
     </thead>
     <tbody>
       @for (row of data(); track row.id) {
-        <tr>
-          @for (header of headers(); track header) {
-            @switch (header.cellType) {
-              @case ('badge-list') {
-                <td>
-                  @for (item of row[header.key]; track item.id) {
-                    <span class="badge bg-light text-dark rounded-pill">{{ item }}</span>
-                  }
-                </td>
-              }
-              @case ('date') {
-                <td>
-                  {{ row[header.key]  | date: dateFormat }}
-                </td>
-              }
-              @case ('icon') {
-                <td>
-                  <app-icon icon="{{this.getIcon(row[header.key], header)}}"></app-icon>
-                </td>
-              }
-              @case ('link') {
-                <td>
-                  @if(!row[header.urlKey] || row[header.urlKey] == '') {
-                    {{ row[header.key] }}
-                  } @else {
-                    <a href="{{ row[header.urlKey] }}">{{ row[header.key] }}</a>
-                  }
-                </td>
-              }
-              @default {
-                <td>
-                  {{ row[header.key] }}
-                </td>
-              }
-            }
+      <tr>
+        @for (header of headers(); track header) { @switch (header.cellType) { @case ('badge-list') {
+        <td>
+          @for (item of row[header.key]; track item.id) {
+          <span class="badge bg-light text-dark rounded-pill">{{ item }}</span>
           }
-          @if (hasAction()) {
-            <td class="text-end">
-              @if (canEdit() && !row[readonlyFlag()]) {
-                <app-button
-                  [size]="'sm'"
-                  [variant]="'link'"
-                  [additionalClasses]="'me-4 p-0'"
-                  [dataCy]="'button-edit-' + row[dataCyNameKey()]"
-                  (click)="edit.emit({ action: EntryAction.edit, id: row.id })"
-                >
-                  <app-icon icon="pencil"></app-icon>
-                </app-button>
-              }
-              @if (canDelete() && !row[readonlyFlag()]) {
-                <app-button
-                  [size]="'sm'"
-                  [variant]="'link'"
-                  [additionalClasses]="'p-0 link-danger'"
-                  [dataCy]="'button-delete-'+ row[dataCyNameKey()]"
-                  (click)="delete.emit({ action: EntryAction.delete, id: row.id })"
-                >
-                  <app-icon icon="trash"></app-icon>
-                </app-button>
-              }
-            </td>
+        </td>
+        } @case ('date') {
+        <td>
+          {{ row[header.key] | date: dateFormat }}
+        </td>
+        } @case ('icon') {
+        <td>
+          <app-icon icon="{{ this.getIcon(row[header.key], header) }}"></app-icon>
+        </td>
+        } @case ('link') {
+        <td>
+          @if(!row[header.urlKey] || row[header.urlKey] === '') {
+          {{ row[header.key] }}
+          } @else {
+          <a href="{{ row[header.urlKey] }}">{{ row[header.key] }}</a>
           }
-        </tr>
+        </td>
+        } @default {
+        <td>
+          {{ row[header.key] }}
+        </td>
+        } } } @if (hasAction()) {
+        <td class="text-end">
+          @if (canEdit() && !row[readonlyFlag()]) {
+          <app-button
+            [size]="'sm'"
+            [variant]="'link'"
+            [additionalClasses]="'me-4 p-0'"
+            [dataCy]="'button-edit-' + row[dataCyNameKey()]"
+            (click)="edit.emit({ action: EntryAction.edit, id: row.id })"
+          >
+            <app-icon icon="pencil"></app-icon>
+          </app-button>
+          } @if (canDelete() && !row[readonlyFlag()]) {
+          <app-button
+            [size]="'sm'"
+            [variant]="'link'"
+            [additionalClasses]="'p-0 link-danger'"
+            [dataCy]="'button-delete-' + row[dataCyNameKey()]"
+            (click)="delete.emit({ action: EntryAction.delete, id: row.id })"
+          >
+            <app-icon icon="trash"></app-icon>
+          </app-button>
+          }
+        </td>
+        }
+      </tr>
       } @empty {
-        <tr>
-          <td class="text-center" [colSpan]="getTotalColspan()">No {{ entityName() }} defined/found</td>
-        </tr>
+      <tr>
+        <td class="text-muted" [colSpan]="getTotalColspan()">No {{ entityName() }} defined/found</td>
+      </tr>
       }
     </tbody>
   </table>

--- a/AMW_angular/io/src/app/shared/table/table.component.html
+++ b/AMW_angular/io/src/app/shared/table/table.component.html
@@ -1,0 +1,85 @@
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead class="table-light">
+    <tr>
+      @for (header of headers(); track header) {
+        <th scope="col">{{ header.columnTitle }}</th>
+      }
+      @if (hasAction()) {
+        <th class="text-end" scope="col">Actions</th>
+      }
+    </tr>
+    </thead>
+    <tbody>
+      @for (row of data(); track row.id) {
+        <tr>
+          @for (header of headers(); track header) {
+            @switch (header.cellType) {
+              @case ('badge-list') {
+                <td>
+                  @for (item of row[header.key]; track item.id) {
+                    <span class="badge bg-light text-dark rounded-pill">{{ item }}</span>
+                  }
+                </td>
+              }
+              @case ('date') {
+                <td>
+                  {{ row[header.key]  | date: dateFormat }}
+                </td>
+              }
+              @case ('icon') {
+                <td>
+                  <app-icon icon="{{this.getIcon(row[header.key], header)}}"></app-icon>
+                </td>
+              }
+              @case ('link') {
+                <td>
+                  @if(!row[header.urlKey] || row[header.urlKey] == '') {
+                    {{ row[header.key] }}
+                  } @else {
+                    <a href="{{ row[header.urlKey] }}">{{ row[header.key] }}</a>
+                  }
+                </td>
+              }
+              @default {
+                <td>
+                  {{ row[header.key] }}
+                </td>
+              }
+            }
+          }
+          @if (hasAction()) {
+            <td class="text-end">
+              @if (canEdit() && !row[readonlyFlag()]) {
+                <app-button
+                  [size]="'sm'"
+                  [variant]="'link'"
+                  [additionalClasses]="'me-1'"
+                  [dataCy]="'button-edit-' + row[dataCyNameKey()]"
+                  (click)="edit.emit({ action: EntryAction.edit, id: row.id })"
+                >
+                  <app-icon icon="pencil"></app-icon>
+                </app-button>
+              }
+              @if (canDelete() && !row[readonlyFlag()]) {
+                <app-button
+                  [size]="'sm'"
+                  [variant]="'link'"
+                  [additionalClasses]="'me-1 link-danger'"
+                  [dataCy]="'button-delete-'+ row[dataCyNameKey()]"
+                  (click)="delete.emit({ action: EntryAction.delete, id: row.id })"
+                >
+                  <app-icon icon="trash"></app-icon>
+                </app-button>
+              }
+            </td>
+          }
+        </tr>
+      } @empty {
+        <tr>
+          <td class="text-center" [colSpan]="getTotalColspan()">No {{ entityName() }} defined/found</td>
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/AMW_angular/io/src/app/shared/table/table.component.html
+++ b/AMW_angular/io/src/app/shared/table/table.component.html
@@ -54,7 +54,7 @@
                 <app-button
                   [size]="'sm'"
                   [variant]="'link'"
-                  [additionalClasses]="'me-1'"
+                  [additionalClasses]="'me-4 p-0'"
                   [dataCy]="'button-edit-' + row[dataCyNameKey()]"
                   (click)="edit.emit({ action: EntryAction.edit, id: row.id })"
                 >
@@ -65,7 +65,7 @@
                 <app-button
                   [size]="'sm'"
                   [variant]="'link'"
-                  [additionalClasses]="'me-1 link-danger'"
+                  [additionalClasses]="'p-0 link-danger'"
                   [dataCy]="'button-delete-'+ row[dataCyNameKey()]"
                   (click)="delete.emit({ action: EntryAction.delete, id: row.id })"
                 >

--- a/AMW_angular/io/src/app/shared/table/table.component.scss
+++ b/AMW_angular/io/src/app/shared/table/table.component.scss
@@ -1,0 +1,3 @@
+.table-fixed {
+  table-layout: fixed;
+}

--- a/AMW_angular/io/src/app/shared/table/table.component.spec.ts
+++ b/AMW_angular/io/src/app/shared/table/table.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TableColumnType, TableComponent } from './table.component';
+import { ComponentRef } from '@angular/core';
+
+describe('TableComponent', () => {
+  let component: TableComponent<any>;
+  let componentRef: ComponentRef<TableComponent<any>>;
+  let fixture: ComponentFixture<TableComponent<any>>;
+
+  const header: TableColumnType = {
+    key: 'name',
+    columnTitle: 'Name',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TableComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TableComponent);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('entityName', 'name');
+    componentRef.setInput('headers', [header]);
+    componentRef.setInput('data', []);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/AMW_angular/io/src/app/shared/table/table.component.ts
+++ b/AMW_angular/io/src/app/shared/table/table.component.ts
@@ -1,0 +1,55 @@
+import { Component, computed, input, output } from '@angular/core';
+import { ButtonComponent } from '../button/button.component';
+import { IconComponent } from '../icon/icon.component';
+import { DATE_FORMAT } from '../../core/amw-constants';
+import { DatePipe } from '@angular/common';
+
+export type TableCellType = 'badge-list' | 'date' | 'icon' | 'link';
+
+export interface TableColumnType<T = any> {
+  key: keyof T;
+  columnTitle: string;
+  cellType?: TableCellType;
+  iconMapping?: { value: any; icon: string }[];
+  urlKey?: keyof T;
+  nameKey?: keyof T;
+}
+
+export enum EntryAction {
+  edit = 'edit',
+  delete = 'delete',
+}
+
+export interface EntryActionOutput {
+  action: EntryAction;
+  id: number;
+}
+@Component({
+  selector: 'app-table',
+  templateUrl: './table.component.html',
+  standalone: true,
+  imports: [ButtonComponent, IconComponent, DatePipe],
+})
+export class TableComponent<T> {
+  entityName = input.required<string>();
+  headers = input.required<TableColumnType<T>[]>();
+  dataCyNameKey = input<keyof T>();
+  readonlyFlag = input<keyof T>();
+  data = input.required<any[]>();
+  canEdit = input<boolean>(false);
+  canDelete = input<boolean>(false);
+  hasAction = computed(() => this.canEdit() || this.canDelete());
+  edit = output<EntryActionOutput>();
+  delete = output<EntryActionOutput>();
+  protected readonly EntryAction = EntryAction;
+  dateFormat = DATE_FORMAT;
+
+  getTotalColspan() {
+    return this.headers().length + (this.hasAction() ? 1 : 0);
+  }
+
+  getIcon(cellValue: any, header: TableColumnType): string | undefined {
+    const mapping = header.iconMapping?.find((m) => m.value === cellValue);
+    return mapping?.icon;
+  }
+}

--- a/AMW_angular/io/src/app/shared/table/table.component.ts
+++ b/AMW_angular/io/src/app/shared/table/table.component.ts
@@ -27,6 +27,7 @@ export interface EntryActionOutput {
 @Component({
   selector: 'app-table',
   templateUrl: './table.component.html',
+  styleUrl: './table.component.scss',
   standalone: true,
   imports: [ButtonComponent, IconComponent, DatePipe],
 })

--- a/AMW_angular/io/src/styles.scss
+++ b/AMW_angular/io/src/styles.scss
@@ -54,5 +54,4 @@ $toast-padding-y: 0;
   min-height: 20vh;
   max-height: 60vh;
   overflow-y: auto;
-
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
@@ -2,12 +2,11 @@ package ch.puzzle.itc.mobiliar.business.apps.boundary;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import java.util.List;
 
 public interface ListAppsUseCase {
 
-    Tuple<List<ResourceWithRelations>, Long> appsFor(Integer startIndex, Integer maxResults, String filter, Integer releaseId) throws NotFoundException;
+    List<ResourceWithRelations> appsFor(String filter, Integer releaseId) throws NotFoundException;
 
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
@@ -14,12 +14,8 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelation
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.common.exception.AMWException;
-import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
-import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
+import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -46,9 +42,14 @@ public class AppsService implements ListAppsUseCase, AddAppServerUseCase, AddApp
     private ResourceTypeRepository resourceTypeRepository;
 
     @Override
-    public Tuple<List<ResourceWithRelations>, Long> appsFor(Integer startIndex, Integer maxResults, String filter, Integer releaseId) throws NotFoundException {
+    public List<ResourceWithRelations> appsFor( String filter, Integer releaseId) throws NotFoundException {
         ReleaseEntity release = releaseLocator.getReleaseById(releaseId);
-        return resourceRelations.getAppServersWithApplications(startIndex, maxResults, filter, release);
+        return resourceRelations.getAppServersWithApplications(filter, release);
+    }
+
+    public List<ResourceWithRelations> paginateList(List<ResourceWithRelations> list, Integer maxResultsPerPage, Integer startIndex) {
+        Integer endIndex = Math.min(startIndex + maxResultsPerPage, list.size());
+        return list.subList(startIndex, endIndex);
     }
 
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.common.util.ApplicationServerContainer;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 /**
  * The ScreenDomainService for Applist Screens
@@ -38,24 +37,22 @@ public class ApplistScreenDomainService {
     @Inject
     private ApplistScreenDomainServiceQueries queries;
 
-    Tuple<List<ResourceEntity>, Long> getApplicationServerResources(Integer startIndex, Integer maxResults, String filter) {
-        return queries.getAppServersWithApps(startIndex, maxResults, filter);
+    public List<ResourceEntity> getAppServerResourcesWithApplications(String filter) {
+        List<ResourceEntity>  result = queries.getAppServersWithApps(filter);
+        return filterAppServersResourcesWithApplications(result);
     }
 
-
-    public Tuple<List<ResourceEntity>, Long> getAppServerResourcesWithApplications(Integer startIndex, Integer maxResults, String filter, boolean withAppServerContainer) {
-        Tuple<List<ResourceEntity>, Long>  result = getApplicationServerResources(startIndex, maxResults, filter);
-        List<ResourceEntity> appServerList = result.getA();
+    private static List<ResourceEntity> filterAppServersResourcesWithApplications( List<ResourceEntity> appServerList) {
         for (ResourceEntity as : appServerList) {
             if (as.getName().equals(ApplicationServerContainer.APPSERVERCONTAINER.getDisplayName())) {
-                if (!withAppServerContainer || as.getConsumedMasterRelations().isEmpty()) {
+                if (as.getConsumedMasterRelations().isEmpty()) {
                     appServerList.remove(as);
                     break;
                 }
                 ;
             }
         }
-        return new Tuple<List<ResourceEntity>, Long>(appServerList, result.getB());
+        return appServerList;
     }
 
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -29,7 +29,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelation
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
@@ -50,11 +49,9 @@ public class ResourceRelations {
     ResourceDependencyResolverService dependencyResolverService;
 
     @HasPermission(permission = Permission.APP_AND_APPSERVER_LIST)
-    public Tuple<List<ResourceWithRelations>, Long> getAppServersWithApplications(Integer startIndex, Integer maxResults, String filter, ReleaseEntity release) {
-        Tuple<List<ResourceEntity>, Long> result = applistScreenDomainService.getAppServerResourcesWithApplications(startIndex, maxResults, filter, true);
-        List<ResourceEntity> appServersWithAllApplications = result.getA();
-        List<ResourceWithRelations> filteredResult = filterAppServersByRelease(release, appServersWithAllApplications);
-        return new Tuple<>(filteredResult, result.getB());
+    public List<ResourceWithRelations> getAppServersWithApplications(String filter, ReleaseEntity release) {
+        List<ResourceEntity> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter);
+        return filterAppServersByRelease(release, result);
     }
 
     @TransactionAttribute(TransactionAttributeType.REQUIRED)

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceTypeLocator.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceTypeLocator.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceTypeDomainService;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceType;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
+import ch.puzzle.itc.mobiliar.common.exception.ValidationException;
 
 @Stateless
 public class ResourceTypeLocator {
@@ -49,7 +50,7 @@ public class ResourceTypeLocator {
         return resourceTypeDomainService.getAllResourceTypesWithoutChildren();
     }
 
-    public ResourceTypeEntity getResourceTypeByName(String resourceTypeName) {
+    public ResourceTypeEntity getResourceTypeByName(String resourceTypeName) throws ValidationException {
         return resourceTypeDomainService.getUniqueResourceTypeByName(resourceTypeName);
     }
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceTypeLocator.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceTypeLocator.java
@@ -49,6 +49,10 @@ public class ResourceTypeLocator {
         return resourceTypeDomainService.getAllResourceTypesWithoutChildren();
     }
 
+    public ResourceTypeEntity getResourceTypeByName(String resourceTypeName) {
+        return resourceTypeDomainService.getUniqueResourceTypeByName(resourceTypeName);
+    }
+
     public List<ResourceTypeEntity> getPredefinedResourceTypes() {
         return resourceTypeDomainService.getResourceTypes()
                 .stream()

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
@@ -151,7 +151,7 @@ public class ResourceTypeDomainService {
 		return resourceType != null ? resourceType.getId() : null;
 	}
 
-	private ResourceTypeEntity getUniqueResourceTypeByName(String resourceTypeName){
+	public ResourceTypeEntity getUniqueResourceTypeByName(String resourceTypeName){
 		ResourceTypeEntity resourceType = null;
 		try {
 			Query searchUniqueResourceTypeQuery = queries.searchResourceTypeByNameCaseInsensitive(resourceTypeName);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/control/ResourceTypeDomainService.java
@@ -37,6 +37,7 @@ import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
 import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
+import ch.puzzle.itc.mobiliar.common.exception.ValidationException;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import org.apache.commons.lang3.StringUtils;
 
@@ -116,7 +117,7 @@ public class ResourceTypeDomainService {
 	 * @throws ResourceTypeNotFoundException
 	 */
 	@HasPermission(permission = Permission.RESOURCETYPE, action = Action.CREATE)
-	public ResourceType addResourceType(String newResourceTypeName, Integer parentId) throws ElementAlreadyExistsException, ResourceTypeNotFoundException {
+	public ResourceType addResourceType(String newResourceTypeName, Integer parentId) throws ElementAlreadyExistsException, ResourceTypeNotFoundException, ValidationException {
 
 		ResourceType result = null;
 		ResourceTypeEntity resourceType = getUniqueResourceTypeByName(newResourceTypeName);
@@ -146,13 +147,16 @@ public class ResourceTypeDomainService {
 	 * @param resourceTypeName
 	 * @return
 	 */
-	public Integer getResourceTypeIdByResourceTypeName(String resourceTypeName) {
+	public Integer getResourceTypeIdByResourceTypeName(String resourceTypeName) throws ValidationException {
 		ResourceTypeEntity resourceType = getUniqueResourceTypeByName(resourceTypeName);
 		return resourceType != null ? resourceType.getId() : null;
 	}
 
-	public ResourceTypeEntity getUniqueResourceTypeByName(String resourceTypeName){
+	public ResourceTypeEntity getUniqueResourceTypeByName(String resourceTypeName) throws ValidationException {
 		ResourceTypeEntity resourceType = null;
+		if (StringUtils.isEmpty(resourceTypeName)) {
+			throw new ValidationException("Resource type name must not be null or blank");
+		}
 		try {
 			Query searchUniqueResourceTypeQuery = queries.searchResourceTypeByNameCaseInsensitive(resourceTypeName);
 			resourceType = (ResourceTypeEntity) searchUniqueResourceTypeQuery.getSingleResult();

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -30,7 +30,6 @@ import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.usersettings.control.UserSettingsService;
 import ch.puzzle.itc.mobiliar.business.usersettings.entity.UserSettingsEntity;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,12 +82,20 @@ public class ResourceRelationsTest {
 
     @Test
     public void testGetAppServersWithApplications() throws Exception {
+        ResourceEntity as2 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as2.getResourceGroup()).thenReturn(asGrp);
+
+        ResourceEntity as3 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as3.getResourceGroup()).thenReturn(asGrp);
+
+        ResourceEntity as4 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as4.getResourceGroup()).thenReturn(asGrp);
+
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
-        List<ResourceEntity> aslist = Arrays.asList(as);
-        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(),
-                Mockito.isNull(), Mockito.isNull(), Mockito.anyBoolean())).thenReturn(new Tuple<>(aslist,0L));
-        service.getAppServersWithApplications(null, null, null, release);
+        List<ResourceEntity> aslist = Arrays.asList(as,as2,as3,as4);
+        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull())).thenReturn(aslist);
+        service.getAppServersWithApplications(null, release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }
 

--- a/AMW_docker/README.md
+++ b/AMW_docker/README.md
@@ -1,6 +1,6 @@
 # Liima Docker image
 
-This image is meant to run liima code quickly on widlfly server provided on docker. 
+This image is meant to run liima code quickly on wildfly server provided on docker. 
 Data is stored in the embedded h2 database in the container and it will be lost if the container is removed.
 
 To run latest code on docker, build the latest ear package:

--- a/AMW_e2e/cypress/e2e/settings/functions/crud.cy.js
+++ b/AMW_e2e/cypress/e2e/settings/functions/crud.cy.js
@@ -1,5 +1,4 @@
 describe("Functions -CRUD", () => {
-
   /**
    * Test scenario:
    * 1. adding a function without content should not be possible
@@ -21,29 +20,28 @@ describe("Functions -CRUD", () => {
     cy.get('[data-cy="button-add"]').click();
     cy.get("#name").type("testFunction");
     cy.get('[data-cy="button-save"]').should("be.disabled");
-    cy.get('.cm-activeLine').invoke('text', "testContent");
+    cy.get(".cm-activeLine").invoke("text", "testContent");
     cy.get('[data-cy="button-save"]').click();
     cy.contains("Function saved successfully.");
     cy.get('[data-cy="button-add"]').click();
     cy.get("#name").type("testFunction");
-    cy.get('.cm-activeLine').invoke('text', "differentContent");
+    cy.get(".cm-activeLine").invoke("text", "differentContent");
     cy.get('[data-cy="button-save"]').click();
     cy.contains("Function with same name already exists");
     cy.get('[data-cy="button-add"]').click();
-    cy.get('.cm-activeLine').invoke('text', "testContent");
+    cy.get(".cm-activeLine").invoke("text", "testContent");
     cy.get('[data-cy="button-save"]').should("be.disabled");
     cy.get("#name").type("differentFunction");
     cy.get('[data-cy="button-save"]').click({ force: true });
-    cy.get('[data-cy="icon-delete"]').first().click();
+    cy.get('[data-cy="button-delete-testFunction"]').first().click();
     cy.get('[data-cy="button-delete"]').click();
     cy.contains("Function deleted");
-    cy.get('[data-cy="icon-delete"]').first().click();
+    cy.get('[data-cy="button-delete-differentFunction"]').first().click();
     cy.get('[data-cy="button-delete"]').click();
     cy.contains("Function deleted");
   });
 
   it("should create, edit, compare and delete a function", () => {
-
     /**
      * Test scenario:
      * 1. adding a function without content should not be possible
@@ -64,19 +62,19 @@ describe("Functions -CRUD", () => {
     cy.get('[data-cy="button-add"]').click();
     cy.get("#name").type("testFunctionEdit");
     cy.get('[data-cy="button-save"]').should("be.disabled");
-    cy.get('.cm-activeLine').invoke('text', "testContentBla");
+    cy.get(".cm-activeLine").invoke("text", "testContentBla");
     cy.get('[data-cy="button-save"]').click();
     cy.contains("Function saved successfully.");
-    cy.get('[data-cy="button-edit"]').click();
-    cy.get('.cm-activeLine').invoke('text', "{enter}differentContent");
+    cy.get('[data-cy="button-edit-testFunctionEdit"]').click();
+    cy.get(".cm-activeLine").invoke("text", "{enter}differentContent");
     cy.get('[data-cy="button-save"]').click({ force: true });
     cy.contains("Function saved successfully.");
-    cy.get('[data-cy="button-edit"]').click();
+    cy.get('[data-cy="button-edit-testFunctionEdit"]').click();
     cy.get('[data-cy="button-dropdown"]').click();
-    cy.get('.dropdown-item').first().click();
-    cy.get('app-diff-editor').should('be.visible');
-    cy.get('[data-cy="button-cancel"]').click({force: true});
-    cy.get('[data-cy="icon-delete"]').first().click();
+    cy.get(".dropdown-item").first().click();
+    cy.get("app-diff-editor").should("be.visible");
+    cy.get('[data-cy="button-cancel"]').click({ force: true });
+    cy.get('[data-cy="button-delete-testFunctionEdit"]').first().click();
     cy.get('[data-cy="button-delete"]').click();
     cy.contains("Function deleted");
   });

--- a/AMW_e2e/cypress/e2e/settings/property-types/crud.cy.js
+++ b/AMW_e2e/cypress/e2e/settings/property-types/crud.cy.js
@@ -30,11 +30,13 @@ describe("PropertyTypes -CRUD", () => {
     cy.get("#regex").type("sd");
     cy.get('[data-cy="button-save"]').click();
     cy.contains("Property type already exists.");
-    cy.get('[data-cy="edit-test-property-type"]').click({ force: true });
+    cy.get('[data-cy="button-edit-test-property-type"]').click({ force: true });
     cy.get("#encrypted").click();
     cy.get('[data-cy="button-save"]').click();
     cy.contains("Property type saved.");
-    cy.get('[data-cy="delete-test-property-type"]').click({ force: true });
+    cy.get('[data-cy="button-delete-test-property-type"]').click({
+      force: true,
+    });
     cy.get('[data-cy="button-delete"]').click();
     cy.contains("Property type deleted.");
   });

--- a/AMW_e2e/cypress/e2e/settings/tags/crud.cy.js
+++ b/AMW_e2e/cypress/e2e/settings/tags/crud.cy.js
@@ -25,9 +25,9 @@ describe("Tags -CRUD", () => {
     cy.get("#tagName").type("other-tag");
     cy.get('[data-cy="button-add"]').click();
     cy.get("#tagName").should("be.empty");
-    cy.get('[data-cy="delete-other-tag"]').click();
+    cy.get('[data-cy="button-delete-other-tag"]').click();
     cy.contains("Tag deleted");
-    cy.get('[data-cy="delete-test-tag"]').click();
+    cy.get('[data-cy="button-delete-test-tag"]').click();
     cy.contains("Tag deleted");
   });
 });

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
@@ -1,12 +1,9 @@
 package ch.mobi.itc.mobiliar.rest.apps;
 
 import ch.mobi.itc.mobiliar.rest.dtos.AppAppServerDTO;
-import ch.mobi.itc.mobiliar.rest.dtos.AppDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.AppServerDTO;
 import ch.puzzle.itc.mobiliar.business.apps.boundary.*;
-import ch.puzzle.itc.mobiliar.business.releasing.boundary.ReleaseLocator;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
-import ch.puzzle.itc.mobiliar.business.releasing.entity.ReleaseEntity;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
 import ch.puzzle.itc.mobiliar.common.util.Tuple;
 import io.swagger.annotations.Api;
@@ -20,6 +17,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.*;
 
 import javax.enterprise.context.RequestScoped;
@@ -29,6 +27,8 @@ import javax.inject.Inject;
 @RequestScoped
 @Path("/apps")
 @Api(value = "/apps", description = "Application servers and apps")
+@Consumes(APPLICATION_JSON)
+@Produces(APPLICATION_JSON)
 public class AppsRest {
 
     @Inject

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
@@ -5,7 +5,6 @@ import ch.mobi.itc.mobiliar.rest.dtos.AppServerDTO;
 import ch.puzzle.itc.mobiliar.business.apps.boundary.*;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -48,13 +47,11 @@ public class AppsRest {
     @GET
     @ApiOperation(value = "Get applicationservers and apps", notes = "Returns all apps")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getApps(@QueryParam("start") Integer start,
-                            @QueryParam("limit") Integer limit,
-                            @QueryParam("appServerName") String filter,
+    public Response getApps(@QueryParam("appServerName") String filter,
                             @NotNull @QueryParam("releaseId") Integer releaseId) throws NotFoundException {
-        Tuple<List<ResourceWithRelations>, Long> result = listAppsUseCase.appsFor(start, limit, filter, releaseId);
+        List<ResourceWithRelations> result = listAppsUseCase.appsFor(filter, releaseId);
 
-        return Response.status(OK).entity(appServersToResponse(result.getA())).header("X-total-count", result.getB()).build();
+        return Response.status(OK).entity(appServersToResponse(result)).build();
     }
 
     private List<AppServerDTO> appServersToResponse(List<ResourceWithRelations> apps) {

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceTypesRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceTypesRest.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 
@@ -74,14 +75,8 @@ public class ResourceTypesRest {
     @Path("/resourceTypes/{name}")
     @GET
     @ApiOperation(value = "Get a resource type by name")
-    public ResourceTypeDTO getResourceTypeByName(@PathParam("name") String name) throws NotFoundException, ValidationException {
-        if (StringUtils.isEmpty(name)) {
-            throw new ValidationException("Resource type name must not be null or blank");
-        }
+    public ResourceTypeDTO getResourceTypeByName(@NotNull @PathParam("name") String name) throws ValidationException {
         ResourceTypeEntity resourceType = resourceTypeLocator.getResourceTypeByName(name);
-        if (resourceType == null) {
-            throw new NotFoundException("Resource type '" + name + "' not found");
-        }
         return new ResourceTypeDTO(resourceType);
     }
 

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceTypesRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceTypesRest.java
@@ -33,6 +33,7 @@ import ch.mobi.itc.mobiliar.rest.dtos.ResourceTypeDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.ResourceTypeRequestDTO;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.boundary.ResourceTypeLocator;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceTypeDomainService;
+import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
 import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
 import ch.puzzle.itc.mobiliar.common.exception.ValidationException;
@@ -68,6 +69,20 @@ public class ResourceTypesRest {
         return resourceTypeLocator.getAllResourceTypes().stream()
                 .map(ResourceTypeDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    @Path("/resourceTypes/{name}")
+    @GET
+    @ApiOperation(value = "Get a resource type by name")
+    public ResourceTypeDTO getResourceTypeByName(@PathParam("name") String name) throws NotFoundException, ValidationException {
+        if (StringUtils.isEmpty(name)) {
+            throw new ValidationException("Resource type name must not be null or blank");
+        }
+        ResourceTypeEntity resourceType = resourceTypeLocator.getResourceTypeByName(name);
+        if (resourceType == null) {
+            throw new NotFoundException("Resource type '" + name + "' not found");
+        }
+        return new ResourceTypeDTO(resourceType);
     }
 
     @Path("/predefinedResourceTypes")

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/common/ResourceTypeDataProvider.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/common/ResourceTypeDataProvider.java
@@ -35,10 +35,7 @@ import javax.inject.Named;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.control.ResourceTypeDomainService;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceType;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
-import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
-import ch.puzzle.itc.mobiliar.common.exception.NotAuthorizedException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
+import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.NameChecker;
 import ch.puzzle.itc.mobiliar.presentation.util.GlobalMessageAppender;
 
@@ -153,8 +150,10 @@ public class ResourceTypeDataProvider implements Serializable {
 					} else {
 						throw e;
 					}
-				}
-			}
+				} catch (ValidationException e) {
+					GlobalMessageAppender.addErrorMessage(e.getMessage());
+                }
+            }
 		} catch (ResourceTypeNotFoundException e) {
 			String message = "Could not find resourcetype.";
 			GlobalMessageAppender.addErrorMessage(message);


### PR DESCRIPTION
Can you please check if my changes are ok?I tried to make all pages look the same but there are still some open issues.

Can you please create all future tables the same look please?

### Settings

- [x] Opening the settings page opens the environments page, but it isn't selected in the menu to the right.
- [x] When opening a settings page, tabt gets renamed to Settings and stays that way when switching to other pages. I would be nice it every page would write to the table title in the following schema: <page title> - Liima
- [x] There is an error when saving a new function:
```
Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden.
Element with focus: button
```
- [x] When creating or changing a release, the saved and displayed release will always be one day before the date selected. E.g. entring 04.01.2025 will be saved as 03.01.2025.

### Apps page
- [x] Somehow the table has a lighter gray for the table striping than the other pages. Also the table header is colored but not on the other pages.
- [x] With "Add Application" all resources can be select instead of just AppServers, same happens on the deployment page.
- [x] When saving, the loading spinner doesn't disappear and the page has to be reloaded. 
- [x] Can the table filters please be added to the url, so the page can be bookmarked?
- [x] If an AppServer or App is created with a name of any existing resource, an empty toast error is shown.
- [x] Can you please decrease the margines between the apps and the appServers in the table, so it gets more compact.
- [x] Searching for an appServer/app doesn't reload the pagination and shows no result when clicked.

### Server page
- [x] Can the table filters please be added to the url, so the page can be bookmarked?
- [x] Same as on the Apps page, the table header is gray and the table stiping is lighter then the on the settings page.

### Resources page
- [x] Could resource types that have resource not be indente but instead align the names and shift the + sign to the left?

Please push commits to this branch to fix the open issues and the check them off.
