### PR TITLE
feat(ui, rest): manage resource releases

### DIFF
--- a/AMW_angular/io/src/app/resources/contexts-list/contexts-list.component.ts
+++ b/AMW_angular/io/src/app/resources/contexts-list/contexts-list.component.ts
@@ -9,6 +9,7 @@ import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-contexts-list',
+  standalone: true,
   imports: [NgClass, UpperCasePipe],
   templateUrl: './contexts-list.component.html',
   styleUrl: './contexts-list.component.scss',

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
@@ -37,6 +37,12 @@
         <app-contexts-list></app-contexts-list>
       </div>
       <div class="flex-grow-1">
+        <app-resource-releases
+          [id]="id()"
+          [releases]="releases()"
+          [contextId]="contextId()"
+          [resourceTypeId]="resource()?.resourceTypeId || 0"
+        ></app-resource-releases>
         <app-resource-properties [contextId]="contextId()"></app-resource-properties>
         <app-resource-templates-list [resource]="resource()" [contextId]="contextId()"></app-resource-templates-list>
         <app-resource-functions-list [resource]="resource()" [contextId]="contextId()"></app-resource-functions-list>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
@@ -42,6 +42,7 @@
           [releases]="releases()"
           [contextId]="contextId()"
           [resourceTypeId]="resource()?.resourceTypeId || 0"
+          [resourceGroupId]="resource()?.resourceGroupId || 0"
         ></app-resource-releases>
         <app-resource-properties [contextId]="contextId()"></app-resource-properties>
         <app-resource-templates-list [resource]="resource()" [contextId]="contextId()"></app-resource-templates-list>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.html
@@ -41,8 +41,7 @@
           [id]="id()"
           [releases]="releases()"
           [contextId]="contextId()"
-          [resourceTypeId]="resource()?.resourceTypeId || 0"
-          [resourceGroupId]="resource()?.resourceGroupId || 0"
+          [resource]="resource()"
         ></app-resource-releases>
         <app-resource-properties [contextId]="contextId()"></app-resource-properties>
         <app-resource-templates-list [resource]="resource()" [contextId]="contextId()"></app-resource-templates-list>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.ts
