### PR TITLE
fix: improve performance of permissions table by mapping icon directly in datasource

### DIFF
--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
@@ -20,7 +20,7 @@ export class RestrictionListComponent {
       return {
         id: res.id,
         permissionName: res.permission.name,
-        permissionGlobal: res.permission.old,
+        permissionGlobal: res.permission.old ? 'check' : null,
         action: res.action,
         contextName: res.contextName,
         resourceGroupName: this.getGroupName(res.resourceGroupId),
@@ -38,10 +38,6 @@ export class RestrictionListComponent {
       key: 'permissionGlobal',
       columnTitle: 'Global',
       cellType: 'icon',
-      iconMapping: [
-        { value: true, icon: 'check' },
-        { value: false, icon: null },
-      ],
     },
     {
       key: 'action',

--- a/AMW_angular/io/src/app/shared/table/table.component.html
+++ b/AMW_angular/io/src/app/shared/table/table.component.html
@@ -29,7 +29,7 @@
               }
               @case ('icon') {
                 <td>
-                  <app-icon icon="{{ this.getIcon(row[header.key], header) }}"></app-icon>
+                  <app-icon [icon]="row[header.key]"></app-icon>
                 </td>
               }
               @case ('link') {
@@ -37,7 +37,7 @@
                   @if (!row[header.urlKey] || row[header.urlKey] === '') {
                     {{ row[header.key] }}
                   } @else {
-                    <a href="{{ row[header.urlKey] }}">{{ row[header.key] }}</a>
+                    <a [href]="row[header.urlKey]">{{ row[header.key] }}</a>
                   }
                 </td>
               }

--- a/AMW_angular/io/src/app/shared/table/table.component.ts
+++ b/AMW_angular/io/src/app/shared/table/table.component.ts
@@ -10,7 +10,6 @@ export interface TableColumnType<T = any> {
   key: keyof T;
   columnTitle: string;
   cellType?: TableCellType;
-  iconMapping?: { value: any; icon: string }[];
   urlKey?: keyof T;
   nameKey?: keyof T;
 }
@@ -47,11 +46,6 @@ export class TableComponent<T> {
 
   getTotalColspan() {
     return this.headers().length + (this.hasAction() ? 1 : 0);
-  }
-
-  getIcon(cellValue: any, header: TableColumnType): string | undefined {
-    const mapping = header.iconMapping?.find((m) => m.value === cellValue);
-    return mapping?.icon;
   }
 
   get tableClass() {


### PR DESCRIPTION
The property binding is what actually fixes it and reduces cpu und ram usage significantly.
I moved the icon mapping to using component to simplify the setup.