### PR TITLE
fix(rest): add admin permissions when ADD_ADMIN_PERMISSIONS_ON_CREATED_RESOURCE is set

### DIFF
--- a/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
+++ b/AMW_angular/io/src/app/settings/permission/restriction-list.component.ts
@@ -75,6 +75,7 @@ export class RestrictionListComponent {
       if (resource) {
         return resource['name'];
       }
+      return 'UNKNOWN'; // can happen if resource or permission cache isn't up to date
     }
     return null;
   }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceBoundaryPersistenceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/resourcegroup/boundary/ResourceBoundaryPersistenceTest.java
@@ -61,10 +61,8 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.entity.Action;
 import ch.puzzle.itc.mobiliar.business.security.entity.Permission;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
 import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceNotDeletableException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceNotFoundException;
-import ch.puzzle.itc.mobiliar.common.exception.ResourceTypeNotFoundException;
 import ch.puzzle.itc.mobiliar.test.testrunner.PersistenceTestRunner;
 
 @RunWith(PersistenceTestRunner.class)
@@ -113,8 +111,7 @@ public class ResourceBoundaryPersistenceTest {
     }
 
     @Test
-    public void test_createNewResourceByName() throws ElementAlreadyExistsException, ResourceTypeNotFoundException,
-            ResourceNotFoundException {
+    public void test_createNewResourceByName() throws AMWException {
         // given
         ResourceTypeEntity appType = new ResourceTypeEntity();
         appType.setName("application");
@@ -148,8 +145,7 @@ public class ResourceBoundaryPersistenceTest {
     }
 
     @Test(expected = ElementAlreadyExistsException.class)
-    public void creationOfNewResourceWithSameNameAsAnExistingOfDifferentTypeShouldFail() throws ElementAlreadyExistsException,
-            ResourceTypeNotFoundException, ResourceNotFoundException {
+    public void creationOfNewResourceWithSameNameAsAnExistingOfDifferentTypeShouldFail() throws AMWException {
         // given
         ResourceTypeEntity appType = new ResourceTypeEntity();
         appType.setName("application");
@@ -180,8 +176,7 @@ public class ResourceBoundaryPersistenceTest {
     }
 
     @Test
-    public void shouldDeleteRestrictionsWhenDeletingResource() throws ElementAlreadyExistsException, ResourceTypeNotFoundException,
-            ResourceNotFoundException, ResourceNotDeletableException, ForeignableOwnerViolationException {
+    public void shouldDeleteRestrictionsWhenDeletingResource() throws ForeignableOwnerViolationException, AMWException {
         // given
         ResourceTypeEntity appType = new ResourceTypeEntity();
         appType.setName("application");

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -199,10 +199,11 @@ public class ResourceGroupsRest {
      * Creates a new resource and returns its location.
      *
      * @param request containing a ResourceReleaseDTO
+     * @throws AMWException
      */
     @POST
     @ApiOperation(value = "Add a Resource")
-    public Response addResource(@ApiParam("Add a Resource") ResourceReleaseDTO request) throws ValidationException, NotFoundException, ElementAlreadyExistsException {
+    public Response addResource(@ApiParam("Add a Resource") ResourceReleaseDTO request) throws AMWException {
         if (StringUtils.isEmpty(request.getName()) || StringUtils.isEmpty(request.getName().trim()))
             throw new ValidationException("Resource name must not be null or blank");
 

--- a/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRestTest.java
+++ b/AMW_rest/src/test/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRestTest.java
@@ -211,7 +211,7 @@ public class ResourceGroupsRestTest {
     }
 
     @Test
-    public void shouldReturnExpectedLocationHeaderOnSuccessfullResourceCreation() throws ElementAlreadyExistsException, ValidationException, NotFoundException {
+    public void shouldReturnExpectedLocationHeaderOnSuccessfullResourceCreation() throws AMWException {
         // given
         ResourceTypeEntity resType = new ResourceTypeEntity();
         resType.setName("APP");

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/resourcelist/ResourceListDataProvider.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/resourcelist/ResourceListDataProvider.java
@@ -28,6 +28,7 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroup;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceType;
 import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.business.security.control.PermissionService;
+import ch.puzzle.itc.mobiliar.common.exception.AMWException;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
 import ch.puzzle.itc.mobiliar.presentation.common.ApplicationCreatorDataProvider;
 import ch.puzzle.itc.mobiliar.presentation.common.ReleaseSelectionDataProvider;
@@ -176,7 +177,7 @@ public class ResourceListDataProvider implements Serializable, ApplicationCreato
 		resourceReleaseSelector.setSelectedReleaseId(null);
 	}
 
-	public void createResource() {
+	public void createResource() throws AMWException {
 		createResourceAction();
 	}
 
@@ -206,7 +207,7 @@ public class ResourceListDataProvider implements Serializable, ApplicationCreato
 		}
 	}
 
-	protected void createResourceAction() {
+	protected void createResourceAction() throws AMWException {
 		if (createResourceController.createResource(getNewResourceName(), getSelectEditResourceTypeComp()
 				.getSelectedResourceType().getEntity(), resourceReleaseSelector
 				.getSelectedRelease())) {

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/resourcesedit/CreateResourceController.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/resourcesedit/CreateResourceController.java
@@ -31,7 +31,6 @@ import ch.puzzle.itc.mobiliar.business.security.boundary.PermissionBoundary;
 import ch.puzzle.itc.mobiliar.common.exception.*;
 import ch.puzzle.itc.mobiliar.common.util.NameChecker;
 import ch.puzzle.itc.mobiliar.presentation.util.GlobalMessageAppender;
-import ch.puzzle.itc.mobiliar.presentation.util.UserSettings;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.ejb.EJBException;
@@ -55,17 +54,15 @@ public class CreateResourceController {
     @Inject
     private PermissionBoundary permissionBoundary;
 
-    @Inject
-    private UserSettings userSettings;
-
     /**
      * @param newResourceName
      * @param resourceType
      * @param release
      * @return @return true if application was successful created, false otherwise
+     * @throws AMWException
      */
     public boolean createResource(String newResourceName, ResourceTypeEntity resourceType
-                                  , ReleaseEntity release) {
+                                  , ReleaseEntity release) throws AMWException {
         boolean isSuccessful = false;
         String errorMessage = null;
         try {
@@ -128,8 +125,9 @@ public class CreateResourceController {
      * @param releaseForApp
      * @param releaseForAs
      * @return true if application was successful created, false otherwise
+     * @throws AMWException
      */
-    public boolean createAppAndAppServer(String appName, Integer appServerGroup, ReleaseEntity releaseForApp, Integer releaseForAs) {
+    public boolean createAppAndAppServer(String appName, Integer appServerGroup, ReleaseEntity releaseForApp, Integer releaseForAs) throws AMWException {
         Application app = null;
         boolean isSuccessful = false;
         String message;


### PR DESCRIPTION
Closes #892
Removes `getOrCreateNewResourceByName` and `getOrCreateResourceEntityByNameForResourceType` because there weren't used.