### PR TITLE
Feat/1109 wrap line

### DIFF
--- a/AMW_angular/io/src/app/resources/resource-edit/resource-templates/resource-template-edit.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-templates/resource-template-edit.component.html
@@ -77,24 +77,33 @@
       </div>
     </div>
     <div class="mb-3 fileContent">
-      <div class="d-flex justify-content-between align-content-center mb-1">
+      <div class="d-flex justify-content-between align-items-center mb-1">
         <div>
           <label class="form-label">Template file content</label>
         </div>
-        <app-fullscreen-toggle (fullscreenChange)="toggleFullscreen($event)"></app-fullscreen-toggle>
-
+        <div class="d-flex align-items-center">
+          <div class="form-check me-3">
+            <input class="form-check-input" type="checkbox" id="isWrapLines" [(ngModel)]="wrapLinesEnabled">
+            <label class="form-check-label" for="isWrapLines">
+              Wrap lines
+            </label>
+          </div>
+          <app-fullscreen-toggle (fullscreenChange)="toggleFullscreen($event)"></app-fullscreen-toggle>
+        </div>
       </div>
       @if (!revision) {
         <div class="editor border border-primary-subtle rounded">
           <app-code-editor
             [theme]="'light'"
             [placeholder]="'Enter your code...'"
+            [lineWrapping]="wrapLinesEnabled"
             [(ngModel)]="template.fileContent"
           ></app-code-editor>
         </div>
       } @else {
         <div class="editor border border-primary-subtle rounded">
-          <app-diff-editor [(ngModel)]="diffValue" revertControls="b-to-a"></app-diff-editor>
+          <app-diff-editor [lineWrapping]="wrapLinesEnabled" [(ngModel)]="diffValue"
+                           revertControls="b-to-a"></app-diff-editor>
         </div>
       }
     </div>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-templates/resource-template-edit.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-templates/resource-template-edit.component.ts
@@ -33,8 +33,8 @@ interface TargetPlatformModel {
     ModalHeaderComponent,
     DiffEditorComponent,
     RevisionCompareComponent,
-    FullscreenToggleComponent,
-  ],
+    FullscreenToggleComponent
+  ]
 })
 export class ResourceTemplateEditComponent implements OnInit {
   @Input() template: ResourceTemplate;
@@ -44,9 +44,10 @@ export class ResourceTemplateEditComponent implements OnInit {
 
   private templatesService = inject(ResourceTemplatesService);
   allSelectableTargetPlatforms: Signal<string[]> = toSignal(this.templatesService.getAllTargetPlatforms(), {
-    initialValue: [],
+    initialValue: []
   });
 
+  public wrapLinesEnabled: false;
   public revisions: RevisionInformation[] = [];
   public revision: ResourceTemplate;
   public selectedRevisionName: string;
@@ -58,10 +59,11 @@ export class ResourceTemplateEditComponent implements OnInit {
   });
   public diffValue = {
     original: '',
-    modified: '',
+    modified: ''
   };
 
-  constructor(public activeModal: NgbActiveModal) {}
+  constructor(public activeModal: NgbActiveModal) {
+  }
 
   ngOnInit(): void {
     if (this.template && this.template.id) {
@@ -93,7 +95,7 @@ export class ResourceTemplateEditComponent implements OnInit {
     return allTargetPlatforms.map((name) => {
       return {
         name: name,
-        selected: this.template.targetPlatforms.includes(name),
+        selected: this.template.targetPlatforms.includes(name)
       };
     });
   }
@@ -103,7 +105,7 @@ export class ResourceTemplateEditComponent implements OnInit {
     return allTargetPlatforms.map((name) => {
       return {
         name: name,
-        selected: this.revision.targetPlatforms.includes(name),
+        selected: this.revision.targetPlatforms.includes(name)
       };
     });
   }


### PR DESCRIPTION
Die Compare-with-Revision-Funktionalität wird beim Bearbeiten einer Entität eingesetzt, um diese mit einer anderen Revision zu vergleichen. Sie wird hier verwendet: 

Settings > Functions
Edit Resource Page
Templates, Edit Resource Page > Functions, ...

Füge bei Edit Resource Page > Templates das folgende Feature hinzu:   
Line Wrap Checkbox : Dass ist ähnlich wie in den IDEs. Wenn eine Zeile sehr lang ist, wird sie per Default nicht umgebrochen. Wenn es aktiv ist, wird die lange Zeile umgebrochen. Sowohl beim normalen Editor, wie auch beim Diff-Editor.