### PR TITLE
chore: remove guava

### DIFF
--- a/AMW_business/pom.xml
+++ b/AMW_business/pom.xml
@@ -159,10 +159,6 @@
 			<version>1.20.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>javax.mail</groupId>
 			<artifactId>mailapi</artifactId>
 			<version>1.4.3</version>

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentOrder.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/deploy/entity/DeploymentOrder.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import static ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentFilterTypes.*;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DeploymentOrder extends Order {
 
@@ -18,8 +17,8 @@ public class DeploymentOrder extends Order {
     }
 
     public static DeploymentOrder of(String colToSort, Sort.SortingDirectionType sortingDirection, boolean lowerSortCol) {
-        checkNotNull(colToSort, "colToSort may not be null");
-        checkNotNull(sortingDirection, "sortingDirection may not be null");
+        Objects.requireNonNull(colToSort, "colToSort may not be null");
+        Objects.requireNonNull(sortingDirection, "sortingDirection may not be null");
         return DEPLOYMENT_FILTER_TYPES_FOR_ORDER.stream()
                 .map(DeploymentFilterTypes::getFilterTabColumnName)
                 .filter(c -> Objects.equals(c, colToSort))

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/commons/Sort.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/domain/commons/Sort.java
@@ -1,6 +1,5 @@
 package ch.puzzle.itc.mobiliar.business.domain.commons;
 
-import com.google.common.collect.ImmutableList;
 import lombok.Builder;
 import lombok.Singular;
 
@@ -8,10 +7,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Strings.isNullOrEmpty;
 
 
 @Builder
@@ -22,8 +17,8 @@ public final class Sort implements Iterable<Sort.Order> {
     private final List<Order> orders;
 
     private Sort(List<Order> orders) {
-        checkNotNull(orders, "orders may not be null");
-        this.orders = ImmutableList.copyOf(orders);
+        Objects.requireNonNull(orders, "orders may not be null");
+        this.orders = List.copyOf(orders);
     }
 
     public static Sort nothing() {
@@ -68,7 +63,9 @@ public final class Sort implements Iterable<Sort.Order> {
 
 
         protected Order(String property, SortingDirectionType direction, boolean ignoreCase) {
-            checkArgument(!isNullOrEmpty(property), "Property must not be null or empty!");
+            if (property == null || property.isEmpty()) {
+                throw new IllegalArgumentException("Property must not be null or empty!");
+            }
 
             this.property = property;
             this.direction = direction == null ? DEFAULT_DIRECTION : direction;

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/properties/AppServerRelationProperties.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/properties/AppServerRelationProperties.java
@@ -20,7 +20,9 @@
 
 package ch.puzzle.itc.mobiliar.business.generator.control.extracted.properties;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,10 +47,6 @@ import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.AbstractResourceR
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ConsumedResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ProvidedResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.SetMultimap;
 
 /**
  * Loads properties for {@link ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity}.
@@ -82,14 +80,14 @@ public class AppServerRelationProperties {
 	@Setter
 	private Set<TemplateDescriptorEntity> resourceRelationTemplates;
 
-	private List<AppServerRelationProperties> consumed = Lists.newArrayList();
-	private List<AppServerRelationProperties> provided = Lists.newArrayList();
+	private List<AppServerRelationProperties> consumed = new ArrayList<>();
+	private List<AppServerRelationProperties> provided = new ArrayList<>();
 	
 	@Getter
 	@Setter
 	private SoftlinkGenerationPackage softlinkPPIGenerationPackage;
 
-	private SetMultimap<ResourceEntity, GeneratedTemplate> templatesCache;
+	private Map<ResourceEntity, Set<GeneratedTemplate>> templatesCache;
 
 	private boolean supportNesting = true;
 	private ApplicationResolver resolver;
@@ -194,7 +192,7 @@ public class AppServerRelationProperties {
 		return provided;
 	}
 
-	public void setTemplatesCache(SetMultimap<ResourceEntity, GeneratedTemplate> templatesCache) {
+	public void setTemplatesCache(Map<ResourceEntity, Set<GeneratedTemplate>> templatesCache) {
 		this.templatesCache = templatesCache;
 	}
 
@@ -210,13 +208,16 @@ public class AppServerRelationProperties {
         return model;
 	}
 
-    private Map<String, GeneratedTemplate> getGeneratedTemplates() {
-		Map<String, GeneratedTemplate> templates = Maps.newLinkedHashMap();
-        if (templatesCache != null && getOwner() != null) {
-            for (GeneratedTemplate template : templatesCache.get(getOwner())) {
-                templates.put(template.getName(), template);
-            }
-        }
+	private Map<String, GeneratedTemplate> getGeneratedTemplates() {
+		Map<String, GeneratedTemplate> templates = new LinkedHashMap<>();
+		if (templatesCache != null && getOwner() != null) {
+			Set<GeneratedTemplate> generatedTemplates = templatesCache.get(getOwner());
+			if (generatedTemplates != null) {
+				for (GeneratedTemplate template : generatedTemplates) {
+					templates.put(template.getName(), template);
+				}
+			}
+		}
 		return templates;
     }
 
@@ -228,8 +229,8 @@ public class AppServerRelationProperties {
 		return transformRelatedInternal(relations, false, parent);
 	}
 
-	private Map<String, Map<String,AmwResourceTemplateModel>> transformRelatedInternal(List<AppServerRelationProperties> relations, boolean transformNested, AmwResourceTemplateModel parent) {
-		Map<String, Map<String,AmwResourceTemplateModel>> map = Maps.newLinkedHashMap();
+	private Map<String, Map<String, AmwResourceTemplateModel>> transformRelatedInternal(List<AppServerRelationProperties> relations, boolean transformNested, AmwResourceTemplateModel parent) {
+		Map<String, Map<String,AmwResourceTemplateModel>> map = new LinkedHashMap<>();
 		for (AppServerRelationProperties relation : relations) {
 			ResourceEntity slave = relation.getOwner();
 
@@ -239,7 +240,7 @@ public class AppServerRelationProperties {
 			
 			if (!map.containsKey(typeName)) {
 
-                Map<String,AmwResourceTemplateModel> typeMap = Maps.newLinkedHashMap();
+                Map<String,AmwResourceTemplateModel> typeMap = new LinkedHashMap<>();
 				map.put(typeName, typeMap);
 			}
             Map<String,AmwResourceTemplateModel> typeMap = map.get(typeName);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/ApplicationResolver.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/ApplicationResolver.java
@@ -29,7 +29,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceGroupEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ProvidedResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import com.google.common.collect.Lists;
 
 import java.util.*;
 
@@ -114,7 +113,7 @@ public class ApplicationResolver {
 		model.setAppProperties(app.getProperties());
 		model.setAppServerProperties(appServer.getProperties());
 
-		List<Map<String, FreeMarkerProperty>> nodePropertyList = Lists.newArrayList();
+		List<Map<String, FreeMarkerProperty>> nodePropertyList = new ArrayList<>();
 
 		model.setNodePropertyList(nodePropertyList);
 	}

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationOptions.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationOptions.java
@@ -20,8 +20,11 @@
 
 package ch.puzzle.itc.mobiliar.business.generator.control.extracted.templates;
 
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import ch.puzzle.itc.mobiliar.business.generator.control.GeneratedTemplate;
 import ch.puzzle.itc.mobiliar.business.generator.control.extracted.GenerationContext;
@@ -30,7 +33,6 @@ import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity.Applicatio
 
 import ch.puzzle.itc.mobiliar.business.property.entity.AmwResourceTemplateModel;
 import ch.puzzle.itc.mobiliar.business.property.entity.FreeMarkerProperty;
-import com.google.common.collect.Maps;
 
 /**
  * Provides a context for common objects used during generation.
@@ -46,15 +48,15 @@ public class GenerationOptions{
 	public GenerationOptions(GenerationContext context) {
 		
 		this.context = context;
-		this.versions = Maps.newHashMap();
+		this.versions = new HashMap<>();
 		populateVersions(context.getApplicationsWithVersion());
 		populateProperties();
 	}
 
 	private void populateProperties() {
-		templateFiles = Maps.newLinkedHashMap();
-		this.applications = Maps.newLinkedHashMap();
-		this.contextProperties = Maps.newTreeMap();
+		templateFiles = new LinkedHashMap<>();
+		this.applications = new LinkedHashMap<>();
+		this.contextProperties = new TreeMap<>();
 		contextProperties.putAll(new BasePropertyCollector().propertiesForContext(context.getContext()));
 	}
 

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationPackage.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationPackage.java
@@ -21,10 +21,10 @@
 package ch.puzzle.itc.mobiliar.business.generator.control.extracted.templates;
 
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +42,7 @@ public class GenerationPackage {
 		for (GenerationSubPackage subPackage : generationSubPackages) {
 			all.addAll(subPackage.getSubGenerationUnitsAsList());
 		}
-		return Sets.newLinkedHashSet(removeDuplicates(all));
+		return new LinkedHashSet<>(removeDuplicates(all));
 	}
 
 	public void addGenerationSubPackage(GenerationSubPackage generationPackage) {
@@ -64,11 +64,11 @@ public class GenerationPackage {
 			}
 		}
 
-		Map<ResourceEntity, Set<GenerationUnit>> map = Maps.newLinkedHashMap();
+		Map<ResourceEntity, Set<GenerationUnit>> map = new LinkedHashMap<>();
 
 		for (GenerationSubPackage generationSubPackage : result) {
 			ResourceEntity resource = generationSubPackage.getPackageGenerationUnit().getSlaveResource();
-			map.put(resource, Sets.newLinkedHashSet(generationSubPackage.getSubGenerationUnitsAsList()));
+			map.put(resource, new LinkedHashSet<>(generationSubPackage.getSubGenerationUnitsAsList()));
 		}
 
 		List<GenerationSubPackage> applicationServerSubPackages = getApplicationServerSubPackages();
@@ -77,7 +77,7 @@ public class GenerationPackage {
 			for (GenerationUnit gu : generationSubPackage.getGenerationUnits()) {
 				if (gu.getSlaveResource().getResourceType().isApplicationResourceType()) {
 					if (!map.containsKey(gu.getSlaveResource())) {
-						Set<GenerationUnit> units = Sets.newLinkedHashSet();
+						Set<GenerationUnit> units = new LinkedHashSet<>();
 						units.add(gu);
 						map.put(gu.getSlaveResource(), units);
 					}
@@ -90,7 +90,7 @@ public class GenerationPackage {
 
 	public Set<GenerationUnit> getAsWithGivenNode(ResourceEntity node) {
 
-		Set<GenerationUnit> result = Sets.newLinkedHashSet();
+		Set<GenerationUnit> result = new LinkedHashSet<>();
 
 		List<GenerationSubPackage> applicationServerSubPackages = getApplicationServerSubPackages();
 		// GenerationSubPackage node = null;
@@ -150,7 +150,7 @@ public class GenerationPackage {
 	 */
 	public Set<GenerationUnit> getNodeGenerationUnits() {
 		Set<GenerationUnit> all = getAsSet();
-		Set<GenerationUnit> result = Sets.newLinkedHashSet();
+		Set<GenerationUnit> result = new LinkedHashSet<>();
 		for (GenerationUnit generationUnit : all) {
 			if (generationUnit.getSlaveResource().getResourceType().isNodeResourceType()) {
 				result.add(generationUnit);

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnit.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnit.java
@@ -20,6 +20,9 @@
 
 package ch.puzzle.itc.mobiliar.business.generator.control.extracted.templates;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,9 +35,6 @@ import ch.puzzle.itc.mobiliar.business.globalfunction.entity.GlobalFunctionEntit
 import ch.puzzle.itc.mobiliar.business.property.entity.AmwResourceTemplateModel;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 /**
  * Data Unit for Template generation.
@@ -198,7 +198,7 @@ public class GenerationUnit {
 				return batches.get(app);
 			}
 		}
-		return Sets.newLinkedHashSet();
+		return new LinkedHashSet<>();
 	}
 
 	
@@ -221,9 +221,10 @@ public class GenerationUnit {
 	}
 
 	public static Set<GenerationUnit> forAppServer(Set<GenerationUnit> work, ResourceEntity node) {
-		List<GenerationUnit> current = Lists.newArrayList();
+		List<GenerationUnit> current = new ArrayList<>();
 
-		List<GenerationUnit> reverse = Lists.reverse(Lists.newArrayList(work));
+		List<GenerationUnit> reverse = new ArrayList<>(work);
+		Collections.reverse(reverse);
 		for (GenerationUnit unit : reverse) {
 			// break as soon as we hit app level
 			if (unit.getSlaveResource().getResourceType().isApplicationResourceType()) {
@@ -238,7 +239,8 @@ public class GenerationUnit {
 			}
 			current.add(unit);
 		}
-		return Sets.newLinkedHashSet(Lists.reverse(current));
+		Collections.reverse(current);
+		return new LinkedHashSet<>(current);
 	}
 
 	@Override

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnitFactory.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnitFactory.java
@@ -43,7 +43,6 @@ import ch.puzzle.itc.mobiliar.common.exception.AMWRuntimeException;
 import ch.puzzle.itc.mobiliar.common.exception.TemplatePropertyException;
 import ch.puzzle.itc.mobiliar.common.util.ApplicationServerContainer;
 import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.inject.Inject;
@@ -199,7 +198,7 @@ public class GenerationUnitFactory {
 				consumedMasterRelations);
 		Collections.sort(consumedMasterRelationsSorted,
 				AbstractResourceRelationEntity.COMPARE_BY_SLAVE_NAME);
-		Set<TemplateDescriptorEntity> relationTemplates = Sets.newLinkedHashSet();
+		Set<TemplateDescriptorEntity> relationTemplates = new LinkedHashSet<>();
 
 		for (ConsumedResourceRelationEntity resourceRelation : consumedMasterRelationsSorted) {
 
@@ -446,7 +445,7 @@ public class GenerationUnitFactory {
 
 	protected Set<TemplateDescriptorEntity> templatesForResource(GenerationOptions options,
 			ResourceEntity resource) {
-		Set<TemplateDescriptorEntity> templates = Sets.newLinkedHashSet();
+		Set<TemplateDescriptorEntity> templates = new LinkedHashSet<>();
 		utils.getTemplates(resource, options.getContext().getContext(), templates, options.getContext()
 				.getTargetPlatformId());
 		return templates;
@@ -454,7 +453,7 @@ public class GenerationUnitFactory {
 
 	protected Set<TemplateDescriptorEntity> templatesForRelation(GenerationOptions options,
 			AbstractResourceRelationEntity resourceRelation) {
-		Set<TemplateDescriptorEntity> templates = Sets.newLinkedHashSet();
+		Set<TemplateDescriptorEntity> templates = new LinkedHashSet<>();
 		if (resourceRelation != null) {
 			// relation is null when handed a ASR base on TYPES
 			utils.getTemplates(options.getContext().getContext(), resourceRelation, templates, options

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
@@ -33,9 +33,8 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 
-import com.google.common.base.Enums;
-
 import org.apache.commons.lang3.StringUtils;
+import java.util.Arrays;
 
 import ch.puzzle.itc.mobiliar.business.foreignable.control.ForeignableService;
 import ch.puzzle.itc.mobiliar.business.foreignable.entity.ForeignableOwner;
@@ -265,7 +264,8 @@ public class RelationEditor {
 		if (StringUtils.isEmpty(resourceRelationTypeString)) {
 			return false;
 		}
-		return (Enums.getIfPresent(ResourceRelationType.class, resourceRelationTypeString.toUpperCase()).isPresent());
+		return Arrays.stream(ResourceRelationType.values())
+				.anyMatch(type -> type.name().equalsIgnoreCase(resourceRelationTypeString));
 	}
 
 }

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/domain/TestUtils.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/domain/TestUtils.java
@@ -21,6 +21,7 @@
 package ch.puzzle.itc.mobiliar.business.domain;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -33,16 +34,17 @@ import ch.puzzle.itc.mobiliar.business.property.entity.AmwResourceTemplateModel;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.test.EntityBuilderType;
 
-import com.google.common.io.Resources;
-
 import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
 public class TestUtils {
 	public static String readRecursionTemplate() {
-		try {
-			return Resources.toString(Resources.getResource("rekursiv_macro_4.txt"), StandardCharsets.UTF_8);
+		try (InputStream in = TestUtils.class.getClassLoader().getResourceAsStream("rekursiv_macro_4.txt")) {
+			if (in == null) {
+				return null;
+			}
+			return new String(in.readAllBytes(), StandardCharsets.UTF_8);
 		}
 		catch (IOException e) {
 			e.printStackTrace();

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/properties/AppServerRelationPropertiesTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/properties/AppServerRelationPropertiesTest.java
@@ -45,8 +45,10 @@ import ch.puzzle.itc.mobiliar.test.AmwEntityBuilder;
 import ch.puzzle.itc.mobiliar.test.CustomLogging;
 import ch.puzzle.itc.mobiliar.test.EntityBuilder;
 
-import com.google.common.collect.LinkedHashMultimap;
-import com.google.common.collect.SetMultimap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModelException;
@@ -120,8 +122,8 @@ public class AppServerRelationPropertiesTest {
 
 		AppServerRelationProperties appServerRelationProperties = new AppServerRelationProperties(context, owner, templateExceptionHandler);
 		appServerRelationProperties.addConsumedRelation("active_directory", ad, relation);
-		SetMultimap<ResourceEntity, GeneratedTemplate> templatesCache = LinkedHashMultimap.create();
-		templatesCache.put(ad, new GeneratedTemplate("name", "path", "content"));
+		Map<ResourceEntity, Set<GeneratedTemplate>> templatesCache = new LinkedHashMap<>();
+		templatesCache.computeIfAbsent(ad, k -> new LinkedHashSet<>()).add(new GeneratedTemplate("name", "path", "content"));
 
 		appServerRelationProperties.getConsumed().get(0).setTemplatesCache(templatesCache);
 		appServerRelationProperties.setTemplatesCache(templatesCache);

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorAmwFunctionTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorAmwFunctionTest.java
@@ -39,7 +39,7 @@ import ch.puzzle.itc.mobiliar.business.property.entity.AmwTemplateModel;
 import ch.puzzle.itc.mobiliar.business.property.entity.FreeMarkerProperty;
 import ch.puzzle.itc.mobiliar.business.property.entity.PropertyDescriptorEntity;
 
-import com.google.common.collect.Maps;
+import java.util.HashMap;
 
 import freemarker.template.TemplateException;
 
@@ -71,11 +71,11 @@ public class BaseTemplateProcessorAmwFunctionTest {
         PropertyDescriptorEntity des2 = new PropertyDescriptorEntity();
         des2.setPropertyName("bar");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("2",des2));
 
-        Map<String, Object> thisProperties = Maps.newHashMap();
+        Map<String, Object> thisProperties = new HashMap<>();
         thisProperties.put("this", dataProperties);
 
         AmwTemplateModel model = new AmwTemplateModel();
@@ -102,7 +102,7 @@ public class BaseTemplateProcessorAmwFunctionTest {
         PropertyDescriptorEntity des2 = new PropertyDescriptorEntity();
         des2.setPropertyName("bar");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("2",des2));
 

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/BaseTemplateProcessorTest.java
@@ -31,8 +31,8 @@ import ch.puzzle.itc.mobiliar.business.property.entity.PropertyDescriptorEntity;
 import ch.puzzle.itc.mobiliar.business.property.entity.PropertyTagEntity;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,8 +76,8 @@ public class BaseTemplateProcessorTest {
     @Test
 	public void test() throws IOException {
 		// given
-		Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-		Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+		Set<TemplateDescriptorEntity> templates = new HashSet<>();
+		Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("bar",des1));
 
 		TemplateDescriptorEntity templateDescriptorEntity = createTemplate("asdf ${foo}");
@@ -98,8 +98,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testPropertynotfound() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("bar",des1));
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("${asdf}");
@@ -120,8 +120,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testPropertynotfound_descriptor() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("bar",des1));
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("${asdf._descriptor.encrypt}");
@@ -142,8 +142,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testFreemarkerFunction_has_content() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", null);
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#if foo?has_content>has_content</#if>");
@@ -163,8 +163,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testFreemarkerFunction_length_onAMW_Property() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 
         thisProperties.put("foo", new FreeMarkerProperty("",des1));
 
@@ -186,8 +186,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testFreemarkerFunction_has_content_onAMW_Property() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 
         thisProperties.put("foo", new FreeMarkerProperty("",des1));
 
@@ -209,7 +209,7 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testFreemarkerFunction_has_content_on_nonexisting_AMW_Property() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#if ((foo.currentValue)?has_content)>has_content</#if>");
 
         templates.add(templateDescriptorEntity);
@@ -229,8 +229,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void testFreemarkerTemplate_NoParse() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#noparse>${test}</#noparse>");
 
@@ -250,8 +250,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void shouldFormatNumberCorrectly() throws IOException {
     	// given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("1000000", des1));
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("asdf ${foo}");
@@ -272,8 +272,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void emptyString() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("", des1));
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("asdf ${foo}");
@@ -295,8 +295,8 @@ public class BaseTemplateProcessorTest {
     @Test
     public void shouldReplaceInnerProperty() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("1000000", des1));
         thisProperties.put("bar", new FreeMarkerProperty("${foo}", des2));
 
@@ -318,9 +318,9 @@ public class BaseTemplateProcessorTest {
     @Test
     public void shouldReplaceInnerInnerProperty() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1000000", des1));
         dataProperties.put("bar", new FreeMarkerProperty("${foo}", des2));
         dataProperties.put("bar2", new FreeMarkerProperty("${bar}", des3));
@@ -350,9 +350,9 @@ public class BaseTemplateProcessorTest {
     	
 		GlobalFunctionEntity globalFunction = createGlobalFunctionTemplateEntity("function1", content);
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("2", des2));
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#include \"function1\">asdf ${add(foo?number,bar?number)}");
@@ -383,9 +383,9 @@ public class BaseTemplateProcessorTest {
 
         GlobalFunctionEntity globalFunction = createGlobalFunctionTemplateEntity("function1", content);
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("2", des2));
 
@@ -417,11 +417,11 @@ public class BaseTemplateProcessorTest {
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#include \"function\">value=${add()}");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("2", des2));
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -447,12 +447,12 @@ public class BaseTemplateProcessorTest {
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#include \"function\">value=<#list getList() as entry>${entry}</#list>");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("value1", des1));
         dataProperties.put("bar", new FreeMarkerProperty("value2", des2));
 
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -478,11 +478,11 @@ public class BaseTemplateProcessorTest {
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#include \"function\"><#list getList() as entry>${entry._descriptor.technicalKey}=${entry}\n</#list>");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("fmp1",des1));
         dataProperties.put("bar", new FreeMarkerProperty("fmp2",des2));
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -508,12 +508,12 @@ public class BaseTemplateProcessorTest {
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#include \"function\">foo=${getHash().foo}\nbar=${getHash().bar}");
 
-        Map<String, FreeMarkerProperty> dataProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> dataProperties = new HashMap<>();
         dataProperties.put("foo", new FreeMarkerProperty("value1",des1));
         dataProperties.put("bar", new FreeMarkerProperty("value2",des2));
 
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -544,7 +544,7 @@ public class BaseTemplateProcessorTest {
         dataProperties.put("bar", new FreeMarkerProperty("value2",des2));
 
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -583,7 +583,7 @@ public class BaseTemplateProcessorTest {
         dataProperties.put("bar", new FreeMarkerProperty("value2",des2));
 
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -613,7 +613,7 @@ public class BaseTemplateProcessorTest {
         thisProperties.put("foo", new FreeMarkerProperty("value1", des1));
         thisProperties.put("bar", new FreeMarkerProperty("value2",des2));
 
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
         templates.add(templateDescriptorEntity);
 
         GenerationUnit unit = new GenerationUnit(null, null, templates, null);
@@ -634,7 +634,7 @@ public class BaseTemplateProcessorTest {
     @Test
     public void shouldFailCallingNewBuiltIn() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#assign ex = \"freemarker.template.utility.Execute\"?new()>${ex(\"id\")}");
 
@@ -654,7 +654,7 @@ public class BaseTemplateProcessorTest {
     @Test
     public void shouldFailCallingApiBuiltIn() throws IOException {
         // given
-        Set<TemplateDescriptorEntity> templates = Sets.newHashSet();
+        Set<TemplateDescriptorEntity> templates = new HashSet<>();
 
         TemplateDescriptorEntity templateDescriptorEntity = createTemplate("<#assign uri=object?api.class.getResource(\"/\").toURI()>${uri}");
 
@@ -688,7 +688,7 @@ public class BaseTemplateProcessorTest {
 
 
     private AmwTemplateModel getAmwTemplateModel(Map<String, FreeMarkerProperty> thisProperties, Map<String, FreeMarkerProperty> asProperties) {
-        Map<String, FreeMarkerProperty> contextProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> contextProperties = new HashMap<>();
 
         AmwTemplateModel model = new AmwTemplateModel();
         model.setAsProperties(new AmwResourceTemplateModel());

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnitTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/GenerationUnitTest.java
@@ -24,7 +24,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 import ch.puzzle.itc.mobiliar.test.AmwEntityBuilder;
 import ch.puzzle.itc.mobiliar.test.EntityBuilder;
-import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -37,7 +36,7 @@ public class GenerationUnitTest {
 
 	EntityBuilder builder = new AmwEntityBuilder();
 	GenerationPackage generationPackage = new GenerationPackage();
-	Set<TemplateDescriptorEntity> templates = ImmutableSet.of();
+	Set<TemplateDescriptorEntity> templates = Set.of();
 
 	@Test
 	public void testInsertIntoSet() {

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/TemplateProcessorBaseTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/extracted/templates/TemplateProcessorBaseTest.java
@@ -36,11 +36,12 @@ import java.util.logging.Logger;
 import org.apache.commons.io.FileExistsException;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.io.TempDir;
+
+import java.util.Arrays;
+
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-
-import com.google.common.collect.Lists;
 
 import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity;
 import ch.puzzle.itc.mobiliar.business.environment.entity.ContextEntity;
@@ -153,7 +154,7 @@ public class TemplateProcessorBaseTest<T extends EntityBuilder> {
 
 	protected void writeFiles() throws FileExistsException, IOException {
 		writer.generateFileStructure(generationResults, folder.toString(), null);
-		files = Lists.newArrayList(new File(folder.toString()).listFiles());
+		files = new ArrayList<>(Arrays.asList(new File(folder.toString()).listFiles()));
 	}
 
 	protected String readFile(String name) throws IOException {
@@ -166,7 +167,7 @@ public class TemplateProcessorBaseTest<T extends EntityBuilder> {
 	}
 	
 	public static List<GenerationUnitGenerationResult> generateTemplates(GenerationOptions options, GenerationPackage work, AppServerRelationsTemplateProcessor processor) throws IOException{
-		List<GenerationUnitGenerationResult> templates = Lists.newArrayList();
+		List<GenerationUnitGenerationResult> templates = new ArrayList<>();
 		work.setGenerationOptions(options);
 		processor.setGlobals(work);
 		processor.setGenerationContext(options.getContext());

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/factory/GenerationUnitFactoryAmwTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/factory/GenerationUnitFactoryAmwTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -63,8 +64,6 @@ import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationT
 import ch.puzzle.itc.mobiliar.common.exception.TemplatePropertyException;
 import ch.puzzle.itc.mobiliar.test.AmwEntityBuilder;
 import ch.puzzle.itc.mobiliar.test.EntityBuilderType;
-
-import com.google.common.collect.Iterables;
 
 import freemarker.template.TemplateModelException;
 
@@ -134,15 +133,17 @@ public class GenerationUnitFactoryAmwTest {
 	@Test
 	public void testFirstItem() {
 		GenerationPackage work = GenerationUnitFactoryTestUtil.createWorkForBuilder(factory, dependencyResolver, builder);
-		assertEquals(Iterables.getFirst(work.getAsSet(), null).getSlaveResource(), resourceByName(builder, AD));
-		assertNotNull(Iterables.getFirst(work.getAsSet(), null).getPropertiesAsModel());
+		GenerationUnit firstUnit = work.getAsSet().iterator().next();
+		assertEquals(firstUnit.getSlaveResource(), resourceByName(builder, AD));
+		assertNotNull(firstUnit.getPropertiesAsModel());
 	}
 
 	@Test
 	public void testLastItem() {
 		GenerationPackage work = GenerationUnitFactoryTestUtil.createWorkForBuilder(factory, dependencyResolver, builder);
-		assertEquals(Iterables.getLast(work.getAsSet()).getSlaveResource(), resourceByName(builder, AS));
-		assertNotNull(Iterables.getLast(work.getAsSet()).getPropertiesAsModel());
+		List<GenerationUnit> workList = new ArrayList<>(work.getAsSet());
+		assertEquals(workList.get(workList.size() - 1).getSlaveResource(), resourceByName(builder, AS));
+		assertNotNull(workList.get(workList.size() - 1).getPropertiesAsModel());
 	}
 
 	@Test

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/factory/GenerationUnitFactoryTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/generator/control/factory/GenerationUnitFactoryTest.java
@@ -28,8 +28,6 @@ import ch.puzzle.itc.mobiliar.test.CustomLogging;
 import ch.puzzle.itc.mobiliar.test.EntityBuilderType;
 import ch.puzzle.itc.mobiliar.test.SimpleEntityBuilder;
 
-import com.google.common.collect.Lists;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +36,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -151,7 +150,7 @@ public class GenerationUnitFactoryTest {
 	}
 
 	void assertGenerationUnitSequence(GenerationPackage work, ResourceEntity... entities) {
-		List<GenerationUnit> list = Lists.newArrayList(work.getAsSet());
+		List<GenerationUnit> list = new ArrayList<>(work.getAsSet());
 		for (int i = 0; i < entities.length; i++) {
 			assertEquals(entities[i], list.get(i).getSlaveResource());
 		}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/property/entity/AmwResourceTemplateModelTest.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/business/property/entity/AmwResourceTemplateModelTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -41,8 +42,6 @@ import ch.puzzle.itc.mobiliar.business.generator.control.AmwModelPreprocessExcep
 import ch.puzzle.itc.mobiliar.business.generator.control.extracted.templates.BaseTemplateProcessor;
 import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 
-import com.google.common.collect.Maps;
-
 import freemarker.cache.StringTemplateLoader;
 import freemarker.core.ParseException;
 import freemarker.template.Configuration;
@@ -55,7 +54,7 @@ public class AmwResourceTemplateModelTest {
 	@Test
 	public void testEvaluateFunction() throws Exception{
 		// given
-		Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 		thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
 		thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 
@@ -80,7 +79,7 @@ public class AmwResourceTemplateModelTest {
 	@Test
 	public void testEvaluateFunction_in_function() throws Exception{
 		// given
-		Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 		thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
 		thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 
@@ -110,11 +109,11 @@ public class AmwResourceTemplateModelTest {
 	@Test
 	public void testEvaluateFunction_deep() throws Exception{
 		// given
-		Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 		thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
 		thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 		
-		Map<String, FreeMarkerProperty> adProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> adProperties = new HashMap<>();
 		adProperties.put("foo", new FreeMarkerProperty("val11", "foo"));
 		adProperties.put("bar", new FreeMarkerProperty("val22", "bar"));
 
@@ -127,8 +126,8 @@ public class AmwResourceTemplateModelTest {
 		AmwResourceTemplateModel resourceModel = new AmwResourceTemplateModel();
 		resourceModel.setProperties(thisProperties);
 		
-		Map<String, Map<String, AmwResourceTemplateModel>> consumedResTypes = Maps.newHashMap();
-		Map<String, AmwResourceTemplateModel> consumedPerType= Maps.newHashMap();
+        Map<String, Map<String, AmwResourceTemplateModel>> consumedResTypes = new HashMap<>();
+        Map<String, AmwResourceTemplateModel> consumedPerType= new HashMap<>();
 		AmwResourceTemplateModel ad = new AmwResourceTemplateModel();
 		ad.setProperties(adProperties);
 		ad.setFunctions(functions);
@@ -148,11 +147,11 @@ public class AmwResourceTemplateModelTest {
 	@Test
 	public void testEvaluateFunction_fullTemplateModel() throws Exception{
 		// given
-		Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
 		thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
 		thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 		
-		Map<String, FreeMarkerProperty> adProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> adProperties = new HashMap<>();
 		adProperties.put("foo", new FreeMarkerProperty("val11", "foo"));
 		adProperties.put("bar", new FreeMarkerProperty("val22", "bar"));
 
@@ -165,8 +164,8 @@ public class AmwResourceTemplateModelTest {
 		AmwResourceTemplateModel resourceModel = new AmwResourceTemplateModel();
 		resourceModel.setProperties(thisProperties);
 		
-		Map<String, Map<String, AmwResourceTemplateModel>> consumedResTypes = Maps.newHashMap();
-		Map<String, AmwResourceTemplateModel> consumedPerType= Maps.newHashMap();
+        Map<String, Map<String, AmwResourceTemplateModel>> consumedResTypes = new HashMap<>();
+        Map<String, AmwResourceTemplateModel> consumedPerType= new HashMap<>();
 		AmwResourceTemplateModel ad = new AmwResourceTemplateModel();
 		ad.setProperties(adProperties);
 		ad.setFunctions(functions);
@@ -179,19 +178,19 @@ public class AmwResourceTemplateModelTest {
 		AmwTemplateModel model = new AmwTemplateModel();
 		model.setAmwModelPreprocessExceptionHandler(new AmwModelPreprocessExceptionHandler());
 
-        Map<String, FreeMarkerProperty> properties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> properties = new HashMap<>();
 		properties.put("foo", new FreeMarkerProperty("val111", "foo"));
 		properties.put("bar", new FreeMarkerProperty("val222", "bar"));
         resourceModel.setProperties(properties);
 		
 		AmwResourceTemplateModel asPropertiesModel = new AmwResourceTemplateModel();
-		Map<String, FreeMarkerProperty> asProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> asProperties = new HashMap<>();
 		asProperties.put("asName", new FreeMarkerProperty("asNameVal", "asName"));
 		asPropertiesModel.setProperties(asProperties);
 		model.setAsProperties(asPropertiesModel);
 		
 		AmwResourceTemplateModel nodePropertiesModel = new AmwResourceTemplateModel();
-		Map<String, FreeMarkerProperty> nodeProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> nodeProperties = new HashMap<>();
 		nodeProperties.put("nodeName", new FreeMarkerProperty("nodeNameVal", "nodeName"));
 		nodePropertiesModel.setProperties(nodeProperties);
 		model.setNodeProperties(nodePropertiesModel);
@@ -209,7 +208,7 @@ public class AmwResourceTemplateModelTest {
     @Test
     public void testEvaluatePropertyInProperty() throws Exception{
         // given
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("${foo}", "bar"));
 
@@ -233,7 +232,7 @@ public class AmwResourceTemplateModelTest {
     @Test
     public void testAccessPropertiesAsHash() throws Exception{
         // given
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 
@@ -256,7 +255,7 @@ public class AmwResourceTemplateModelTest {
     @Test
     public void testAccessPropertiesAsHashListAccess() throws Exception{
         // given
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newLinkedHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new LinkedHashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
 
@@ -323,7 +322,7 @@ public class AmwResourceTemplateModelTest {
     @Test
     public void testEvaluatePropertyInPropertyOnConsumedResource() throws Exception{
         // given
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("${foo}", "bar"));
 
@@ -363,7 +362,7 @@ public class AmwResourceTemplateModelTest {
         desc.setMachineInterpretationKey("MIK1");
         FreeMarkerProperty mik = new FreeMarkerProperty(null, desc);
 
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
         thisProperties.put("mikProperty", mik);
@@ -400,7 +399,7 @@ public class AmwResourceTemplateModelTest {
         desc.setMachineInterpretationKey("MIK1");
         FreeMarkerProperty mik = new FreeMarkerProperty(null, desc);
 
-        Map<String, FreeMarkerProperty> thisProperties = Maps.newHashMap();
+        Map<String, FreeMarkerProperty> thisProperties = new HashMap<>();
         thisProperties.put("foo", new FreeMarkerProperty("val1", "foo"));
         thisProperties.put("bar", new FreeMarkerProperty("val2", "bar"));
         thisProperties.put("mikProperty", mik);

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/DeploymentInfo.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/DeploymentInfo.java
@@ -25,19 +25,18 @@ import ch.puzzle.itc.mobiliar.business.deploy.entity.DeploymentEntity.Applicatio
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 public class DeploymentInfo implements Comparable<DeploymentInfo> {
 	private ObjectMapper objectMapper = new ObjectMapper();
@@ -98,7 +97,7 @@ public class DeploymentInfo implements Comparable<DeploymentInfo> {
 		Query query = entityManager
 				.createQuery("select distinct d.resource, d.context, d.applicationsWithVersion from DeploymentEntity d where d.buildSuccess = true");
 		List<Object[]> resultList = query.getResultList();
-		List<DeploymentInfo> list = Lists.newArrayList();
+		List<DeploymentInfo> list = new ArrayList<>();
 
 		for (Object[] objects : resultList) {
 			ResourceEntity resource = (ResourceEntity) objects[0];
@@ -119,18 +118,14 @@ public class DeploymentInfo implements Comparable<DeploymentInfo> {
 	}
 
 	public static List<DeploymentInfo> lastForContext(List<DeploymentInfo> allMos) {
-		final Set<String> contextNames = Sets.newHashSet();
-		return Lists.newArrayList(Collections2.filter(allMos, new Predicate<DeploymentInfo>() {
-
-			@Override
-			public boolean apply(DeploymentInfo input) {
-				if (contextNames.add(input.context.getName())) {
-					return true;
-				}
-				return false;
+		Set<String> contextNames = new HashSet<>();
+		List<DeploymentInfo> result = new ArrayList<>();
+		for (DeploymentInfo info : allMos) {
+			if (contextNames.add(info.context.getName())) {
+				result.add(info);
 			}
-
-		}));
+		}
+		return result;
 	}
 
 	public static List<DeploymentInfo> latest(List<DeploymentInfo> deployments, String server) {
@@ -138,16 +133,17 @@ public class DeploymentInfo implements Comparable<DeploymentInfo> {
 	}
 
 	public static List<DeploymentInfo> filter(List<DeploymentInfo> deployments, final String serverName) {
-		return Lists.newArrayList(Collections2.filter(deployments, new Predicate<DeploymentInfo>() {
-			@Override
-			public boolean apply(DeploymentInfo input) {
-				return input.appServer.getName().equals(serverName);
+		List<DeploymentInfo> result = new ArrayList<>();
+		for (DeploymentInfo deployment : deployments) {
+			if (deployment.appServer.getName().equals(serverName)) {
+				result.add(deployment);
 			}
-		}));
+		}
+		return result;
 	}
 
 	public static Set<String> serverNames(List<DeploymentInfo> deployments) {
-		Set<String> serverNames = Sets.newTreeSet();
+		Set<String> serverNames = new TreeSet<>();
 		for (DeploymentInfo info : deployments) {
 			serverNames.add(info.appServer.getName());
 		}

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/EntityBuilder.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/EntityBuilder.java
@@ -33,8 +33,8 @@ import ch.puzzle.itc.mobiliar.business.template.entity.TemplateDescriptorEntity;
 import ch.puzzle.itc.mobiliar.business.utils.Identifiable;
 import ch.puzzle.itc.mobiliar.common.exception.ElementAlreadyExistsException;
 import ch.puzzle.itc.mobiliar.common.util.ContextNames;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -47,12 +47,12 @@ import java.util.List;
  * @see {@link PersistingEntityBuilder} for building model in DB.
  */
 public class EntityBuilder {
-	private List<ResourceTypeEntity> types = Lists.newArrayList();
-	private List<ResourceEntity> resources = Lists.newArrayList();
-	private List<ProvidedResourceRelationEntity> providedRelations = Lists.newArrayList();
-	private List<ConsumedResourceRelationEntity> consumedRelations = Lists.newArrayList();
-	private List<ResourceRelationTypeEntity> typeRelations = Lists.newArrayList();
-	private List<ContextEntity> contexts = Lists.newArrayList();
+	private List<ResourceTypeEntity> types = new ArrayList<>();
+	private List<ResourceEntity> resources = new ArrayList<>();
+	private List<ProvidedResourceRelationEntity> providedRelations = new ArrayList<>();
+	private List<ConsumedResourceRelationEntity> consumedRelations = new ArrayList<>();
+	private List<ResourceRelationTypeEntity> typeRelations = new ArrayList<>();
+	private List<ContextEntity> contexts = new ArrayList<>();
 
 	private int resourceContextId = 0;
 	private int contextTypeId = 0;

--- a/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/EntityBuilderType.java
+++ b/AMW_business/src/test/java/ch/puzzle/itc/mobiliar/test/EntityBuilderType.java
@@ -20,10 +20,10 @@
 
 package ch.puzzle.itc.mobiliar.test;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public enum EntityBuilderType {
 
@@ -40,16 +40,13 @@ public enum EntityBuilderType {
 	}
 
 	public static List<String> typeNames() {
-		return Lists.transform(vals(), new Function<EntityBuilderType, String>() {
-			public String apply(EntityBuilderType input) {
-				return input.type;
-			}
-
-		});
+		return vals().stream()
+				.map(input -> input.type)
+				.collect(Collectors.toList());
 	}
 
 	static List<EntityBuilderType> vals() {
-		return Lists.newArrayList(EntityBuilderType.values());
+		return new ArrayList<>(Arrays.asList(EntityBuilderType.values()));
 	}
 
 }

--- a/AMW_web/pom.xml
+++ b/AMW_web/pom.xml
@@ -68,10 +68,6 @@
             <scope>provided</scope>
         </dependency>
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/functionEdit/EditFunctionView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/functionEdit/EditFunctionView.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 
 import ch.puzzle.itc.mobiliar.business.template.entity.RevisionInformation;
 import ch.puzzle.itc.mobiliar.common.exception.NotFoundException;
-import com.google.common.collect.Lists;
 import lombok.Getter;
 import lombok.Setter;
 import ch.puzzle.itc.mobiliar.business.function.boundary.FunctionsBoundary;
@@ -207,7 +206,8 @@ public class EditFunctionView implements Serializable {
     }
 
     private void refreshRevisionInformation(Integer funId){
-        revisionInformations = Lists.reverse(functionsBoundary.getFunctionRevisions(funId));
+        revisionInformations = new java.util.ArrayList<>(functionsBoundary.getFunctionRevisions(funId));
+        java.util.Collections.reverse(revisionInformations);
     }
 
     /**

--- a/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
+++ b/AMW_web/src/main/java/ch/puzzle/itc/mobiliar/presentation/templateEdit/EditTemplateView.java
@@ -34,7 +34,6 @@ import ch.puzzle.itc.mobiliar.presentation.ViewBackingBean;
 import ch.puzzle.itc.mobiliar.presentation.common.context.SessionContext;
 import ch.puzzle.itc.mobiliar.presentation.util.GlobalMessageAppender;
 import ch.puzzle.itc.mobiliar.presentation.util.UserSettings;
-import com.google.common.collect.Lists;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -132,7 +131,8 @@ public class EditTemplateView implements Serializable {
      */
     public void setTemplateId(Integer templateId) {
         template = templateEditor.getTemplateById(templateId);
-        revisionInformations = Lists.reverse(templateEditor.getTemplateRevisions(templateId));
+        revisionInformations = new ArrayList<>(templateEditor.getTemplateRevisions(templateId));
+        Collections.reverse(revisionInformations);
     }
 
     public boolean isNewTemplate() {
@@ -227,7 +227,8 @@ public class EditTemplateView implements Serializable {
 
     void succeed() {
         GlobalMessageAppender.addSuccessMessage("Template successfully saved.");
-        revisionInformations = Lists.reverse(templateEditor.getTemplateRevisions(template.getId()));
+        revisionInformations = new ArrayList<>(templateEditor.getTemplateRevisions(template.getId()));
+        Collections.reverse(revisionInformations);
     }
 
     boolean fail(AMWException e) {

--- a/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/resourcetypeedit/EntityBuilder.java
+++ b/AMW_web/src/test/java/ch/puzzle/itc/mobiliar/presentation/resourcetypeedit/EntityBuilder.java
@@ -21,6 +21,7 @@
 package ch.puzzle.itc.mobiliar.presentation.resourcetypeedit;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -29,8 +30,6 @@ import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceFactory;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ResourceRelationTypeEntity;
 import ch.puzzle.itc.mobiliar.business.resourcegroup.entity.ResourceTypeEntity;
-
-import com.google.common.collect.Lists;
 
 public class EntityBuilder {
 
@@ -100,8 +99,8 @@ public class EntityBuilder {
 		child.setParentResourceType(base);
 	}
 
-	private ArrayList<String> amwTypes() {
-		return Lists.newArrayList("APPLICATIONSERVER", "NODE", "APPLICATION", "ActiveDirectory", "CertLoginModule", "DB2",
+	private List<String> amwTypes() {
+		return Arrays.asList("APPLICATIONSERVER", "NODE", "APPLICATION", "ActiveDirectory", "CertLoginModule", "DB2",
 				"JBoss7Management", "Keystore", "Mail", "ModCluster", "Truststore");
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -368,11 +368,6 @@
                 <version>2.3.0.1</version>
                 <scope>provided</scope>
             </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>33.5.0-jre</version>
-            </dependency>
             <!-- Test dependencies -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
## Summary

Successfully removed Google Guava dependency from the Java 11 project and replaced all usages with JDK standard library equivalents.

### Changes Made

**POM Files:**
- pom.xml: Removed Guava 33.5.0-jre from dependency management
- AMW_business/pom.xml: Removed Guava dependency
- AMW_web/pom.xml: Removed Guava dependency

**Main Source Code (13 files refactored):**
- Preconditions → `Objects.requireNonNull()`
- ImmutableList → `List.copyOf()`
- ImmutableSet → `Set.copyOf()`
- Maps.newHashMap/LinkedHashMap/TreeMap() → `new HashMap<>()` / `new LinkedHashMap<>()` / `new TreeMap<>()`
- Sets.newHashSet/LinkedHashSet() → `new HashSet<>()` / `new LinkedHashSet<>()`
- Lists.newArrayList() → `new ArrayList<>()`
- Lists.reverse() → `Collections.reverse()`
- Joiner → `String.join()`
- Enums.getIfPresent() → `Arrays.stream().anyMatch()`
- SetMultimap → `Map<K, Set<V>>`

**Test Files (19 files refactored):**
- Same replacements as main code
- Iterables.getLast() → List indexing
- Iterables.getFirst() → `iterator().next()`
- Resources.toString() → `InputStream.readAllBytes()`