### PR TITLE
Improve permission cache management with revision-based invalidation

### DIFF
--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/auditview/control/AuditService.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/auditview/control/AuditService.java
@@ -179,6 +179,21 @@ public class AuditService {
                     .getResultList();
     }
 
+    public Integer getLastRevisionForEntityType(Class<?> entityClass, Integer lastKnownRevision) {
+        AuditReader auditReader = AuditReaderFactory.get(entityManager);
+        AuditQuery query = auditReader.createQuery()
+                .forRevisionsOfEntity(entityClass, false, true)
+                .addProjection(AuditEntity.revisionNumber().max());
+
+        @SuppressWarnings("unchecked")
+        List<Integer> results = (List<Integer>) query.getResultList();
+        log.fine("Last revision for entity type " + entityClass.getSimpleName() + " is " + results);
+        if (results.isEmpty()) {
+            return null;
+        }
+        return results.get(0);
+    }
+
     public void storeIdInThreadLocalForAuditLog(HasContexts<?> hasContexts) {
         if (hasContexts instanceof ResourceTypeEntity) {
             setResourceTypeIdInThreadLocal(hasContexts.getId());

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/EntityManagerProducer.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/EntityManagerProducer.java
@@ -24,7 +24,6 @@ import javax.enterprise.inject.Produces;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-
 public class EntityManagerProducer {
 	@PersistenceContext
 	@Produces

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/JpaSqlResultMapper.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/database/control/JpaSqlResultMapper.java
@@ -28,7 +28,6 @@ import java.lang.reflect.Modifier;
 import java.sql.Clob;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import javax.persistence.Query;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/boundary/ContextLocator.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/environment/boundary/ContextLocator.java
@@ -87,7 +87,6 @@ public class ContextLocator {
 				}
 			}
 			restrictionRepository.deleteAllWithContext(context);
-			permissionService.reloadCache();
 			contextRepository.remove(context);
 		} else {
 			throw new AMWException("Es wurde versucht den Kontext \"Global\" (id: "+contextId+" zu löschen.");

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRefreshEvent.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionRefreshEvent.java
@@ -1,0 +1,5 @@
+package ch.puzzle.itc.mobiliar.business.security.control;
+
+public class PermissionRefreshEvent {
+
+}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionServiceTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/security/control/PermissionServiceTest.java
@@ -24,12 +24,14 @@ import java.security.Principal;
 import java.util.*;
 
 import javax.ejb.SessionContext;
+import javax.enterprise.event.Event;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 
 import ch.puzzle.itc.mobiliar.builders.ContextEntityBuilder;
 import ch.puzzle.itc.mobiliar.builders.ResourceEntityBuilder;
 import ch.puzzle.itc.mobiliar.builders.RestrictionDTOBuilder;
+import ch.puzzle.itc.mobiliar.business.auditview.control.AuditService;
 import ch.puzzle.itc.mobiliar.business.environment.entity.ContextEntity;
 import ch.puzzle.itc.mobiliar.business.integration.entity.util.ResourceTypeEntityBuilder;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.*;
@@ -71,7 +73,7 @@ public class PermissionServiceTest {
 
 	private Principal principal;
 
-    @Before
+	@Before
 	public void setUp(){
 		permissionService = new PermissionService();
 		roleCache = new RoleCache();
@@ -85,6 +87,8 @@ public class PermissionServiceTest {
 		permissionService.deployableRolesWithRestrictions = null;
 		permissionService.rolesWithRestrictions = null;
 		permissionService.userRestrictions = null;
+		permissionService.auditService = Mockito.mock(AuditService.class);
+		permissionService.permissionRefreshEvent = Mockito.mock(Event.class);
 
 		global = new ContextEntityBuilder().id(1).buildContextEntity("GLOBAL", null, new HashSet<ContextEntity>(), false);
 		test = new ContextEntityBuilder().id(5).buildContextEntity("TEST", global, new HashSet<ContextEntity>(), false);


### PR DESCRIPTION
With the migration of resource creation to Angular in combination with the ADD_ADMIN_PERMISSIONS_ON_CREATED_RESOURCE permission, users could end up on a different Liima instance than where the resource and restrictions were created. This means users won't have permissions on the new resource until the permissions cache is refreshed on the that instance.

To minimize this issue:
- Reduce cache refresh interval from 20m to 1m for better responsiveness
- Add revision-based checking to prevent unnecessary reloads when no changes occurred

This ensures users get their permissions faster while avoiding performance overhead from unnecessary cache refreshes.