### PR TITLE
feat: improve ui, make app table more consistent with the others

### DIFF
--- a/AMW_angular/io/src/app/apps/apps-list/apps-list-component.ts
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list-component.ts
@@ -1,16 +1,14 @@
-import { Component, Input } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { PaginationComponent } from '../../shared/pagination/pagination.component';
+import { Component, input } from '@angular/core';
 import { App } from '../app';
 
 @Component({
   selector: 'app-apps-list',
   standalone: true,
-  imports: [AsyncPipe, PaginationComponent],
+  imports: [],
   templateUrl: './apps-list.component.html',
   styleUrl: './apps-list.component.scss',
 })
 export class AppsListComponent {
-  @Input() apps: App[];
-  @Input() even: boolean;
+  apps = input.required<App[]>();
+  even = input.required<boolean>();
 }

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
@@ -1,5 +1,5 @@
 @if (apps() && apps().length > 0) {
-  <table class="table table-sm">
+  <table class="table table-sm mb-0">
     <tbody>
       @for (app of apps(); track app) {
         <tr [class.table-light]="!even()">

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.html
@@ -1,16 +1,16 @@
-@if (apps && apps.length > 0) {
-<table class="table table-sm table-borderless mb-0">
-  <tbody>
-    @for (app of apps; track app) {
-    <tr [class.table-light]="!even">
-      <td class="align-middle ps-2 w-90 border-0 py-2">
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
-      </td>
-      <td class="align-middle ps-4 w-10 border-0 py-2">
-        <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
-      </td>
-    </tr>
-    }
-  </tbody>
-</table>
+@if (apps() && apps().length > 0) {
+  <table class="table table-sm">
+    <tbody>
+      @for (app of apps(); track app) {
+        <tr [class.table-light]="!even()">
+          <td>
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.name }}</a>
+          </td>
+          <td class="text-end pe-0">
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ app.id }}">{{ app.release.name }}</a>
+          </td>
+        </tr>
+      }
+    </tbody>
+  </table>
 }

