### PR TITLE
Bugfix/1077 apps page reload pagination

### DIFF
--- a/AMW_angular/io/src/app/apps/apps.component.html
+++ b/AMW_angular/io/src/app/apps/apps.component.html
@@ -37,17 +37,6 @@
         <div class="card-body">
           <app-apps-servers-list [appServers]="appServers()"></app-apps-servers-list>
         </div>
-        <div class="card-footer py-1">
-          <div class="row bg-light align-items-center">
-            <app-pagination
-              [currentPage]="currentPage()"
-              [lastPage]="lastPage()"
-              (doSetMax)="setMaxResultsPerPage($event)"
-              (doSetOffset)="setNewOffset($event)"
-            >
-            </app-pagination>
-          </div>
-        </div>
         }
       </div>
     </div>

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -66,7 +66,7 @@ export class AppsComponent implements OnInit, OnDestroy {
 
   showLoader = signal(false);
   isLoading = computed(() => {
-    return this.appServers() === undefined || this.showLoader();
+    return this.appServers() === undefined || this.appServers() === null || this.showLoader();
   });
 
   permissions = computed(() => {

--- a/AMW_angular/io/src/app/apps/apps.component.ts
+++ b/AMW_angular/io/src/app/apps/apps.component.ts
@@ -12,7 +12,6 @@ import { switchMap, takeUntil } from 'rxjs/operators';
 import { ToastService } from '../shared/elements/toast/toast.service';
 import { AppServer } from './app-server';
 import { AppsServersListComponent } from './apps-servers-list/apps-servers-list.component';
-import { PaginationComponent } from '../shared/pagination/pagination.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { AppServerAddComponent } from './app-server-add/app-server-add.component';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
@@ -33,7 +32,6 @@ import { ActivatedRoute, Router } from '@angular/router';
     IconComponent,
     LoadingIndicatorComponent,
     PageComponent,
-    PaginationComponent,
     ButtonComponent,
   ],
   templateUrl: './apps.component.html',
@@ -80,9 +78,6 @@ export class AppsComponent implements OnInit, OnDestroy {
       return { canCreateApp: false, canCreateAppServer: false, canViewAppList: false };
     }
   });
-
-  currentPage = computed(() => Math.floor(this.appsService.offset() / this.appsService.limit()) + 1);
-  lastPage = computed(() => Math.ceil(this.appsService.count() / this.appsService.limit()));
 
   constructor() {
     toObservable(this.upcomingRelease)
@@ -155,17 +150,6 @@ export class AppsComponent implements OnInit, OnDestroy {
         },
       });
     this.showLoader.set(false);
