### PR TITLE
fix(ResourceGroupsRest): get resource with type id shadowing get resource with type name

### DIFF
--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/entity/ResourceTest.java
@@ -133,7 +133,7 @@ public class ResourceTest {
 	public void canAddResourceRelationTwice() throws ElementAlreadyExistsException{
 		ResourceRelationTypeEntity resRelationType = new ResourceRelationTypeEntity();
 		master.addConsumedResourceRelation(secondSlave, resRelationType, null, ForeignableOwner.AMW);
-		assertEquals(master.getConsumedRelation(secondSlave).getResourceRelationType(), resRelationType);
+		assertEquals(resRelationType, master.getConsumedRelation(secondSlave).getResourceRelationType());
 		master.addConsumedResourceRelation(secondSlave, resRelationType, null, ForeignableOwner.AMW);
 	}
 	

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -38,7 +38,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.control.ResourceRelationService;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ConsumedResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ProvidedResourceRelationEntity;
-import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
 import ch.puzzle.itc.mobiliar.common.util.NameChecker;
@@ -94,9 +93,6 @@ public class ResourceGroupsRest {
     private ResourceDependencyResolverService resourceDependencyResolverService;
 
     @Inject
-    private PermissionBoundary permissionBoundary;
-
-    @Inject
     private ResourceTemplatesRest resourceTemplatesRest;
 
     @Inject
@@ -108,7 +104,18 @@ public class ResourceGroupsRest {
     @GET
     @ApiOperation(value = "Get resource groups", notes = "Returns the available resource groups")
     public List<ResourceGroupDTO> getResources(
-            @ApiParam(value = "a resource type, the list should be filtered by") @QueryParam("type") String type) {
+            @ApiParam(value = "a resource type name, the list should be filtered by") @QueryParam("type") String type,
+            @ApiParam(value = "a resource type id, the list should be filtered by") @QueryParam("typeId") Integer typeId) {
+        if (type != null && typeId != null) {
+            throw new BadRequestException("You cannot filter by both type and typeId at the same");
+        };
+        if (typeId != null) {
+            return getResourceGroupsByResourceTypeId(typeId);
+        }
+        return getResources(type);
+    }
+
+    private List<ResourceGroupDTO> getResources(String type) {
         List<ResourceGroupDTO> result = new ArrayList<>();
         List<ResourceGroupEntity> resourceGroups;
         if (type != null) {
@@ -127,10 +134,7 @@ public class ResourceGroupsRest {
         return result;
     }
 
-    @GET
-    @ApiOperation(value = "Get resource groups by resource type id")
-    public List<ResourceGroupDTO> getResourceGroupsByResourceTypeId(
-            @ApiParam(value = "a resource type id, the list should be filtered by") @QueryParam("typeId") Integer typeId) {
+    private List<ResourceGroupDTO> getResourceGroupsByResourceTypeId(Integer typeId) {
         List<ResourceGroupEntity> resourceGroups;
         if (typeId != null) {
             resourceGroups = resourceGroupLocator.getGroupsForType(typeId, true, true);

--- a/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRestTest.java
+++ b/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRestTest.java
@@ -125,7 +125,7 @@ public class ResourceGroupsRestTest {
         when(resourceGroupLocatorMock.getResourceGroups()).thenReturn(resourceGroupEntities);
 
         // when
-        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName);
+        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName, null);
 
         // then
         assertTrue(resourcesResult.isEmpty());
@@ -142,7 +142,7 @@ public class ResourceGroupsRestTest {
         when(resourceGroupLocatorMock.getResourceGroups()).thenReturn(resourceGroupEntities);
 
         // when
-        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName);
+        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName, null);
 
         // then
         Assert.assertFalse(resourcesResult.isEmpty());
@@ -160,7 +160,7 @@ public class ResourceGroupsRestTest {
         when(resourceGroupLocatorMock.getResourceGroups()).thenReturn(resourceGroupEntities);
 
         // when
-        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName);
+        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName, null);
 
         // then
         Assert.assertFalse(resourcesResult.isEmpty());
@@ -177,7 +177,7 @@ public class ResourceGroupsRestTest {
         when(resourceGroupLocatorMock.getGroupsForType(typeName, true, true)).thenReturn(new ArrayList<ResourceGroupEntity>());
 
         // when
-        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName);
+        List<ResourceGroupDTO> resourcesResult = rest.getResources(typeName, null);
 
         // then
         assertTrue(resourcesResult.isEmpty());


### PR DESCRIPTION
The rest method with type name wasn't callable anymore because it was shadowed/overwritten by `getResourceGroupsByResourceTypeId`.
Fix by making a new method that accept string or int as type filter.