--- a/AMW_angular/io/src/app/apps/apps-list/apps-list.component.spec.ts
+++ b/AMW_angular/io/src/app/apps/apps-list/apps-list.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppsListComponent } from './apps-list-component';
+import { ComponentRef } from '@angular/core';
 
 describe('AppsListComponent', () => {
   let component: AppsListComponent;
+  let componentRef: ComponentRef<AppsListComponent>;
   let fixture: ComponentFixture<AppsListComponent>;
 
   beforeEach(async () => {
@@ -13,6 +15,9 @@ describe('AppsListComponent', () => {
 
     fixture = TestBed.createComponent(AppsListComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('apps', []);
+    componentRef.setInput('even', true);
     fixture.detectChanges();
   });
 

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -1,30 +1,30 @@
 <div class="table-responsive">
-  <table class="table table-sm table-borderless">
+  <table class="table table-sm">
     <thead class="table-light">
       <tr>
-        <th class="w-90">App Name</th>
-        <th class="w-10">Release</th>
+        <th scope="col">AS/App Name</th>
+        <th scope="col" class="text-end">Release</th>
       </tr>
     </thead>
     <tbody>
-      @for (appServer of appServers; track appServer; let even = $even) {
+      @for (appServer of appServers(); track appServer; let even = $even) {
         <tr [class.table-light]="!even">
-          <td class="align-middle w-90">
+          <td class="border-0">
             @if (!appServer.deletable) {
             <div id="appServer.id">{{ appServer.name }}</div>
             } @else {
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
-            {{ appServer.runtimeName }} ] }
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a>[
+                {{ appServer.runtimeName }} ] }
           </td>
-          <td class="align-middle w-10">
+          <td class="text-end border-0">
             <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{
               appServer.release.name
             }}</a>
           </td>
         </tr>
         @if (appServer.apps && appServer.apps.length > 0) {
-        <tr class="py-0 borderless" [class.table-light]="!even">
-          <td colspan="2" class="py-0 border-0">
+        <tr [class.table-light]="!even">
+          <td colspan="2" class="border-0 ps-4 py-0">
             <app-apps-list [apps]="appServer.apps" [even]="even"></app-apps-list>
           </td>
         </tr>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -13,8 +13,8 @@
             @if (!appServer.deletable) {
             <div id="appServer.id">{{ appServer.name }}</div>
             } @else {
-            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a>[
-                {{ appServer.runtimeName }} ] }
+            <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.id }}">{{ appServer.name }}</a> [
+            {{ appServer.runtimeName }} ] }
           </td>
           <td class="text-end border-0">
             <a href="/AMW_web/pages/editResourceView.xhtml?ctx=1&id={{ appServer.release.id }}">{{

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.html
@@ -2,7 +2,7 @@
   <table class="table table-sm">
     <thead class="table-light">
       <tr>
-        <th scope="col">AS/App Name</th>
+        <th scope="col">App Name</th>
         <th scope="col" class="text-end">Release</th>
       </tr>
     </thead>

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.spec.ts
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppsServersListComponent } from './apps-servers-list.component';
+import { ComponentRef } from '@angular/core';
 
 describe('AppsListComponent', () => {
   let component: AppsServersListComponent;
+  let componentRef: ComponentRef<AppsServersListComponent>;
   let fixture: ComponentFixture<AppsServersListComponent>;
 
   beforeEach(async () => {
@@ -13,6 +15,8 @@ describe('AppsListComponent', () => {
 
     fixture = TestBed.createComponent(AppsServersListComponent);
     component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+    componentRef.setInput('appServers', []);
     fixture.detectChanges();
   });
 

--- a/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.ts
+++ b/AMW_angular/io/src/app/apps/apps-servers-list/apps-servers-list.component.ts
@@ -1,16 +1,14 @@
-import { Component, Input } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
-import { PaginationComponent } from '../../shared/pagination/pagination.component';
+import { Component, input } from '@angular/core';
 import { AppServer } from '../app-server';
 import { AppsListComponent } from '../apps-list/apps-list-component';
 
 @Component({
   selector: 'app-apps-servers-list',
   standalone: true,
-  imports: [AsyncPipe, AppsListComponent, PaginationComponent],
+  imports: [AppsListComponent],
   templateUrl: './apps-servers-list.component.html',
   styleUrl: './apps-servers-list.component.scss',
 })
 export class AppsServersListComponent {
-  @Input() appServers: AppServer[];
+  appServers = input.required<AppServer[]>();
 }

--- a/AMW_angular/io/src/app/shared/table/table.component.html
+++ b/AMW_angular/io/src/app/shared/table/table.component.html
@@ -54,7 +54,7 @@
                 <app-button
                   [size]="'sm'"
                   [variant]="'link'"
-                  [additionalClasses]="'me-1'"
+                  [additionalClasses]="'me-4 p-0'"
                   [dataCy]="'button-edit-' + row[dataCyNameKey()]"
                   (click)="edit.emit({ action: EntryAction.edit, id: row.id })"
                 >
@@ -65,7 +65,7 @@
                 <app-button
                   [size]="'sm'"
                   [variant]="'link'"
-                  [additionalClasses]="'me-1 link-danger'"
+                  [additionalClasses]="'p-0 link-danger'"
                   [dataCy]="'button-delete-'+ row[dataCyNameKey()]"
                   (click)="delete.emit({ action: EntryAction.delete, id: row.id })"
                 >


### PR DESCRIPTION
This PR should resolve the following 2 issues:

`Apps page: Somehow the table has a lighter gray for the table striping than the other pages. Also the table header is colored but not on the other pages.`

`Apps page: Can you please decrease the margines between the apps and the appServers in the table, so it gets more compact.`

I would appreciate it if this could be checked in the review.