-  }
-
-  setMaxResultsPerPage(max: number) {
-    this.appsService.limit.set(max);
-    this.appsService.offset.set(0);
-    this.appsService.refreshData();
-  }
-
-  setNewOffset(offset: number) {
-    this.appsService.offset.set(offset);
-    this.appsService.refreshData();
   }
 
   updateFilter(values: { filter: string; releaseId: number }) {

--- a/AMW_angular/io/src/app/apps/apps.service.ts
+++ b/AMW_angular/io/src/app/apps/apps.service.ts
@@ -19,12 +19,12 @@ export class AppsService extends BaseService {
   filter = signal<string>(null);
   releaseId: WritableSignal<number | undefined> = signal(undefined);
   private apps$: Observable<AppServer[]> = this.reload$.pipe(
-    startWith(null),
     switchMap(() => this.getApps(this.offset(), this.limit(), this.filter(), this.releaseId())),
+    startWith(null),
     shareReplay(1),
   );
   count = signal(0);
-  apps = toSignal(this.apps$, { initialValue: [] as AppServer[] });
+  apps = toSignal(this.apps$, { initialValue: null as AppServer[] });
 
   constructor() {
     super();

--- a/AMW_angular/io/src/app/apps/apps.service.ts
+++ b/AMW_angular/io/src/app/apps/apps.service.ts
@@ -14,16 +14,13 @@ export class AppsService extends BaseService {
 
   private reload$ = new Subject<AppServer[]>();
 
-  offset = signal(0);
-  limit = signal(10);
   filter = signal<string>(null);
   releaseId: WritableSignal<number | undefined> = signal(undefined);
   private apps$: Observable<AppServer[]> = this.reload$.pipe(
-    switchMap(() => this.getApps(this.offset(), this.limit(), this.filter(), this.releaseId())),
+    switchMap(() => this.getApps(this.filter(), this.releaseId())),
     startWith(null),
     shareReplay(1),
   );
-  count = signal(0);
   apps = toSignal(this.apps$, { initialValue: null as AppServer[] });
 
   constructor() {
@@ -34,18 +31,10 @@ export class AppsService extends BaseService {
     this.reload$.next([]);
   }
 
-  private getApps(offset: number, limit: number, filter: string, releaseId: number | undefined) {
+  private getApps(filter: string, releaseId: number | undefined) {
     if (!releaseId) return of([]);
 
     let urlParams = '';
-    if (offset !== null) {
-      urlParams = `start=${offset}&`;
-    }
-
-    if (limit !== null) {
-      urlParams += `limit=${limit}&`;
-    }
-
     if (filter !== undefined && filter !== null && filter !== '') {
       urlParams += `appServerName=${filter}&`;
     }
@@ -58,11 +47,6 @@ export class AppsService extends BaseService {
       .pipe(catchError(this.handleError))
       .pipe(
         map((response: HttpResponse<AppServer[]>) => {
-          if (response.body.length <= 0) {
-            this.count.set(0);
-          } else {
-            this.count.set(Number(response.headers.get('x-total-count')));
-          }
           return response.body;
         }),
       );

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
@@ -2,7 +2,6 @@ package ch.puzzle.itc.mobiliar.business.apps.boundary;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import java.util.List;
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/boundary/ListAppsUseCase.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface ListAppsUseCase {
 
-    Tuple<List<ResourceWithRelations>, Long> appsFor(Integer startIndex, Integer maxResults, String filter, Integer releaseId) throws NotFoundException;
+    List<ResourceWithRelations> appsFor(String filter, Integer releaseId) throws NotFoundException;
 
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
@@ -14,10 +14,7 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelation
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
-import ch.puzzle.itc.mobiliar.common.exception.AMWException;
-import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
-import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
+import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
@@ -48,7 +45,13 @@ public class AppsService implements ListAppsUseCase, AddAppServerUseCase, AddApp
     @Override
     public Tuple<List<ResourceWithRelations>, Long> appsFor(Integer startIndex, Integer maxResults, String filter, Integer releaseId) throws NotFoundException {
         ReleaseEntity release = releaseLocator.getReleaseById(releaseId);
-        return resourceRelations.getAppServersWithApplications(startIndex, maxResults, filter, release);
+        Tuple<List<ResourceWithRelations>, Long> result = resourceRelations.getAppServersWithApplications(filter, release);
+        return new Tuple<>(paginateList(result.getA(),maxResults, startIndex), result.getB());
+    }
+
+    public List<ResourceWithRelations> paginateList(List<ResourceWithRelations> list, Integer maxResultsPerPage, Integer startIndex) {
+        Integer endIndex = Math.min(startIndex + maxResultsPerPage, list.size());
+        return list.subList(startIndex, endIndex);
     }
 
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
@@ -16,7 +16,6 @@ import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
 import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/apps/control/AppsService.java
@@ -43,10 +43,9 @@ public class AppsService implements ListAppsUseCase, AddAppServerUseCase, AddApp
     private ResourceTypeRepository resourceTypeRepository;
 
     @Override
-    public Tuple<List<ResourceWithRelations>, Long> appsFor(Integer startIndex, Integer maxResults, String filter, Integer releaseId) throws NotFoundException {
+    public List<ResourceWithRelations> appsFor( String filter, Integer releaseId) throws NotFoundException {
         ReleaseEntity release = releaseLocator.getReleaseById(releaseId);
-        Tuple<List<ResourceWithRelations>, Long> result = resourceRelations.getAppServersWithApplications(filter, release);
-        return new Tuple<>(paginateList(result.getA(),maxResults, startIndex), result.getB());
+        return resourceRelations.getAppServersWithApplications(filter, release);
     }
 
     public List<ResourceWithRelations> paginateList(List<ResourceWithRelations> list, Integer maxResultsPerPage, Integer startIndex) {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -38,10 +38,9 @@ public class ApplistScreenDomainService {
     @Inject
     private ApplistScreenDomainServiceQueries queries;
 
-    public Tuple<List<ResourceEntity>, Long> getAppServerResourcesWithApplications(String filter, boolean withAppServerContainer) {
-        Tuple<List<ResourceEntity>, Long>  result = queries.getAppServersWithApps(filter);
-        List<ResourceEntity> appServerList = filterAppServersResourcesWithApplications(withAppServerContainer, result.getA());
-      return new Tuple<>(appServerList, (long) appServerList.size());
+    public List<ResourceEntity> getAppServerResourcesWithApplications(String filter, boolean withAppServerContainer) {
+        List<ResourceEntity>  result = queries.getAppServersWithApps(filter);
+        return filterAppServersResourcesWithApplications(withAppServerContainer, result);
     }
 
     private static List<ResourceEntity> filterAppServersResourcesWithApplications(boolean withAppServerContainer, List<ResourceEntity> appServerList) {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -37,15 +37,15 @@ public class ApplistScreenDomainService {
     @Inject
     private ApplistScreenDomainServiceQueries queries;
 
-    public List<ResourceEntity> getAppServerResourcesWithApplications(String filter, boolean withAppServerContainer) {
+    public List<ResourceEntity> getAppServerResourcesWithApplications(String filter) {
         List<ResourceEntity>  result = queries.getAppServersWithApps(filter);
-        return filterAppServersResourcesWithApplications(withAppServerContainer, result);
+        return filterAppServersResourcesWithApplications(result);
     }
 
-    private static List<ResourceEntity> filterAppServersResourcesWithApplications(boolean withAppServerContainer, List<ResourceEntity> appServerList) {
+    private static List<ResourceEntity> filterAppServersResourcesWithApplications( List<ResourceEntity> appServerList) {
         for (ResourceEntity as : appServerList) {
             if (as.getName().equals(ApplicationServerContainer.APPSERVERCONTAINER.getDisplayName())) {
-                if (!withAppServerContainer || as.getConsumedMasterRelations().isEmpty()) {
+                if (as.getConsumedMasterRelations().isEmpty()) {
                     appServerList.remove(as);
                     break;
                 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.common.util.ApplicationServerContainer;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 /**
  * The ScreenDomainService for Applist Screens

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainService.java
@@ -38,14 +38,13 @@ public class ApplistScreenDomainService {
     @Inject
     private ApplistScreenDomainServiceQueries queries;
 
-    Tuple<List<ResourceEntity>, Long> getApplicationServerResources(Integer startIndex, Integer maxResults, String filter) {
-        return queries.getAppServersWithApps(startIndex, maxResults, filter);
+    public Tuple<List<ResourceEntity>, Long> getAppServerResourcesWithApplications(String filter, boolean withAppServerContainer) {
+        Tuple<List<ResourceEntity>, Long>  result = queries.getAppServersWithApps(filter);
+        List<ResourceEntity> appServerList = filterAppServersResourcesWithApplications(withAppServerContainer, result.getA());
+      return new Tuple<>(appServerList, (long) appServerList.size());
     }
 
-
-    public Tuple<List<ResourceEntity>, Long> getAppServerResourcesWithApplications(Integer startIndex, Integer maxResults, String filter, boolean withAppServerContainer) {
-        Tuple<List<ResourceEntity>, Long>  result = getApplicationServerResources(startIndex, maxResults, filter);
-        List<ResourceEntity> appServerList = result.getA();
+    private static List<ResourceEntity> filterAppServersResourcesWithApplications(boolean withAppServerContainer, List<ResourceEntity> appServerList) {
         for (ResourceEntity as : appServerList) {
             if (as.getName().equals(ApplicationServerContainer.APPSERVERCONTAINER.getDisplayName())) {
                 if (!withAppServerContainer || as.getConsumedMasterRelations().isEmpty()) {
@@ -55,7 +54,7 @@ public class ApplistScreenDomainService {
                 ;
             }
         }
-        return new Tuple<List<ResourceEntity>, Long>(appServerList, result.getB());
+        return appServerList;
     }
 
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainServiceQueries.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainServiceQueries.java
@@ -33,7 +33,6 @@ import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ConsumedResourceR
 import ch.puzzle.itc.mobiliar.business.utils.JpaWildcardConverter;
 import ch.puzzle.itc.mobiliar.business.utils.database.DatabaseUtil;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 public class ApplistScreenDomainServiceQueries {
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainServiceQueries.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/applist/ApplistScreenDomainServiceQueries.java
@@ -43,16 +43,10 @@ public class ApplistScreenDomainServiceQueries {
     @Inject
     private DatabaseUtil dbUtil;
 
-
-    Tuple<List<ResourceEntity>, Long> getAppServersWithApps(Integer startIndex, Integer maxResult, String nameFilter) {
+    Tuple<List<ResourceEntity>, Long> getAppServersWithApps(String nameFilter) {
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
         Predicate p;
         boolean nameFilterIsEmpty = nameFilter == null || nameFilter.trim().isEmpty();
-
-
-
-        // Count all values before filtering
-        Long totalCount = getTotalCount(cb);
 
         // Filter and retrieve results
         CriteriaQuery<ResourceEntity> q = cb.createQuery(ResourceEntity.class);
@@ -85,15 +79,10 @@ public class ApplistScreenDomainServiceQueries {
 
         TypedQuery<ResourceEntity> query = entityManager.createQuery(q);
 
-        if (startIndex != null) {
-            query.setFirstResult(startIndex);
-        }
+        // Count all values after filtering
+        Long count = (long) query.getResultList().size();
 
-        if (maxResult != null) {
-            query.setMaxResults(maxResult);
-        }
-
-        return  new Tuple<>(query.getResultList(), totalCount);
+        return  new Tuple<>(query.getResultList(), count);
     }
 
     private Long getTotalCount(CriteriaBuilder cb) {

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -50,7 +50,7 @@ public class ResourceRelations {
 
     @HasPermission(permission = Permission.APP_AND_APPSERVER_LIST)
     public List<ResourceWithRelations> getAppServersWithApplications(String filter, ReleaseEntity release) {
-        List<ResourceEntity> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter, true);
+        List<ResourceEntity> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter);
         return filterAppServersByRelease(release, result);
     }
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -50,10 +50,9 @@ public class ResourceRelations {
     ResourceDependencyResolverService dependencyResolverService;
 
     @HasPermission(permission = Permission.APP_AND_APPSERVER_LIST)
-    public Tuple<List<ResourceWithRelations>, Long> getAppServersWithApplications(String filter, ReleaseEntity release) {
-        Tuple<List<ResourceEntity>, Long> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter, true);
-        List<ResourceWithRelations> filteredResult = filterAppServersByRelease(release, result.getA());
-        return new Tuple<>(filteredResult, (long) filteredResult.size());
+    public List<ResourceWithRelations> getAppServersWithApplications(String filter, ReleaseEntity release) {
+        List<ResourceEntity> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter, true);
+        return filterAppServersByRelease(release, result);
     }
 
     @TransactionAttribute(TransactionAttributeType.REQUIRED)

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -29,7 +29,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelation
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
 import ch.puzzle.itc.mobiliar.business.security.interceptor.HasPermission;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelations.java
@@ -50,11 +50,10 @@ public class ResourceRelations {
     ResourceDependencyResolverService dependencyResolverService;
 
     @HasPermission(permission = Permission.APP_AND_APPSERVER_LIST)
-    public Tuple<List<ResourceWithRelations>, Long> getAppServersWithApplications(Integer startIndex, Integer maxResults, String filter, ReleaseEntity release) {
-        Tuple<List<ResourceEntity>, Long> result = applistScreenDomainService.getAppServerResourcesWithApplications(startIndex, maxResults, filter, true);
-        List<ResourceEntity> appServersWithAllApplications = result.getA();
-        List<ResourceWithRelations> filteredResult = filterAppServersByRelease(release, appServersWithAllApplications);
-        return new Tuple<>(filteredResult, result.getB());
+    public Tuple<List<ResourceWithRelations>, Long> getAppServersWithApplications(String filter, ReleaseEntity release) {
+        Tuple<List<ResourceEntity>, Long> result = applistScreenDomainService.getAppServerResourcesWithApplications(filter, true);
+        List<ResourceWithRelations> filteredResult = filterAppServersByRelease(release, result.getA());
+        return new Tuple<>(filteredResult, (long) filteredResult.size());
     }
 
     @TransactionAttribute(TransactionAttributeType.REQUIRED)

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -83,14 +83,19 @@ public class ResourceRelationsTest {
     @Test
     public void testGetAppServersWithApplications() throws Exception {
         ResourceEntity as2 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as2.getResourceGroup()).thenReturn(asGrp);
+
         ResourceEntity as3 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as3.getResourceGroup()).thenReturn(asGrp);
+
         ResourceEntity as4 = Mockito.mock(ResourceEntity.class);
+        Mockito.when(as4.getResourceGroup()).thenReturn(asGrp);
 
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
         List<ResourceEntity> aslist = Arrays.asList(as,as2,as3,as4);
         Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull())).thenReturn(aslist);
-        service.getAppServersWithApplications("", release);
+        service.getAppServersWithApplications(null, release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }
 

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -30,7 +30,6 @@ import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
 import ch.puzzle.itc.mobiliar.business.usersettings.control.UserSettingsService;
 import ch.puzzle.itc.mobiliar.business.usersettings.entity.UserSettingsEntity;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -85,7 +85,7 @@ public class ResourceRelationsTest {
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
         List<ResourceEntity> aslist = Arrays.asList(as);
-        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(), Mockito.anyBoolean())).thenReturn(aslist);
+        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull())).thenReturn(aslist);
         service.getAppServersWithApplications(null, release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -86,9 +86,8 @@ public class ResourceRelationsTest {
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
         List<ResourceEntity> aslist = Arrays.asList(as);
-        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(),
-                Mockito.isNull(), Mockito.isNull(), Mockito.anyBoolean())).thenReturn(new Tuple<>(aslist,0L));
-        service.getAppServersWithApplications(null, null, null, release);
+        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(), Mockito.anyBoolean())).thenReturn(new Tuple<>(aslist,0L));
+        service.getAppServersWithApplications(null, release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }
 

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -86,7 +86,7 @@ public class ResourceRelationsTest {
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
         List<ResourceEntity> aslist = Arrays.asList(as);
-        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(), Mockito.anyBoolean())).thenReturn(new Tuple<>(aslist,0L));
+        Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull(), Mockito.anyBoolean())).thenReturn(aslist);
         service.getAppServersWithApplications(null, release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceRelationsTest.java
@@ -82,11 +82,15 @@ public class ResourceRelationsTest {
 
     @Test
     public void testGetAppServersWithApplications() throws Exception {
+        ResourceEntity as2 = Mockito.mock(ResourceEntity.class);
+        ResourceEntity as3 = Mockito.mock(ResourceEntity.class);
+        ResourceEntity as4 = Mockito.mock(ResourceEntity.class);
+
         UserSettingsEntity userSettings = Mockito.mock(UserSettingsEntity.class);
         Mockito.when(userSettingsService.getUserSettings(Mockito.anyString())).thenReturn(userSettings);
-        List<ResourceEntity> aslist = Arrays.asList(as);
+        List<ResourceEntity> aslist = Arrays.asList(as,as2,as3,as4);
         Mockito.when(applistScreenDomainService.getAppServerResourcesWithApplications(Mockito.isNull())).thenReturn(aslist);
-        service.getAppServersWithApplications(null, release);
+        service.getAppServersWithApplications("", release);
         Mockito.verify(service).filterAppServersByRelease(release, aslist);
     }
 

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
@@ -48,13 +48,11 @@ public class AppsRest {
     @GET
     @ApiOperation(value = "Get applicationservers and apps", notes = "Returns all apps")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getApps(@QueryParam("start") Integer start,
-                            @QueryParam("limit") Integer limit,
-                            @QueryParam("appServerName") String filter,
+    public Response getApps(@QueryParam("appServerName") String filter,
                             @NotNull @QueryParam("releaseId") Integer releaseId) throws NotFoundException {
-        Tuple<List<ResourceWithRelations>, Long> result = listAppsUseCase.appsFor(start, limit, filter, releaseId);
+        List<ResourceWithRelations> result = listAppsUseCase.appsFor(filter, releaseId);
 
-        return Response.status(OK).entity(appServersToResponse(result.getA())).header("X-total-count", result.getB()).build();
+        return Response.status(OK).entity(appServersToResponse(result)).build();
     }
 
     private List<AppServerDTO> appServersToResponse(List<ResourceWithRelations> apps) {

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/apps/AppsRest.java
@@ -5,7 +5,6 @@ import ch.mobi.itc.mobiliar.rest.dtos.AppServerDTO;
 import ch.puzzle.itc.mobiliar.business.apps.boundary.*;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceWithRelations;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import ch.puzzle.itc.mobiliar.common.util.Tuple;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;


### PR DESCRIPTION
**Bug**: Incorrect Pagination on the Apps Page

The pagination on the Apps page was faulty. When on the page, a list of app servers with their apps was displayed, but neither the correct number of app servers (not the selected maximum results per page) nor the correct number of pages for all results was displayed.

**Incorrect Behavior**: If the maximum number of results per page was set to 10 and there were a total of 50 results, 7 app servers were displayed on the first page, but it was indicated that there were 5 pages. On the next page, 3 app servers were displayed, etc.

**Correct Solution**: 10 app servers should be displayed per page and it should be indicated that there are 5 pages.

**Cause of the Error**: The error was in the backend. The idea was that the frontend could make a REST call and specify the following query parameters:

- start
- limit
- appServerName
- releaseId

The endpoint should then return the filtered result with the correct offset (which page am I on) and the correct maximum number of results per page.

**First Problem**: The total number of results ( `result.getB()` ) was always returned as the number of all unfiltered Resource Entities with the ResourceType = APPLICATIONSERVER. 

`ch.mobi.itc.mobiliar.rest.apps.AppsRest#getApps`:

`return Response.status(OK).entity(appServersToResponse(result.getA())).header("X-total-count", result.getB()).build();`

Solution to that would have been:

`return Response.status(OK).entity(appServersToResponse(result.getA())).header("X-total-count", result.getA().size()).build();`

**Second Problem**: Even if the total number of results had been corrected, the pagination would still not have worked. The reason for this was that the endpoint set a query that retrieved all Resource Entities with the ResourceType = APPLICATIONSERVER and the filtered name. The offset and limit were then set in the query:

```java
   if (startIndex != null) {
            query.setFirstResult(startIndex);
        }
        
    if (maxResult != null) {
            query.setMaxResults(maxResult);
        }
```



The idea was to reduce the load time by only retrieving the "paginated" results directly. However, the problem was that this already paginated list of results was filtered twice in the business logic, so that the set _start_ and _limit_ no longer matched the final list.

**Solution**: The original solution would have been to correct the pagination, but this would have increased the load time (See commit: b695fa063722f5a6e42141a63c82bb0c3e9aca06 ). Since the DB was already under load, it was decided to **remove the pagination and initially display only the first 20 app servers**, as it was in the old version.