### PR TITLE
fix: JSF set empty string relation name instead of null, add check

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/control/ResourceRelationService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/control/ResourceRelationService.java
@@ -385,7 +385,7 @@ public class ResourceRelationService implements Serializable{
 					.getIdentifier());
 
 			for (AbstractResourceRelationEntity rel : relations) {
-				if (isMatchingRelation(relation, hasResourceIdentifier, hasResourceTypeIdentifier, rel)) {
+				if (isMatchingRelation(relation, rel)) {
 					relation.getMasterResource().removeRelation(rel);
 					relation.getSlaveResource().removeSlaveRelation(rel);
 					entityManager.remove(rel);
@@ -399,8 +399,9 @@ public class ResourceRelationService implements Serializable{
 		}
 	}
 
-	private boolean isMatchingRelation(AbstractResourceRelationEntity relation, boolean hasResourceIdentifier,
-									   boolean hasResourceTypeIdentifier, AbstractResourceRelationEntity rel) {
+	private boolean isMatchingRelation(AbstractResourceRelationEntity relation, AbstractResourceRelationEntity rel) {
+		boolean hasResourceIdentifier = relation.getIdentifier() != null;
+		boolean hasResourceTypeIdentifier = relation.getResourceRelationType().getIdentifier() != null;
 		if (hasResourceIdentifier && relation.getIdentifier().equals(rel.getIdentifier())) {
             return true;
         }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/entity/AbstractResourceRelationEntity.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/entity/AbstractResourceRelationEntity.java
@@ -84,7 +84,6 @@ public abstract class AbstractResourceRelationEntity extends HasContexts<Resourc
 	private long v;
 
 	@Getter
-	@Setter
 	@Column(nullable = true)
 	private String identifier;
 
@@ -180,6 +179,14 @@ public abstract class AbstractResourceRelationEntity extends HasContexts<Resourc
 	public String toString() {
 		return "AbstractResourceRelationEntity [id=" + id + ", masterResource=" + masterResource
 				+ ", slaveResource=" + slaveResource + "]";
+	}
+
+	public void setIdentifier(String identifier) {
+		if (identifier != null && identifier.isBlank()) {
+			// allow null but not blank
+			throw new IllegalArgumentException("Identifier of relation must not be blank");
+		}
+		this.identifier = identifier;
 	}
 
 	public String buildIdentifer() {

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/issues/Issue6111RelationIdentifierTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/issues/Issue6111RelationIdentifierTest.java
@@ -71,12 +71,12 @@ public class Issue6111RelationIdentifierTest extends TemplateProcessorBaseTest<P
 		app = builder.app;
 
 		ConsumedResourceRelationEntity adInternRelation = builder.buildConsumedRelation(app, adIntern, ForeignableOwner.AMW);
-		adInternRelation.setIdentifier("");
+		adInternRelation.setIdentifier(null);
 		ConsumedResourceRelationEntity adintern_1Relation = builder.buildConsumedRelation(app, adIntern, ForeignableOwner.AMW);
 		adintern_1Relation.setIdentifier("1");
 
 		ConsumedResourceRelationEntity adExternRelation = builder.buildConsumedRelation(app, adExtern, ForeignableOwner.AMW);
-		adExternRelation.setIdentifier("");
+		adExternRelation.setIdentifier(null);
 		ConsumedResourceRelationEntity adExtern_1Relation = builder.buildConsumedRelation(app, adExtern, ForeignableOwner.AMW);
 		adExtern_1Relation.setIdentifier("1");
 	}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcerelation/entity/AbstractResourceRelationEntityTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcerelation/entity/AbstractResourceRelationEntityTest.java
@@ -107,8 +107,9 @@ public class AbstractResourceRelationEntityTest {
 		ConsumedResourceRelationEntity relation = builder.relationFor(APP, AD);
 		assertEquals("adIntern", relation.buildIdentifer());
 
-		relation.setIdentifier("");
-		assertEquals("adIntern", relation.buildIdentifer());
+		assertThrows(IllegalArgumentException.class, () -> {
+			relation.setIdentifier("");
+		});
 	}
 	
 	@Test

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/propertyEdit/RelationDataProvider.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/propertyEdit/RelationDataProvider.java
@@ -205,9 +205,14 @@ public class RelationDataProvider implements Serializable {
         selectableItems.addAll(resourceTypes);
     }
 
-    /**
-     * @param typeName
-     */
+    public void loadResourceGroupsForType() {
+        loadResourceGroupsForType(null, null);
+    }
+
+    public void loadResourceGroupsForType(String typeName) {
+        loadResourceGroupsForType(typeName, null);
+    }
+
     public void loadResourceGroupsForType(String typeName, String identifier) {
         addApplicationToAppServerMode = false;
         addRuntimeToAppServerMode = false;

--- a/AMW_web/src/main/webapp/resources/mobi/addRelation.xhtml
+++ b/AMW_web/src/main/webapp/resources/mobi/addRelation.xhtml
@@ -34,7 +34,7 @@
                   event="click"
                   onbegin="showLoader();"
                   oncomplete="if(confirmAddRelation()){#{rich:component('addRelationPopup')}.show();} hideLoader();"
-                  listener="#{relationDataProvider.loadResourceGroupsForType(null, null)}"></a4j:ajax>
+                  listener="#{relationDataProvider.loadResourceGroupsForType()}"></a4j:ajax>
     </h:commandLink>
 
     <h:commandLink styleClass="btn light right"
@@ -83,7 +83,7 @@
                                             <div class="ellipsisRight" title="#{resType.name}">#{resType.name}</div>
                                             <a4j:ajax execute="@this" render="relationPopupContent"
                                                       oncomplete="hideLoader();restoreScrollPositions();"
-                                                      listener="#{relationDataProvider.loadResourceGroupsForType(resType.name, null)}"></a4j:ajax>
+                                                      listener="#{relationDataProvider.loadResourceGroupsForType(resType.name)}"></a4j:ajax>
                                         </h:commandLink>
                                         <ul>
                                             <ui:repeat var="subType" rendered="${relationDataProvider.isCurrentType(resType.id) or relationDataProvider.isChildCurrentType(resType.id)}"
@@ -96,7 +96,7 @@
                                                         <a4j:ajax execute="@this"
                                                                   render="relationPopupContent"
                                                                   oncomplete="hideLoader();restoreScrollPositions();"
-                                                                  listener="#{relationDataProvider.loadResourceGroupsForType(subType.name, null)}"></a4j:ajax>
+                                                                  listener="#{relationDataProvider.loadResourceGroupsForType(subType.name)}"></a4j:ajax>
                                                     </h:commandLink>
                                                 </li>
                                             </ui:repeat>


### PR DESCRIPTION
Only Wildfly is affected. The `null` passed via JSF would be set to an empty string instead of `null`. 