@@ -14,6 +14,7 @@ import { ButtonComponent } from '../../shared/button/button.component';
 import { NgbDropdown, NgbDropdownItem, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/ng-bootstrap';
 import { ContextsListComponent } from '../contexts-list/contexts-list.component';
 import { ResourcePropertiesComponent } from './resource-properties/resource-properties.component';
+import { ResourceReleasesComponent } from './resource-releases/resource-releases.component';
 
 @Component({
   selector: 'app-resource-edit',
@@ -30,6 +31,7 @@ import { ResourcePropertiesComponent } from './resource-properties/resource-prop
     NgbDropdownItem,
     ContextsListComponent,
     ResourcePropertiesComponent,
+    ResourceReleasesComponent,
   ],
   templateUrl: './resource-edit.component.html',
   styleUrl: './resource-edit.component.scss',

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.ts
@@ -69,7 +69,7 @@ export class ResourcePropertiesComponent {
   permissions = computed(() => {
     if (this.authService.restrictions().length > 0) {
       return {
-        canAddProperty: this.authService.hasPermission('RESOURCE', 'UPDATE', null, null, this.context().name),
+        canAddProperty: this.authService.hasPermission('RESOURCE', 'UPDATE', null, null, this.context()?.name),
       };
     } else {
       return { canAddProperty: false };

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -19,7 +19,7 @@
           <tr
             style="cursor: pointer"
             [routerLink]="['/resource/edit']"
-            [queryParams]="{ ctx: contextId(), id: release.id, selectedResourceTypeId: resourceTypeId() }"
+            [queryParams]="{ ctx: contextId(), id: release.id, selectedResourceTypeId: resource().resourceTypeId }"
           >
             <td [class.fw-bold]="release.id === id()">
               {{ release.name }}
@@ -47,7 +47,7 @@
 </app-tile-component>
 
 <ng-template #deleteReleaseConfirmation let-modal>
-  <app-modal-header
+  < app-modal-header
     [title]="'Delete release ' + selectedRelease()?.name"
     (cancel)="modal.dismiss('Cross click')"
   ></app-modal-header>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -1,0 +1,29 @@
+<app-loading-indicator [isLoading]="isLoading()"></app-loading-indicator>
+<app-tile-component
+  [title]="'Releases'"
+  [actionName]="'New Release'"
+  [canAction]="permissions().canAddRelease"
+  [isVisible]="true"
+  (tileAction)="addRelease()"
+  [noContent]="false"
+  [notAllowed]="false"
+>
+  @if (!releases() || releases().length < 1) {
+    <div class="no-content">
+      <span>No Release for this resource</span>
+    </div>
+  } @else {
+    <ul>
+      @for (release of releases(); track release) {
+        <li [class.fw-bold]="release.id === id()">
+          <a
+            [routerLink]="['/resource/edit']"
+            [queryParams]="{ ctx: contextId(), id: release.id, selectedResourceTypeId: resourceTypeId() }"
+          >
+            {{ release.name }}
+          </a>
+        </li>
+      }
+    </ul>
+  }
+</app-tile-component>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -47,7 +47,7 @@
 </app-tile-component>
 
 <ng-template #deleteReleaseConfirmation let-modal>
-  < app-modal-header
+  <app-modal-header
     [title]="'Delete release ' + selectedRelease()?.name"
     (cancel)="modal.dismiss('Cross click')"
   ></app-modal-header>
@@ -57,5 +57,42 @@
   <div class="modal-footer">
     <app-button [variant]="'secondary'" (click)="modal.dismiss('Cancel click')">Cancel</app-button>
     <app-button [variant]="'danger'" (click)="modal.close('Confirm click')" ngbAutofocus>Delete</app-button>
+  </div>
+</ng-template>
+
+<ng-template #createReleaseModal let-modal>
+  <app-modal-header [title]="'Create New Release'" (cancel)="modal.dismiss('Cross click')"></app-modal-header>
+  <div class="modal-body">
+    @if (availableReleases().length === 0) {
+      <p>No available releases to create.</p>
+    } @else {
+      <div class="mb-3">
+        <label for="releaseSelect" class="form-label">Select Release</label>
+        <select
+          id="releaseSelect"
+          class="form-select"
+          [(ngModel)]="selectedReleaseId"
+          [disabled]="isCreatingRelease()"
+        >
+          <option [ngValue]="null">Select Release</option>
+          @for (release of availableReleases(); track release.id) {
+            <option [ngValue]="release.id">{{ release.name }}</option>
+          }
+        </select>
+      </div>
+    }
+  </div>
+  <div class="modal-footer">
+    <app-button [variant]="'secondary'" (click)="modal.dismiss('Cancel click')" [disabled]="isCreatingRelease()">
+      Cancel
+    </app-button>
+    <app-button
+      [variant]="'primary'"
+      (click)="modal.close('Create click')"
+      [disabled]="!selectedReleaseId || isCreatingRelease()"
+      ngbAutofocus
+    >
+      Create
+    </app-button>
   </div>
 </ng-template>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -13,17 +13,31 @@
       <span>No Release for this resource</span>
     </div>
   } @else {
-    <ul>
-      @for (release of releases(); track release) {
-        <li [class.fw-bold]="release.id === id()">
-          <a
+    <table class="table table-borderless">
+      <tbody>
+        @for (release of releases(); track release) {
+          <tr
+            style="cursor: pointer"
             [routerLink]="['/resource/edit']"
             [queryParams]="{ ctx: contextId(), id: release.id, selectedResourceTypeId: resourceTypeId() }"
           >
-            {{ release.name }}
-          </a>
-        </li>
-      }
-    </ul>
+            <td [class.fw-bold]="release.id === id()">
+              {{ release.name }}
+            </td>
+            <td class="text-end">
+              <app-button
+                title="Delete"
+                [size]="'sm'"
+                [variant]="'link'"
+                [additionalClasses]="'p-0 link-danger'"
+                (click)="deleteRelease(release.id); $event.stopPropagation(); $event.preventDefault()"
+              >
+                <app-icon icon="trash"></app-icon>
+              </app-button>
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
   }
 </app-tile-component>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -30,7 +30,11 @@
                 [size]="'sm'"
                 [variant]="'link'"
                 [additionalClasses]="'p-0 link-danger'"
-                (click)="deleteRelease(release.id); $event.stopPropagation(); $event.preventDefault()"
+                (click)="
+                  showDeleteConfirmation(deleteReleaseConfirmation, release);
+                  $event.stopPropagation();
+                  $event.preventDefault()
+                "
               >
                 <app-icon icon="trash"></app-icon>
               </app-button>
@@ -41,3 +45,17 @@
     </table>
   }
 </app-tile-component>
+
+<ng-template #deleteReleaseConfirmation let-modal>
+  <app-modal-header
+    [title]="'Delete release ' + selectedRelease()?.name"
+    (cancel)="modal.dismiss('Cross click')"
+  ></app-modal-header>
+  <div class="modal-body">
+    <p class="text-warning-2">Are you sure that you want to delete this release?</p>
+  </div>
+  <div class="modal-footer">
+    <app-button [variant]="'secondary'" (click)="modal.dismiss('Cancel click')">Cancel</app-button>
+    <app-button [variant]="'danger'" (click)="modal.close('Confirm click')" ngbAutofocus>Delete</app-button>
+  </div>
+</ng-template>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -63,7 +63,7 @@
 
 <ng-template #deleteReleaseConfirmation let-modal>
   <app-modal-header
-    [title]="'Delete release ' + selectedRelease()?.name"
+    [title]="'Delete release ' + releaseToDelete()?.name"
     (cancel)="modal.dismiss('Cross click')"
   ></app-modal-header>
   <div class="modal-body">
@@ -86,7 +86,8 @@
         <select
           id="releaseSelect"
           class="form-select"
-          [(ngModel)]="selectedReleaseId"
+          [ngModel]="selectedReleaseId()"
+          (ngModelChange)="selectedReleaseId.set($event)"
           [disabled]="isCreatingRelease()"
         >
           <option [ngValue]="null">Select Release</option>
@@ -104,7 +105,7 @@
     <app-button
       [variant]="'primary'"
       (click)="modal.close('Create click')"
-      [disabled]="!selectedReleaseId || isCreatingRelease()"
+      [disabled]="!selectedReleaseId() || isCreatingRelease()"
       ngbAutofocus
     >
       Create
@@ -126,7 +127,8 @@
         <select
           id="changeReleaseSelect"
           class="form-select"
-          [(ngModel)]="selectedReleaseId"
+          [ngModel]="selectedReleaseId()"
+          (ngModelChange)="selectedReleaseId.set($event)"
           [disabled]="isChangingRelease()"
         >
           <option [ngValue]="null">Select Release</option>
@@ -148,7 +150,7 @@
     <app-button
       [variant]="'primary'"
       (click)="modal.close('Change click')"
-      [disabled]="!selectedReleaseId || isChangingRelease()"
+      [disabled]="!selectedReleaseId() || isChangingRelease()"
       ngbAutofocus
     >
       Save

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -25,6 +25,21 @@
               {{ release.name }}
             </td>
             <td class="text-end">
+              @if (release.id === id()) {
+                <app-button
+                  title="Change Release"
+                  [size]="'sm'"
+                  [variant]="'link'"
+                  [additionalClasses]="'p-0 link-secondary me-2'"
+                  (click)="
+                    showChangeReleaseModal(release);
+                    $event.stopPropagation();
+                    $event.preventDefault()
+                  "
+                >
+                  <app-icon icon="pencil"></app-icon>
+                </app-button>
+              }
               <app-button
                 title="Delete"
                 [size]="'sm'"
@@ -93,6 +108,50 @@
       ngbAutofocus
     >
       Create
+    </app-button>
+  </div>
+</ng-template>
+
+<ng-template #changeReleaseModal let-modal>
+  <app-modal-header
+    [title]="'Change Release for ' + releaseToChange()?.name"
+    (cancel)="modal.dismiss('Cross click')"
+  ></app-modal-header>
+  <div class="modal-body">
+    @if (availableReleases().length === 0) {
+      <p>No available releases to change to.</p>
+    } @else {
+      <div class="mb-3">
+        <label for="changeReleaseSelect" class="form-label">Select New Release</label>
+        <select
+          id="changeReleaseSelect"
+          class="form-select"
+          [(ngModel)]="selectedReleaseId"
+          [disabled]="isChangingRelease()"
+        >
+          <option [ngValue]="null">Select Release</option>
+          @for (release of availableReleases(); track release.id) {
+            <option [ngValue]="release.id">{{ release.name }}</option>
+          }
+        </select>
+      </div>
+      <p class="text-muted small">
+        This will move the current resource to the selected release. The resource will keep its properties and
+        relations.
+      </p>
+    }
+  </div>
+  <div class="modal-footer">
+    <app-button [variant]="'secondary'" (click)="modal.dismiss('Cancel click')" [disabled]="isChangingRelease()">
+      Cancel
+    </app-button>
+    <app-button
+      [variant]="'primary'"
+      (click)="modal.close('Change click')"
+      [disabled]="!selectedReleaseId || isChangingRelease()"
+      ngbAutofocus
+    >
+      Save
     </app-button>
   </div>
 </ng-template>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.html
@@ -25,34 +25,32 @@
               {{ release.name }}
             </td>
             <td class="text-end">
-              @if (release.id === id()) {
+              @if (release.id === id() && permissions().canChangeRelease) {
                 <app-button
                   title="Change Release"
                   [size]="'sm'"
                   [variant]="'link'"
                   [additionalClasses]="'p-0 link-secondary me-2'"
-                  (click)="
-                    showChangeReleaseModal(release);
-                    $event.stopPropagation();
-                    $event.preventDefault()
-                  "
+                  (click)="showChangeReleaseModal(release); $event.stopPropagation(); $event.preventDefault()"
                 >
                   <app-icon icon="pencil"></app-icon>
                 </app-button>
               }
-              <app-button
-                title="Delete"
-                [size]="'sm'"
-                [variant]="'link'"
-                [additionalClasses]="'p-0 link-danger'"
-                (click)="
-                  showDeleteConfirmation(deleteReleaseConfirmation, release);
-                  $event.stopPropagation();
-                  $event.preventDefault()
-                "
-              >
-                <app-icon icon="trash"></app-icon>
-              </app-button>
+              @if (permissions().canDeleteRelease) {
+                <app-button
+                  title="Delete"
+                  [size]="'sm'"
+                  [variant]="'link'"
+                  [additionalClasses]="'p-0 link-danger'"
+                  (click)="
+                    showDeleteConfirmation(deleteReleaseConfirmation, release);
+                    $event.stopPropagation();
+                    $event.preventDefault()
+                  "
+                >
+                  <app-icon icon="trash"></app-icon>
+                </app-button>
+              }
             </td>
           </tr>
         }

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -11,6 +11,7 @@ import { ResourceService } from '../../services/resource.service';
 import { Resource } from '../../models/resource';
 import { FormsModule } from '@angular/forms';
 import { ModalHeaderComponent } from '../../../shared/modal-header/modal-header.component';
+import { ToastService } from '../../../shared/elements/toast/toast.service';
 
 @Component({
   selector: 'app-resource-releases',
@@ -32,6 +33,7 @@ export class ResourceReleasesComponent {
   private resourceService = inject(ResourceService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private toastService = inject(ToastService);
 
   isLoading = signal(false);
   selectedRelease = signal<Release | null>(null);
@@ -71,6 +73,7 @@ export class ResourceReleasesComponent {
       },
       error: (error) => {
         console.error('Failed to load available releases:', error);
+        this.toastService.error('Failed to load available releases.');
         this.isLoading.set(false);
       },
     });
@@ -120,6 +123,7 @@ export class ResourceReleasesComponent {
         },
         error: (error) => {
           console.error('Failed to create release:', error);
+          this.toastService.error('Failed to create release.');
           this.isCreatingRelease.set(false);
           this.selectedReleaseId = null;
         },
@@ -138,6 +142,7 @@ export class ResourceReleasesComponent {
       },
       error: (error) => {
         console.error('Failed to load available releases:', error);
+        this.toastService.error('Failed to load available releases.');
         this.isLoading.set(false);
         this.releaseToChange.set(null);
       },
@@ -177,6 +182,7 @@ export class ResourceReleasesComponent {
       },
       error: (error) => {
         console.error('Failed to change release:', error);
+        this.toastService.error('Failed to change release.');
         this.isChangingRelease.set(false);
         this.selectedReleaseId = null;
         this.releaseToChange.set(null);
@@ -225,6 +231,7 @@ export class ResourceReleasesComponent {
       },
       error: (error) => {
         console.error('Failed to delete release:', error);
+        this.toastService.error('Failed to delete release.');
         this.isLoading.set(false);
         this.selectedRelease.set(null);
       },

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -4,11 +4,13 @@ import { AuthService } from '../../../auth/auth.service';
 import { TileComponent } from '../../../shared/tile/tile.component';
 import { Release } from '../../models/release';
 import { RouterLink } from '@angular/router';
+import { IconComponent } from '../../../shared/icon/icon.component';
+import { ButtonComponent } from '../../../shared/button/button.component';
 
 @Component({
   selector: 'app-resource-releases',
   standalone: true,
-  imports: [LoadingIndicatorComponent, TileComponent, RouterLink],
+  imports: [LoadingIndicatorComponent, TileComponent, RouterLink, IconComponent, ButtonComponent],
   templateUrl: './resource-releases.component.html',
 })
 export class ResourceReleasesComponent {
@@ -34,5 +36,9 @@ export class ResourceReleasesComponent {
 
   addRelease() {
     console.log('add release');
+  }
+
+  deleteRelease(releaseId: number) {
+    console.log('delete release', releaseId);
   }
 }

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -7,13 +7,13 @@ import { RouterLink, Router, ActivatedRoute } from '@angular/router';
 import { IconComponent } from '../../../shared/icon/icon.component';
 import { ButtonComponent } from '../../../shared/button/button.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { ModalHeaderComponent } from '../../../shared/modal-header/modal-header.component';
 import { ResourceService } from '../../services/resource.service';
+import { Resource } from '../../models/resource';
 
 @Component({
   selector: 'app-resource-releases',
   standalone: true,
-  imports: [LoadingIndicatorComponent, TileComponent, RouterLink, IconComponent, ButtonComponent, ModalHeaderComponent],
+  imports: [LoadingIndicatorComponent, TileComponent, RouterLink, IconComponent, ButtonComponent],
   templateUrl: './resource-releases.component.html',
 })
 export class ResourceReleasesComponent {
@@ -29,8 +29,7 @@ export class ResourceReleasesComponent {
   id = input.required<number>();
   releases = input.required<Release[]>();
   contextId = input.required<number>();
-  resourceTypeId = input.required<number>();
-  resourceGroupId = input.required<number>();
+  resource = input.required<Resource>();
 
   // same permissions for crud
   permissions = computed(() => {

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -6,17 +6,21 @@ import { Release } from '../../models/release';
 import { RouterLink } from '@angular/router';
 import { IconComponent } from '../../../shared/icon/icon.component';
 import { ButtonComponent } from '../../../shared/button/button.component';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { ModalHeaderComponent } from '../../../shared/modal-header/modal-header.component';
 
 @Component({
   selector: 'app-resource-releases',
   standalone: true,
-  imports: [LoadingIndicatorComponent, TileComponent, RouterLink, IconComponent, ButtonComponent],
+  imports: [LoadingIndicatorComponent, TileComponent, RouterLink, IconComponent, ButtonComponent, ModalHeaderComponent],
   templateUrl: './resource-releases.component.html',
 })
 export class ResourceReleasesComponent {
   private authService = inject(AuthService);
+  private modalService = inject(NgbModal);
 
   isLoading = signal(false);
+  selectedRelease = signal<Release | null>(null);
 
   id = input.required<number>();
   releases = input.required<Release[]>();
@@ -38,7 +42,20 @@ export class ResourceReleasesComponent {
     console.log('add release');
   }
 
+  showDeleteConfirmation(content: unknown, release: Release) {
+    this.selectedRelease.set(release);
+    this.modalService.open(content).result.then(
+      () => {
+        this.deleteRelease(release.id);
+      },
+      () => {
+        this.selectedRelease.set(null);
+      },
+    );
+  }
+
   deleteRelease(releaseId: number) {
     console.log('delete release', releaseId);
+    this.selectedRelease.set(null);
   }
 }

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -36,9 +36,9 @@ export class ResourceReleasesComponent {
   private toastService = inject(ToastService);
 
   isLoading = signal(false);
-  selectedRelease = signal<Release | null>(null);
+  releaseToDelete = signal<Release | null>(null);
   availableReleases = signal<Release[]>([]);
-  selectedReleaseId: number | null = null;
+  selectedReleaseId = signal<number | null>(null);
   isCreatingRelease = signal(false);
   releaseToChange = signal<Release | null>(null);
   isChangingRelease = signal(false);
@@ -67,7 +67,7 @@ export class ResourceReleasesComponent {
     this.resourceService.getAvailableReleasesForResource(this.id()).subscribe({
       next: (releases) => {
         this.availableReleases.set(releases);
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
         this.isLoading.set(false);
         this.showCreateReleaseModal();
       },
@@ -83,12 +83,12 @@ export class ResourceReleasesComponent {
     const modalRef = this.modalService.open(this.createReleaseModal);
     modalRef.result.then(
       () => {
-        if (this.selectedReleaseId) {
-          this.createRelease(this.selectedReleaseId);
+        if (this.selectedReleaseId()) {
+          this.createRelease(this.selectedReleaseId()!);
         }
       },
       () => {
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
       },
     );
   }
@@ -118,14 +118,14 @@ export class ResourceReleasesComponent {
       .subscribe({
         next: () => {
           this.isCreatingRelease.set(false);
-          this.selectedReleaseId = null;
+          this.selectedReleaseId.set(null);
           this.resourceService.setIdForResource(this.id());
         },
         error: (error) => {
           console.error('Failed to create release:', error);
           this.toastService.error('Failed to create release.');
           this.isCreatingRelease.set(false);
-          this.selectedReleaseId = null;
+          this.selectedReleaseId.set(null);
         },
       });
   }
@@ -136,7 +136,7 @@ export class ResourceReleasesComponent {
     this.resourceService.getAvailableReleasesForResource(release.id).subscribe({
       next: (releases) => {
         this.availableReleases.set(releases);
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
         this.isLoading.set(false);
         this.openChangeReleaseModal();
       },
@@ -153,12 +153,12 @@ export class ResourceReleasesComponent {
     const modalRef = this.modalService.open(this.changeReleaseModal);
     modalRef.result.then(
       () => {
-        if (this.selectedReleaseId && this.releaseToChange()) {
-          this.changeRelease(this.releaseToChange()!.id, this.selectedReleaseId);
+        if (this.selectedReleaseId() && this.releaseToChange()) {
+          this.changeRelease(this.releaseToChange()!.id, this.selectedReleaseId()!);
         }
       },
       () => {
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
         this.releaseToChange.set(null);
       },
     );
@@ -169,7 +169,7 @@ export class ResourceReleasesComponent {
     this.resourceService.changeResourceRelease(resourceId, releaseId).subscribe({
       next: () => {
         this.isChangingRelease.set(false);
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
         this.releaseToChange.set(null);
         // Reload the resource and releases data to reflect the change
         this.resourceService.setIdForResource(resourceId);
@@ -184,20 +184,20 @@ export class ResourceReleasesComponent {
         console.error('Failed to change release:', error);
         this.toastService.error('Failed to change release.');
         this.isChangingRelease.set(false);
-        this.selectedReleaseId = null;
+        this.selectedReleaseId.set(null);
         this.releaseToChange.set(null);
       },
     });
   }
 
   showDeleteConfirmation(content: unknown, release: Release) {
-    this.selectedRelease.set(release);
+    this.releaseToDelete.set(release);
     this.modalService.open(content).result.then(
       () => {
         this.deleteRelease(release.id);
       },
       () => {
-        this.selectedRelease.set(null);
+        this.releaseToDelete.set(null);
       },
     );
   }
@@ -209,7 +209,7 @@ export class ResourceReleasesComponent {
     this.resourceService.deleteResourceByResourceId(resourceIdToDelete).subscribe({
       next: () => {
         this.isLoading.set(false);
-        this.selectedRelease.set(null);
+        this.releaseToDelete.set(null);
         // Only navigate if we deleted the currently selected release
         if (resourceIdToDelete === this.id()) {
           const remainingReleases = this.releases().filter((r) => r.id !== resourceIdToDelete);
@@ -233,7 +233,7 @@ export class ResourceReleasesComponent {
         console.error('Failed to delete release:', error);
         this.toastService.error('Failed to delete release.');
         this.isLoading.set(false);
-        this.selectedRelease.set(null);
+        this.releaseToDelete.set(null);
       },
     });
   }

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -51,15 +51,17 @@ export class ResourceReleasesComponent {
   contextId = input.required<number>();
   resource = input.required<Resource>();
 
-  // same permissions for crud
   permissions = computed(() => {
     if (this.authService.restrictions().length > 0) {
+      const resourceTypeName = this.resource()?.type ?? null;
+      const resourceGroupId = this.resource()?.resourceGroupId ?? null;
       return {
-        //canAddRelease: this.authService.hasPermission('RESOURCE', 'UPDATE', null, null, this.context().name),
-        canAddRelease: true, // TODO: replace with actual permission check
+        canAddRelease: this.authService.hasPermission('RESOURCE', 'CREATE', resourceTypeName, resourceGroupId),
+        canChangeRelease: this.authService.hasPermission('RELEASE', 'UPDATE', resourceTypeName, resourceGroupId),
+        canDeleteRelease: this.authService.hasPermission('RESOURCE', 'DELETE', resourceTypeName, resourceGroupId),
       };
     }
-    return { canAddRelease: false };
+    return { canAddRelease: false, canChangeRelease: false, canDeleteRelease: false };
   });
 
   addRelease() {

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -41,8 +41,8 @@ export class ResourceReleasesComponent {
   releaseToChange = signal<Release | null>(null);
   isChangingRelease = signal(false);
 
-  @ViewChild('createReleaseModal') createReleaseModal!: TemplateRef<any>;
-  @ViewChild('changeReleaseModal') changeReleaseModal!: TemplateRef<any>;
+  @ViewChild('createReleaseModal') createReleaseModal!: TemplateRef<void>;
+  @ViewChild('changeReleaseModal') changeReleaseModal!: TemplateRef<void>;
 
   id = input.required<number>();
   releases = input.required<Release[]>();

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-releases/resource-releases.component.ts
@@ -1,0 +1,38 @@
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { LoadingIndicatorComponent } from '../../../shared/elements/loading-indicator.component';
+import { AuthService } from '../../../auth/auth.service';
+import { TileComponent } from '../../../shared/tile/tile.component';
+import { Release } from '../../models/release';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-resource-releases',
+  standalone: true,
+  imports: [LoadingIndicatorComponent, TileComponent, RouterLink],
+  templateUrl: './resource-releases.component.html',
+})
+export class ResourceReleasesComponent {
+  private authService = inject(AuthService);
+
+  isLoading = signal(false);
+
+  id = input.required<number>();
+  releases = input.required<Release[]>();
+  contextId = input.required<number>();
+  resourceTypeId = input.required<number>();
+
+  // same permissions for crud
+  permissions = computed(() => {
+    if (this.authService.restrictions().length > 0) {
+      return {
+        //canAddRelease: this.authService.hasPermission('RESOURCE', 'UPDATE', null, null, this.context().name),
+        canAddRelease: true, // TODO: replace with actual permission check
+      };
+    }
+    return { canAddRelease: false };
+  });
+
+  addRelease() {
+    console.log('add release');
+  }
+}

--- a/AMW_angular/io/src/app/resources/services/resource.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource.service.ts
@@ -228,6 +228,14 @@ export class ResourceService extends BaseService {
       )
       .pipe(catchError(this.handleError));
   }
+
+  changeResourceRelease(resourceId: number, releaseId: number): Observable<void> {
+    return this.http
+      .put<void>(`${this.getBaseUrl()}/resources/${resourceId}/release/${releaseId}`, null, {
+        headers: this.getHeaders(),
+      })
+      .pipe(catchError(this.handleError));
+  }
 }
 
 function toAppWithVersion(r: any): AppWithVersion {

--- a/AMW_angular/io/src/app/resources/services/resource.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource.service.ts
@@ -210,6 +210,24 @@ export class ResourceService extends BaseService {
       })
       .pipe(catchError(this.handleError));
   }
+
+  getAvailableReleasesForResource(resourceId: number): Observable<Release[]> {
+    return this.http
+      .get<Release[]>(`${this.getBaseUrl()}/resources/${resourceId}/availableReleases`, {
+        headers: this.getHeaders(),
+      })
+      .pipe(catchError(this.handleError));
+  }
+
+  createResourceRelease(resourceGroupName: string, releaseName: string, sourceReleaseName: string): Observable<void> {
+    return this.http
+      .post<void>(
+        `${this.getBaseUrl()}/resources/${resourceGroupName}`,
+        { releaseName, sourceReleaseName },
+        { headers: this.getHeaders() },
+      )
+      .pipe(catchError(this.handleError));
+  }
 }
 
 function toAppWithVersion(r: any): AppWithVersion {

--- a/AMW_angular/io/src/app/resources/services/resource.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource.service.ts
@@ -202,6 +202,14 @@ export class ResourceService extends BaseService {
       .get<Release[]>(`${this.getBaseUrl()}/resources/resourceGroups/releases/${resourceId}`)
       .pipe(catchError(this.handleError));
   }
+
+  deleteResourceByResourceId(resourceId: number): Observable<void> {
+    return this.http
+      .delete<void>(`${this.getBaseUrl()}/resources/${resourceId}`, {
+        headers: this.getHeaders(),
+      })
+      .pipe(catchError(this.handleError));
+  }
 }
 
 function toAppWithVersion(r: any): AppWithVersion {

--- a/AMW_angular/io/src/app/resources/services/resource.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource.service.ts
@@ -5,7 +5,6 @@ import { map, catchError, switchMap, shareReplay } from 'rxjs/operators';
 import { Resource } from '../models/resource';
 import { Release } from '../models/release';
 import { Relation } from '../models/relation';
-import { Property } from '../models/property';
 import { AppWithVersion } from '../../deployment/app-with-version';
 import { BaseService } from '../../base/base.service';
 import { ResourceType } from '../models/resource-type';

--- a/AMW_angular/io/src/app/shared/modal-header/modal-header.component.ts
+++ b/AMW_angular/io/src/app/shared/modal-header/modal-header.component.ts
@@ -2,6 +2,7 @@ import { Component, input, output } from '@angular/core';
 
 @Component({
   selector: 'app-modal-header',
+  standalone: true,
   imports: [],
   template: `<div class="modal-header">
     <h5 class="modal-title">{{ title() }}</h5>

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -140,6 +140,19 @@ public class ResourceGroupsRest {
         return Response.ok(new ResourceDTO(resourceBoundary.getResource(id))).build();
     }
 
+    @DELETE
+    @Path("/{id : \\d+}")
+    @Operation(summary = "Delete a resource by id")
+    @Produces(APPLICATION_JSON)
+    public Response deleteResourceById(@Parameter(description = "Resource ID") @PathParam("id") Integer id) throws NotFoundException, ElementAlreadyExistsException {
+        ResourceEntity resource = resourceLocator.getResourceById(id);
+        if (resource == null) {
+            return Response.status(NOT_FOUND).entity(new ExceptionDto("Resource not found")).build();
+        }
+        resourceBoundary.removeResource(id);
+        return Response.ok().build();
+    }
+
     @GET
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Get resource groups", description = "Returns the available resource groups")

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -512,4 +512,23 @@ public class ResourceGroupsRest {
                 .collect(Collectors.toList());
         return Response.ok(releaseDTOs).build();
     }
+
+    @Path("/{resourceId}/release/{releaseId}")
+    @PUT
+    @Produces(APPLICATION_JSON)
+    @Operation(summary = "Change the release of a resource - used by Angular")
+    public Response changeResourceRelease(@PathParam("resourceId") Integer resourceId,
+                                         @PathParam("releaseId") Integer releaseId) {
+        try {
+            releaseMgmtService.changeReleaseOfResource(
+                resourceLocator.getResourceById(resourceId),
+                releaseLocator.getReleaseById(releaseId)
+            );
+            return Response.ok().build();
+        } catch (ResourceNotFoundException e) {
+            return Response.status(NOT_FOUND).entity(new ExceptionDto(e.getMessage())).build();
+        } catch (NotFoundException e) {
+            return Response.status(NOT_FOUND).entity(new ExceptionDto(e.getMessage())).build();
+        }
+    }
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -518,17 +518,11 @@ public class ResourceGroupsRest {
     @Produces(APPLICATION_JSON)
     @Operation(summary = "Change the release of a resource - used by Angular")
     public Response changeResourceRelease(@PathParam("resourceId") Integer resourceId,
-                                         @PathParam("releaseId") Integer releaseId) {
-        try {
-            releaseMgmtService.changeReleaseOfResource(
-                resourceLocator.getResourceById(resourceId),
-                releaseLocator.getReleaseById(releaseId)
-            );
-            return Response.ok().build();
-        } catch (ResourceNotFoundException e) {
-            return Response.status(NOT_FOUND).entity(new ExceptionDto(e.getMessage())).build();
-        } catch (NotFoundException e) {
-            return Response.status(NOT_FOUND).entity(new ExceptionDto(e.getMessage())).build();
-        }
+                                         @PathParam("releaseId") Integer releaseId) throws NotFoundException {
+        releaseMgmtService.changeReleaseOfResource(
+            resourceLocator.getResourceById(resourceId),
+            releaseLocator.getReleaseById(releaseId)
+        );
+        return Response.ok().build();
     }
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceGroupsRest.java
@@ -132,6 +132,9 @@ public class ResourceGroupsRest {
     @Inject
     private ResourceRelationService resourceRelationService;
 
+    @Inject
+    private ch.puzzle.itc.mobiliar.business.releasing.boundary.Releasing releasing;
+
     @GET
     @Path("/{id : \\d+}")
     @Operation(summary = "Get a resource by id")
@@ -492,5 +495,21 @@ public class ResourceGroupsRest {
                 .map(entry -> new ReleaseDTO(entry.getValue(), entry.getKey()))
                 .collect(Collectors.toList());
         return Response.ok(releases).build();
+    }
+
+    @Path("/{resourceId}/availableReleases")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get available releases for creating a new resource release - used by Angular")
+    public Response getAvailableReleasesForResource(@PathParam("resourceId") Integer resourceId) {
+        ResourceEntity resource = resourceLocator.getResourceById(resourceId);
+        if (resource == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        List<ReleaseEntity> availableReleases = releasing.getNotDefinedReleasesForResource(resource);
+        List<ReleaseDTO> releaseDTOs = availableReleases.stream()
+                .map(release -> new ReleaseDTO(release.getId(), release.getName()))
+                .collect(Collectors.toList());
+        return Response.ok(releaseDTOs).build();
     }
 }


### PR DESCRIPTION
This PR adds a new "Release"-Tile to the edit resource page.

The purpose of the tile is to add the features to the page that were previously covered by the "releases" dropdown as shown in the following image:

<img width="642" height="158" alt="image" src="https://github.com/user-attachments/assets/517c4d42-2b37-43ec-961a-7869a6c43df1" />

The functionality is not captured in a tile:

<img width="1804" height="279" alt="image" src="https://github.com/user-attachments/assets/5535d39c-c84d-4bff-97b1-f81e7a83269e" />


What is different to the old implemenation:

- the current resource release that is now visible is indicated in **bold**
- trash icons are used to delete one of the resource releases - now any release can be deleted in this view, not only the currently loaded one
- only the release of the currently selected resource release can be changed - this makes it a bit clearer for the user what happens

Notes:
* The changes use new components that are not on the master branch yet, thats why the target branch is set to feat/resource-properties
* The layout/ placement of the tiles on the edit resource page is not final - this should be probably reworked when more  functionality is implemented
