### PR TITLE
Feat/related applications (1202)

### DIFF
--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.html
@@ -1,0 +1,28 @@
+@if (isApplicationServerToNode() && hasApplications()) {
+  <div class="active-applications-section">
+    <h4>Active Applications</h4>
+    <p class="text-muted small">
+      Uncheck applications to exclude them from deployment on this node.
+    </p>
+
+    <app-loading-indicator [isLoading]="isLoading()"></app-loading-indicator>
+
+    <div class="applications-list">
+      @for (app of activations(); track app.resourceGroupId) {
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            [id]="'app-' + app.resourceGroupId"
+            [checked]="isApplicationActive(app.resourceGroupId)"
+            (change)="onCheckboxChange(app.resourceGroupId, $event.target.checked)"
+            [disabled]="!canEdit()"
+          />
+          <label class="form-check-label" [for]="'app-' + app.resourceGroupId">
+            {{ app.resourceGroupName }}
+          </label>
+        </div>
+      }
+    </div>
+  </div>
+}

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentRef } from '@angular/core';
+import { of } from 'rxjs';
+
+import { RelationActiveApplicationsComponent } from './relation-active-applications.component';
+import { ResourceActivationService, ResourceActivation } from '../../../services/resource-activation.service';
+
+describe('RelationActiveApplicationsComponent', () => {
+  let component: RelationActiveApplicationsComponent;
+  let fixture: ComponentFixture<RelationActiveApplicationsComponent>;
+  let componentRef: ComponentRef<RelationActiveApplicationsComponent>;
+  let mockActivationService: jasmine.SpyObj<ResourceActivationService>;
+
+  const mockActivations: ResourceActivation[] = [
+    { resourceGroupId: 1, resourceGroupName: 'Application A', active: true },
+    { resourceGroupId: 2, resourceGroupName: 'Application B', active: false },
+    { resourceGroupId: 3, resourceGroupName: 'Application C', active: true },
+  ];
+
+  beforeEach(async () => {
+    mockActivationService = jasmine.createSpyObj('ResourceActivationService', [
+      'setRelationParams',
+    ], {
+      activations: mockActivations,
+      isLoading: false,
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [RelationActiveApplicationsComponent],
+      providers: [
+        { provide: ResourceActivationService, useValue: mockActivationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RelationActiveApplicationsComponent);
+    component = fixture.componentInstance;
+    componentRef = fixture.componentRef;
+
+    // Set required inputs
+    componentRef.setInput('resourceId', 100);
+    componentRef.setInput('relationId', 200);
+    componentRef.setInput('contextId', 1);
+    componentRef.setInput('isApplicationServerToNode', true);
+    componentRef.setInput('canEdit', true);
+    componentRef.setInput('activeApplicationIds', [1, 3]);
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set relation params on service when inputs change', () => {
+    expect(mockActivationService.setRelationParams).toHaveBeenCalledWith(100, 200, 1);
+  });
+
+  it('should compute activations from service', () => {
+    expect(component.activations()).toEqual(mockActivations);
+  });
+
+  it('should compute hasApplications based on activations', () => {
+    expect(component.hasApplications()).toBe(true);
+
+    // Test empty activations
+    mockActivationService.activations = [];
+    fixture.detectChanges();
+    expect(component.hasApplications()).toBe(false);
+  });
+
+  it('should determine if application is active', () => {
+    expect(component.isApplicationActive(1)).toBe(true);
+    expect(component.isApplicationActive(2)).toBe(false);
+    expect(component.isApplicationActive(3)).toBe(true);
+  });
+
+  describe('onCheckboxChange', () => {
+    it('should emit activationChange with added app ID when checked', () => {
+      spyOn(component.activationChange, 'emit');
+
+      component.onCheckboxChange(2, true);
+
+      expect(component.activationChange.emit).toHaveBeenCalledWith([1, 3, 2]);
+    });
+
+    it('should emit activationChange with removed app ID when unchecked', () => {
+      spyOn(component.activationChange, 'emit');
+
+      component.onCheckboxChange(1, false);
+
+      expect(component.activationChange.emit).toHaveBeenCalledWith([3]);
+    });
+
+    it('should handle multiple changes correctly', () => {
+      spyOn(component.activationChange, 'emit');
+
+      // First uncheck app 1
+      component.onCheckboxChange(1, false);
+      expect(component.activationChange.emit).toHaveBeenCalledWith([3]);
+
+      // Then check app 2
+      componentRef.setInput('activeApplicationIds', [3]);
+      component.onCheckboxChange(2, true);
+      expect(component.activationChange.emit).toHaveBeenCalledWith([3, 2]);
+    });
+  });
+
+  it('should inherit isLoading from service', () => {
+    expect(component.isLoading()).toBe(false);
+  });
+
+  describe('conditional rendering', () => {
+    it('should not render when isApplicationServerToNode is false', () => {
+      componentRef.setInput('isApplicationServerToNode', false);
+      fixture.detectChanges();
+
+      const section = fixture.nativeElement.querySelector('.active-applications-section');
+      expect(section).toBeFalsy();
+    });
+
+    it('should not render when hasApplications is false', () => {
+      mockActivationService.activations = [];
+      fixture.detectChanges();
+
+      const section = fixture.nativeElement.querySelector('.active-applications-section');
+      expect(section).toBeFalsy();
+    });
+
+    it('should render when conditions are met', () => {
+      const section = fixture.nativeElement.querySelector('.active-applications-section');
+      expect(section).toBeTruthy();
+
+      const heading = section.querySelector('h4');
+      expect(heading.textContent).toContain('Active Applications');
+    });
+
+    it('should render checkboxes for each application', () => {
+      const checkboxes = fixture.nativeElement.querySelectorAll('input[type="checkbox"]');
+      expect(checkboxes.length).toBe(3);
+    });
+
+    it('should disable checkboxes when canEdit is false', () => {
+      componentRef.setInput('canEdit', false);
+      fixture.detectChanges();
+
+      const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+      expect(checkbox.disabled).toBe(true);
+    });
+
+    it('should enable checkboxes when canEdit is true', () => {
+      const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+      expect(checkbox.disabled).toBe(false);
+    });
+  });
+});

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ComponentRef } from '@angular/core';
-import { of } from 'rxjs';
+import { ComponentRef, signal } from '@angular/core';
 
 import { RelationActiveApplicationsComponent } from './relation-active-applications.component';
 import { ResourceActivationService, ResourceActivation } from '../../../services/resource-activation.service';
@@ -9,7 +8,11 @@ describe('RelationActiveApplicationsComponent', () => {
   let component: RelationActiveApplicationsComponent;
   let fixture: ComponentFixture<RelationActiveApplicationsComponent>;
   let componentRef: ComponentRef<RelationActiveApplicationsComponent>;
-  let mockActivationService: jasmine.SpyObj<ResourceActivationService>;
+  let mockActivationService: {
+    setRelationParams: ReturnType<typeof vi.fn>;
+    activations: ReturnType<typeof signal<ResourceActivation[]>>;
+    isLoading: ReturnType<typeof signal<boolean>>;
+  };
 
   const mockActivations: ResourceActivation[] = [
     { resourceGroupId: 1, resourceGroupName: 'Application A', active: true },
@@ -18,18 +21,15 @@ describe('RelationActiveApplicationsComponent', () => {
   ];
 
   beforeEach(async () => {
-    mockActivationService = jasmine.createSpyObj('ResourceActivationService', [
-      'setRelationParams',
-    ], {
-      activations: mockActivations,
-      isLoading: false,
-    });
+    mockActivationService = {
+      setRelationParams: vi.fn(),
+      activations: signal(mockActivations),
+      isLoading: signal(false),
+    };
 
     await TestBed.configureTestingModule({
       imports: [RelationActiveApplicationsComponent],
-      providers: [
-        { provide: ResourceActivationService, useValue: mockActivationService },
-      ],
+      providers: [{ provide: ResourceActivationService, useValue: mockActivationService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(RelationActiveApplicationsComponent);
@@ -63,7 +63,7 @@ describe('RelationActiveApplicationsComponent', () => {
     expect(component.hasApplications()).toBe(true);
 
     // Test empty activations
-    mockActivationService.activations = [];
+    mockActivationService.activations.set([]);
     fixture.detectChanges();
     expect(component.hasApplications()).toBe(false);
   });
@@ -76,7 +76,7 @@ describe('RelationActiveApplicationsComponent', () => {
 
   describe('onCheckboxChange', () => {
     it('should emit activationChange with added app ID when checked', () => {
-      spyOn(component.activationChange, 'emit');
+      vi.spyOn(component.activationChange, 'emit');
 
       component.onCheckboxChange(2, true);
 
@@ -84,7 +84,7 @@ describe('RelationActiveApplicationsComponent', () => {
     });
 
     it('should emit activationChange with removed app ID when unchecked', () => {
-      spyOn(component.activationChange, 'emit');
+      vi.spyOn(component.activationChange, 'emit');
 
       component.onCheckboxChange(1, false);
 
@@ -92,7 +92,7 @@ describe('RelationActiveApplicationsComponent', () => {
     });
 
     it('should handle multiple changes correctly', () => {
-      spyOn(component.activationChange, 'emit');
+      vi.spyOn(component.activationChange, 'emit');
 
       // First uncheck app 1
       component.onCheckboxChange(1, false);
@@ -119,7 +119,7 @@ describe('RelationActiveApplicationsComponent', () => {
     });
 
     it('should not render when hasApplications is false', () => {
-      mockActivationService.activations = [];
+      mockActivationService.activations.set([]);
       fixture.detectChanges();
 
       const section = fixture.nativeElement.querySelector('.active-applications-section');

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/relation-active-applications/relation-active-applications.component.ts
@@ -1,0 +1,57 @@
+import { Component, computed, effect, inject, input, output } from '@angular/core';
+import { ResourceActivationService, ResourceActivation } from '../../../services/resource-activation.service';
+import { FormsModule } from '@angular/forms';
+import { LoadingIndicatorComponent } from '../../../../shared/elements/loading-indicator.component';
+
+@Component({
+  selector: 'app-relation-active-applications',
+  standalone: true,
+  imports: [FormsModule, LoadingIndicatorComponent],
+  templateUrl: './relation-active-applications.component.html',
+})
+export class RelationActiveApplicationsComponent {
+  private resourceActivationService = inject(ResourceActivationService);
+
+  resourceId = input.required<number>();
+  relationId = input.required<number>();
+  contextId = input.required<number>();
+  isApplicationServerToNode = input.required<boolean>();
+  canEdit = input.required<boolean>();
+  activeApplicationIds = input.required<number[]>();
+
+  activationChange = output<number[]>();
+
+  constructor() {
+    effect(() => {
+      const resourceId = this.resourceId();
+      const relationId = this.relationId();
+      const contextId = this.contextId();
+      const isAppServerToNode = this.isApplicationServerToNode();
+
+      if (resourceId && relationId && contextId && isAppServerToNode) {
+        this.resourceActivationService.setRelationParams(resourceId, relationId, contextId);
+      }
+    });
+  }
+
+  activations = computed(() => this.resourceActivationService.activations());
+  isLoading = this.resourceActivationService.isLoading;
+  hasApplications = computed(() => this.activations().length > 0);
+
+  onCheckboxChange(applicationId: number, checked: boolean) {
+    const current = this.activeApplicationIds();
+    let updated: number[];
+
+    if (checked) {
+      updated = [...current, applicationId];
+    } else {
+      updated = current.filter((id) => id !== applicationId);
+    }
+
+    this.activationChange.emit(updated);
+  }
+
+  isApplicationActive(applicationId: number): boolean {
+    return this.activeApplicationIds().includes(applicationId);
+  }
+}

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
@@ -93,6 +93,16 @@
                 (resetToggled)="onPropertyReset($event.name, $event.checked)"
                 (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
               ></app-properties-list>
+
+              <app-relation-active-applications
+                [resourceId]="resource()?.id!"
+                [relationId]="selectedRelation()?.id!"
+                [contextId]="contextId()"
+                [isApplicationServerToNode]="isApplicationServerToNodeRelation()"
+                [canEdit]="permissions().canUpdateProperty"
+                [activeApplicationIds]="currentActiveAppIds()"
+                (activationChange)="onActivationChange($event)"
+              ></app-relation-active-applications>
             </app-properties-panel>
           </div>
         </div>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
@@ -1,8 +1,19 @@
-import { Component, computed, inject, linkedSignal, signal, Signal, TemplateRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  linkedSignal,
+  signal,
+  Signal,
+  TemplateRef,
+  ViewChild,
+  effect,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { Observable } from 'rxjs';
+import { Observable, of, forkJoin } from 'rxjs';
 import { NgOptionComponent, NgSelectComponent } from '@ng-select/ng-select';
+import { finalize } from 'rxjs/operators';
 import { TileComponent } from '../../../shared/tile/tile.component';
 import { LoadingIndicatorComponent } from '../../../shared/elements/loading-indicator.component';
 import { ButtonComponent } from '../../../shared/button/button.component';
@@ -19,6 +30,8 @@ import { RelationGroupItem, RelationGroupComponent } from '../../relation-group/
 import { PropertiesPanelComponent } from '../../properties-panel/properties-panel.component';
 import { PropertiesListComponent } from '../../properties-list/properties-list.component';
 import { BaseRelationsDirective, NODE_FILTERED_PROPERTIES } from '../../base-relations/base-relations.directive';
+import { RelationActiveApplicationsComponent } from './relation-active-applications/relation-active-applications.component';
+import { ResourceActivationService, ResourceActivation } from '../../services/resource-activation.service';
 
 @Component({
   selector: 'app-resource-relations',
@@ -36,6 +49,7 @@ import { BaseRelationsDirective, NODE_FILTERED_PROPERTIES } from '../../base-rel
     IconComponent,
     RouterLink,
     ModalHeaderComponent,
+    RelationActiveApplicationsComponent,
   ],
   templateUrl: './resource-relations.component.html',
   styleUrl: './resource-relations.component.scss',
@@ -43,6 +57,7 @@ import { BaseRelationsDirective, NODE_FILTERED_PROPERTIES } from '../../base-rel
 export class ResourceRelationsComponent extends BaseRelationsDirective {
   private resourceService = inject(ResourceService);
   private resourceTypesService = inject(ResourceTypesService);
+  private resourceActivationService = inject(ResourceActivationService);
   resource: Signal<Resource> = this.resourceService.resource;
 
   @ViewChild('addRelationModal') addRelationModal!: TemplateRef<void>;
@@ -61,6 +76,19 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
   selectedResourceGroupId = signal<number | null>(null);
   addAsProvided = signal<boolean>(false);
   isAddingRelation = signal<boolean>(false);
+
+  originalActiveAppIds = signal<number[]>([]);
+  currentActiveAppIds = signal<number[]>([]);
+  isSavingActivations = signal(false);
+
+  protected groupedRelations: Signal<GroupedResourceRelations> = this.relationsService.relations;
+  protected isLoadingRelations = this.relationsService.isLoadingRelations;
+  protected isLoadingProperties = this.relationsService.isLoadingRelationProperties;
+
+  protected hasRelations = computed(() => {
+    const g = this.groupedRelations();
+    return g.runtime.length + g.consumed.length + g.provided.length + g.unresolved.length > 0;
+  });
 
   isResource = computed(
     () =>
@@ -90,9 +118,6 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     return releases.some((r) => r.release > res.release);
   });
 
-  protected groupedRelations: Signal<GroupedResourceRelations> = this.relationsService.relations;
-  protected isLoadingRelations = this.relationsService.isLoadingRelations;
-
   protected permissions = computed(() => {
     if (this.authService.restrictions().length > 0) {
       return {
@@ -114,11 +139,6 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     } else {
       return { canUpdateProperty: false, canDecryptProperties: false };
     }
-  });
-
-  protected hasRelations = computed(() => {
-    const g = this.groupedRelations();
-    return g.runtime.length + g.consumed.length + g.provided.length + g.unresolved.length > 0;
   });
 
   // set by url, input, onItemSelected and onReleaseChange
@@ -163,7 +183,16 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
 
   selectedRelationIdForRelease = computed(() => this.selectedRelation()?.id ?? null);
 
-  protected isLoadingProperties = this.relationsService.isLoadingRelationProperties;
+  protected isApplicationServerToNodeRelation = computed(() => {
+    const resource = this.resource();
+    const relation = this.selectedRelation();
+    if (!resource || !relation) return false;
+
+    const isAppServer = resource.type === 'APPLICATIONSERVER' || resource.type === '"APPLICATIONSERVER"';
+    const isNode = relation.type === 'NODE' || relation.type === '"NODE"';
+
+    return isAppServer && isNode;
+  });
 
   protected properties = computed<Property[]>(() => {
     const props = this.relationsService.relationProperties;
@@ -181,68 +210,6 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     return result;
   });
 
-  protected entityId = computed(() => this.resource()?.id);
-
-  protected reloadRelation(entityId: number): void {
-    this.relationsService.setIdForResourceRelations(entityId);
-  }
-
-  protected reloadProperties(entityId: number, relationId: number, contextId: number): void {
-    this.relationsService.setIdsForRelationProperties(entityId, relationId, contextId);
-  }
-
-  protected bulkUpdateProperties(
-    relationId: number,
-    updatedProperties: PropertyUpdate[],
-    resetProperties: PropertyUpdate[],
-    contextId: number,
-  ): Observable<void> {
-    return this.relationsService.bulkUpdateResourceRelationProperties(
-      this.entityId(),
-      relationId,
-      updatedProperties,
-      resetProperties,
-      contextId,
-    );
-  }
-
-  protected afterPropertiesSaved(): void {
-    const changes = this.editor.changedProperties();
-    if (changes.has('relationName')) {
-      this.reloadRelation(this.entityId());
-    }
-  }
-
-  protected getUnsavedChangesKey(): string {
-    return 'resource-relation-properties';
-  }
-
-  protected getEditorOptions(): { includeResetsInHasChanges: boolean; unmarkResetOnChange: boolean } {
-    return {
-      includeResetsInHasChanges: true,
-      unmarkResetOnChange: true,
-    };
-  }
-
-  protected hasIdentifierProperty() {
-    const rel = this.selectedRelation();
-    return rel != null && rel.relationType === 'consumed' && rel.type !== 'RUNTIME';
-  }
-
-  protected toUnresolvedItem(unresolved: UnresolvedRelation): RelationGroupItem {
-    return {
-      key: `${unresolved.type}::${unresolved.name}`,
-      name: unresolved.name,
-      type: unresolved.type,
-      unresolved: true,
-    };
-  }
-
-  onReleaseChange(relationId: number) {
-    this.activeRelationId.set(relationId);
-    this.setQueryParamForRelationId(relationId);
-  }
-
   relationIdentifier = computed<Property>(() => ({
     name: 'relationName',
     displayName: `Relation name`,
@@ -256,6 +223,42 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     optional: true,
     disabled: this.contextId() !== 1,
   }));
+
+  hasActivationChanges = computed(() => {
+    const original = this.originalActiveAppIds();
+    const current = this.currentActiveAppIds();
+    if (original.length !== current.length) return true;
+    const originalSet = new Set(original);
+    for (const id of current) {
+      if (!originalSet.has(id)) return true;
+    }
+    return false;
+  });
+
+  override hasChanges = computed(() => this.editor.hasChanges() || this.hasActivationChanges());
+
+  protected entityId = computed(() => this.resource()?.id);
+
+  constructor() {
+    super();
+    effect(() => {
+      const activations = this.resourceActivationService.activations();
+      const activeIds = activations
+        .filter((a: ResourceActivation) => a.active)
+        .map((a: ResourceActivation) => a.resourceGroupId);
+      this.originalActiveAppIds.set(activeIds);
+      this.currentActiveAppIds.set(activeIds);
+    });
+  }
+
+  onActivationChange(appIds: number[]) {
+    this.currentActiveAppIds.set(appIds);
+  }
+
+  onReleaseChange(relationId: number) {
+    this.activeRelationId.set(relationId);
+    this.setQueryParamForRelationId(relationId);
+  }
 
   showAddRelationModal(): void {
     this.selectedResourceTypeId.set(null);
@@ -343,16 +346,6 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     }
   }
 
-  private loadResourceGroups(typeId: number): void {
-    this.resourceService.getGroupsForType({ id: typeId } as ResourceType).subscribe({
-      next: (groups) => this.availableResourceGroups.set(groups),
-      error: (err) => {
-        console.error('Failed to load resource groups:', err);
-        this.toastService.error('Failed to load resource groups.');
-      },
-    });
-  }
-
   addRelation(): void {
     const groupId = this.selectedResourceGroupId();
     if (!groupId) {
@@ -399,6 +392,144 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
       () => this.removeRelation(),
       () => {},
     );
+  }
+
+  // ==================== OVERRIDE METHODS - Save/Reset ====================
+  override saveChanges() {
+    const propertyChanges = this.editor.changedProperties();
+    const propertyResets = this.editor.resetProperties();
+    const hasPropertyChanges = propertyChanges.size > 0 || propertyResets.size > 0;
+    const hasActivationChanges = this.hasActivationChanges();
+
+    if ((!hasPropertyChanges && !hasActivationChanges) || this.hasValidationErrors()) return;
+
+    this.isSaving.set(true);
+    this.errorMessage.set(null);
+    this.successMessage.set(null);
+
+    let propertyUpdate$: Observable<void> = of(void 0);
+    if (hasPropertyChanges) {
+      const updatedProperties: PropertyUpdate[] = Array.from(propertyChanges.entries()).map(([name, value]) => ({
+        name,
+        value,
+      }));
+      const resetProperties: PropertyUpdate[] = Array.from(propertyResets.entries()).map(([name, value]) => ({
+        name,
+        value,
+      }));
+      propertyUpdate$ = this.bulkUpdateProperties(
+        this.getRelationId(),
+        updatedProperties,
+        resetProperties,
+        this.contextId(),
+      );
+    }
+
+    let activationUpdate$: Observable<void> = of(void 0);
+    if (hasActivationChanges && this.isApplicationServerToNodeRelation()) {
+      this.isSavingActivations.set(true);
+      activationUpdate$ = this.resourceActivationService.updateActivations(
+        this.entityId()!,
+        this.getRelationId(),
+        this.contextId(),
+        { activeResourceGroupIds: this.currentActiveAppIds() },
+      );
+    }
+
+    forkJoin([propertyUpdate$, activationUpdate$])
+      .pipe(
+        finalize(() => {
+          this.isSaving.set(false);
+          this.isSavingActivations.set(false);
+        }),
+      )
+      .subscribe({
+        next: () => {
+          this.successMessage.set('Changes saved successfully');
+          if (hasPropertyChanges) {
+            this.reloadProperties(this.entityId(), this.getRelationId(), this.contextId());
+            this.afterPropertiesSaved();
+            this.editor.resetChanges();
+          }
+          if (hasActivationChanges) {
+            this.resourceActivationService.setRelationParams(this.entityId()!, this.getRelationId(), this.contextId());
+          }
+          setTimeout(() => this.successMessage.set(null), 3000);
+        },
+        error: (error) => {
+          this.errorMessage.set('Failed to save changes: ' + (error.message || 'Unknown error'));
+        },
+      });
+  }
+
+  override resetChanges() {
+    super.resetChanges();
+    this.currentActiveAppIds.set(this.originalActiveAppIds());
+  }
+
+  protected reloadRelation(entityId: number): void {
+    this.relationsService.setIdForResourceRelations(entityId);
+  }
+
+  protected reloadProperties(entityId: number, relationId: number, contextId: number): void {
+    this.relationsService.setIdsForRelationProperties(entityId, relationId, contextId);
+  }
+
+  protected bulkUpdateProperties(
+    relationId: number,
+    updatedProperties: PropertyUpdate[],
+    resetProperties: PropertyUpdate[],
+    contextId: number,
+  ): Observable<void> {
+    return this.relationsService.bulkUpdateResourceRelationProperties(
+      this.entityId(),
+      relationId,
+      updatedProperties,
+      resetProperties,
+      contextId,
+    );
+  }
+
+  protected afterPropertiesSaved(): void {
+    const changes = this.editor.changedProperties();
+    if (changes.has('relationName')) {
+      this.reloadRelation(this.entityId());
+    }
+  }
+
+  protected getUnsavedChangesKey(): string {
+    return 'resource-relation-properties';
+  }
+
+  protected getEditorOptions(): { includeResetsInHasChanges: boolean; unmarkResetOnChange: boolean } {
+    return {
+      includeResetsInHasChanges: true,
+      unmarkResetOnChange: true,
+    };
+  }
+
+  protected hasIdentifierProperty() {
+    const rel = this.selectedRelation();
+    return rel != null && rel.relationType === 'consumed' && rel.type !== 'RUNTIME';
+  }
+
+  protected toUnresolvedItem(unresolved: UnresolvedRelation): RelationGroupItem {
+    return {
+      key: `${unresolved.type}::${unresolved.name}`,
+      name: unresolved.name,
+      type: unresolved.type,
+      unresolved: true,
+    };
+  }
+
+  private loadResourceGroups(typeId: number): void {
+    this.resourceService.getGroupsForType({ id: typeId } as ResourceType).subscribe({
+      next: (groups) => this.availableResourceGroups.set(groups),
+      error: (err) => {
+        console.error('Failed to load resource groups:', err);
+        this.toastService.error('Failed to load resource groups.');
+      },
+    });
   }
 
   private removeRelation(): void {

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
@@ -9,11 +9,7 @@ describe('ResourceActivationService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        ResourceActivationService,
-        provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting(),
-      ],
+      providers: [ResourceActivationService, provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()],
     });
 
     httpTestingController = TestBed.inject(HttpTestingController);
@@ -39,9 +35,7 @@ describe('ResourceActivationService', () => {
         expect(activations).toEqual(mockActivations);
       });
 
-      const req = httpTestingController.expectOne(
-        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
-      );
+      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
       expect(req.request.method).toEqual('GET');
       req.flush(mockActivations);
     });
@@ -49,13 +43,11 @@ describe('ResourceActivationService', () => {
     it('should use default contextId when not provided', () => {
       const mockActivations: ResourceActivation[] = [];
 
-      service.getActivations(100, 200).subscribe((activations) => {
+      service.getActivations(100, 200, 1).subscribe((activations) => {
         expect(activations).toEqual(mockActivations);
       });
 
-      const req = httpTestingController.expectOne(
-        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
-      );
+      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
       expect(req.request.method).toEqual('GET');
       req.flush(mockActivations);
     });
@@ -69,9 +61,7 @@ describe('ResourceActivationService', () => {
         // Success
       });
 
-      const req = httpTestingController.expectOne(
-        '/AMW_rest/resources/100/relations/200/activations?contextId=5'
-      );
+      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=5');
       expect(req.request.method).toEqual('PUT');
       expect(req.request.body).toEqual(request);
       req.flush(null);
@@ -80,15 +70,11 @@ describe('ResourceActivationService', () => {
 
   describe('activations signal', () => {
     it('should update activations signal when setRelationParams is called', () => {
-      const mockActivations: ResourceActivation[] = [
-        { resourceGroupId: 1, resourceGroupName: 'App1', active: true },
-      ];
+      const mockActivations: ResourceActivation[] = [{ resourceGroupId: 1, resourceGroupName: 'App1', active: true }];
 
       service.setRelationParams(100, 200, 1);
 
-      const req = httpTestingController.expectOne(
-        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
-      );
+      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
       req.flush(mockActivations);
 
       expect(service.activations()).toEqual(mockActivations);
@@ -105,9 +91,7 @@ describe('ResourceActivationService', () => {
 
       expect(service.isLoading()).toBe(true);
 
-      const req = httpTestingController.expectOne(
-        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
-      );
+      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
       req.flush(mockActivations);
 
       expect(service.isLoading()).toBe(false);

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed } from '@angular/core/testing';
+import { ResourceActivationService, ResourceActivation } from './resource-activation.service';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+
+describe('ResourceActivationService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ResourceActivationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ResourceActivationService,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ResourceActivationService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getActivations', () => {
+    it('should fetch activations from the correct endpoint', () => {
+      const mockActivations: ResourceActivation[] = [
+        { resourceGroupId: 1, resourceGroupName: 'App1', active: true },
+        { resourceGroupId: 2, resourceGroupName: 'App2', active: false },
+      ];
+
+      service.getActivations(100, 200, 1).subscribe((activations) => {
+        expect(activations).toEqual(mockActivations);
+      });
+
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(mockActivations);
+    });
+
+    it('should use default contextId when not provided', () => {
+      const mockActivations: ResourceActivation[] = [];
+
+      service.getActivations(100, 200).subscribe((activations) => {
+        expect(activations).toEqual(mockActivations);
+      });
+
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(mockActivations);
+    });
+  });
+
+  describe('updateActivations', () => {
+    it('should send PUT request to the correct endpoint', () => {
+      const request = { activeResourceGroupIds: [1, 2, 3] };
+
+      service.updateActivations(100, 200, 5, request).subscribe(() => {
+        // Success
+      });
+
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/100/relations/200/activations?contextId=5'
+      );
+      expect(req.request.method).toEqual('PUT');
+      expect(req.request.body).toEqual(request);
+      req.flush(null);
+    });
+  });
+
+  describe('activations signal', () => {
+    it('should update activations signal when setRelationParams is called', () => {
+      const mockActivations: ResourceActivation[] = [
+        { resourceGroupId: 1, resourceGroupName: 'App1', active: true },
+      ];
+
+      service.setRelationParams(100, 200, 1);
+
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
+      );
+      req.flush(mockActivations);
+
+      expect(service.activations()).toEqual(mockActivations);
+    });
+  });
+
+  describe('isLoading signal', () => {
+    it('should be true during request and false after', () => {
+      const mockActivations: ResourceActivation[] = [];
+
+      expect(service.isLoading()).toBe(false);
+
+      service.setRelationParams(100, 200, 1);
+
+      expect(service.isLoading()).toBe(true);
+
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/100/relations/200/activations?contextId=1'
+      );
+      req.flush(mockActivations);
+
+      expect(service.isLoading()).toBe(false);
+    });
+  });
+});

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.spec.ts
@@ -35,7 +35,9 @@ describe('ResourceActivationService', () => {
         expect(activations).toEqual(mockActivations);
       });
 
-      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/resources/100/relations/200/activations?contextId=1',
+      );
       expect(req.request.method).toEqual('GET');
       req.flush(mockActivations);
     });
@@ -47,7 +49,9 @@ describe('ResourceActivationService', () => {
         expect(activations).toEqual(mockActivations);
       });
 
-      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/resources/100/relations/200/activations?contextId=1',
+      );
       expect(req.request.method).toEqual('GET');
       req.flush(mockActivations);
     });
@@ -61,7 +65,9 @@ describe('ResourceActivationService', () => {
         // Success
       });
 
-      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=5');
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/resources/100/relations/200/activations?contextId=5',
+      );
       expect(req.request.method).toEqual('PUT');
       expect(req.request.body).toEqual(request);
       req.flush(null);
@@ -74,7 +80,9 @@ describe('ResourceActivationService', () => {
 
       service.setRelationParams(100, 200, 1);
 
-      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/resources/100/relations/200/activations?contextId=1',
+      );
       req.flush(mockActivations);
 
       expect(service.activations()).toEqual(mockActivations);
@@ -91,7 +99,9 @@ describe('ResourceActivationService', () => {
 
       expect(service.isLoading()).toBe(true);
 
-      const req = httpTestingController.expectOne('/AMW_rest/resources/100/relations/200/activations?contextId=1');
+      const req = httpTestingController.expectOne(
+        '/AMW_rest/resources/resources/100/relations/200/activations?contextId=1',
+      );
       req.flush(mockActivations);
 
       expect(service.isLoading()).toBe(false);

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
@@ -28,10 +28,10 @@ export class ResourceActivationService extends BaseService {
     switchMap((params) => {
       this.loading.set(true);
       return this.getActivations(params.resourceId, params.relationId, params.contextId).pipe(
-        finalize(() => this.loading.set(false))
+        finalize(() => this.loading.set(false)),
       );
     }),
-    shareReplay(1)
+    shareReplay(1),
   );
 
   activations = toSignal(this.activationsForRelation$, { initialValue: [] as ResourceActivation[] });
@@ -42,10 +42,9 @@ export class ResourceActivationService extends BaseService {
 
   getActivations(resourceId: number, relationId: number, contextId: number): Observable<ResourceActivation[]> {
     return this.http
-      .get<ResourceActivation[]>(
-        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
-        { headers: this.getHeaders() }
-      )
+      .get<
+        ResourceActivation[]
+      >(`${this.getBaseUrl()}/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`, { headers: this.getHeaders() })
       .pipe(catchError(this.handleError));
   }
 
@@ -53,13 +52,13 @@ export class ResourceActivationService extends BaseService {
     resourceId: number,
     relationId: number,
     contextId: number,
-    request: ResourceActivationsRequest
+    request: ResourceActivationsRequest,
   ): Observable<void> {
     return this.http
       .put<void>(
-        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
+        `${this.getBaseUrl()}/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
         request,
-        { headers: this.getHeaders() }
+        { headers: this.getHeaders() },
       )
       .pipe(catchError(this.handleError));
   }

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
@@ -1,0 +1,66 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, Subject } from 'rxjs';
+import { catchError, finalize, shareReplay, switchMap } from 'rxjs/operators';
+import { BaseService } from '../../base/base.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+export interface ResourceActivation {
+  resourceGroupId: number;
+  resourceGroupName: string;
+  active: boolean;
+}
+
+export interface ResourceActivationsRequest {
+  activeResourceGroupIds: number[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class ResourceActivationService extends BaseService {
+  private http = inject(HttpClient);
+
+  private loading = signal(false);
+  isLoading = this.loading.asReadonly();
+
+  private activationParams$ = new Subject<{ resourceId: number; relationId: number; contextId: number }>();
+
+  private activationsForRelation$ = this.activationParams$.pipe(
+    switchMap((params) => {
+      this.loading.set(true);
+      return this.getActivations(params.resourceId, params.relationId, params.contextId).pipe(
+        finalize(() => this.loading.set(false))
+      );
+    }),
+    shareReplay(1)
+  );
+
+  activations = toSignal(this.activationsForRelation$, { initialValue: [] as ResourceActivation[] });
+
+  setRelationParams(resourceId: number, relationId: number, contextId: number) {
+    this.activationParams$.next({ resourceId, relationId, contextId });
+  }
+
+  getActivations(resourceId: number, relationId: number, contextId: number): Observable<ResourceActivation[]> {
+    return this.http
+      .get<ResourceActivation[]>(
+        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
+        { headers: this.getHeaders() }
+      )
+      .pipe(catchError(this.handleError));
+  }
+
+  updateActivations(
+    resourceId: number,
+    relationId: number,
+    contextId: number,
+    request: ResourceActivationsRequest
+  ): Observable<void> {
+    return this.http
+      .put<void>(
+        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
+        request,
+        { headers: this.getHeaders() }
+      )
+      .pipe(catchError(this.handleError));
+  }
+}

--- a/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-activation.service.ts
@@ -44,7 +44,7 @@ export class ResourceActivationService extends BaseService {
     return this.http
       .get<
         ResourceActivation[]
-      >(`${this.getBaseUrl()}/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`, { headers: this.getHeaders() })
+      >(`${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`, { headers: this.getHeaders() })
       .pipe(catchError(this.handleError));
   }
 
@@ -56,7 +56,7 @@ export class ResourceActivationService extends BaseService {
   ): Observable<void> {
     return this.http
       .put<void>(
-        `${this.getBaseUrl()}/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
+        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/activations?contextId=${contextId}`,
         request,
         { headers: this.getHeaders() },
       )

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
@@ -60,7 +60,7 @@ import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
  * @author cweber
  */
 @Stateless
-public class RelationEditor implements AddResourceTypeRelationUseCase, RemoveResourceTypeRelationUseCase {
+public class RelationEditor {
 
 	@Inject
 	EntityManager entityManager;
@@ -260,19 +260,4 @@ public class RelationEditor implements AddResourceTypeRelationUseCase, RemoveRes
 				.anyMatch(type -> type.name().equalsIgnoreCase(resourceRelationTypeString));
 	}
 
-	@Override
-	public void addResourceTypeRelation(AddResourceTypeRelationCommand command)
-			throws ResourceTypeNotFoundException {
-		ResourceTypeEntity masterType = entityManager.find(ResourceTypeEntity.class, command.getMasterResourceTypeId());
-		if (masterType == null) {
-			throw new ResourceTypeNotFoundException("Resource type with ID " + command.getMasterResourceTypeId() + " not found");
-		}
-		addResourceTypeRelation(masterType, command.getSlaveResourceTypeId());
-	}
-
-	@Override
-	public void removeResourceTypeRelation(RemoveResourceTypeRelationCommand command)
-			throws ResourceTypeNotFoundException {
-		removeResourceTypeRelation(command.getResourceTypeRelationId());
-	}
 }

--- a/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
+++ b/AMW_business/src/main/java/ch/puzzle/itc/mobiliar/business/resourcerelation/boundary/RelationEditor.java
@@ -60,7 +60,7 @@ import ch.puzzle.itc.mobiliar.common.util.DefaultResourceTypeDefinition;
  * @author cweber
  */
 @Stateless
-public class RelationEditor {
+public class RelationEditor implements AddResourceTypeRelationUseCase, RemoveResourceTypeRelationUseCase {
 
 	@Inject
 	EntityManager entityManager;
@@ -260,4 +260,19 @@ public class RelationEditor {
 				.anyMatch(type -> type.name().equalsIgnoreCase(resourceRelationTypeString));
 	}
 
+	@Override
+	public void addResourceTypeRelation(AddResourceTypeRelationCommand command)
+			throws ResourceTypeNotFoundException {
+		ResourceTypeEntity masterType = entityManager.find(ResourceTypeEntity.class, command.getMasterResourceTypeId());
+		if (masterType == null) {
+			throw new ResourceTypeNotFoundException("Resource type with ID " + command.getMasterResourceTypeId() + " not found");
+		}
+		addResourceTypeRelation(masterType, command.getSlaveResourceTypeId());
+	}
+
+	@Override
+	public void removeResourceTypeRelation(RemoveResourceTypeRelationCommand command)
+			throws ResourceTypeNotFoundException {
+		removeResourceTypeRelation(command.getResourceTypeRelationId());
+	}
 }

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/ResourceActivationDTO.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/ResourceActivationDTO.java
@@ -1,0 +1,48 @@
+/*
+ * AMW - Automated Middleware allows you to manage the configurations of
+ * your Java EE applications on an unlimited number of different environments
+ * with various versions, including the automated deployment of those apps.
+ * Copyright (C) 2013-2016 by Puzzle ITC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.mobi.itc.mobiliar.rest.dtos;
+
+import ch.puzzle.itc.mobiliar.business.resourceactivation.entity.ResourceActivationEntity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "activation")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceActivationDTO {
+
+    private Integer resourceGroupId;
+    private String resourceGroupName;
+    private boolean active;
+
+    public ResourceActivationDTO(ResourceActivationEntity entity) {
+        this.resourceGroupId = entity.getResourceGroup().getId();
+        this.resourceGroupName = entity.getResourceGroup().getName();
+        this.active = entity.isActive();
+    }
+}

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/ResourceActivationsRequestDTO.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/dtos/ResourceActivationsRequestDTO.java
@@ -1,0 +1,40 @@
+/*
+ * AMW - Automated Middleware allows you to manage the configurations of
+ * your Java EE applications on an unlimited number of different environments
+ * with various versions, including the automated deployment of those apps.
+ * Copyright (C) 2013-2016 by Puzzle ITC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ch.mobi.itc.mobiliar.rest.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "activations")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceActivationsRequestDTO {
+
+    private List<Integer> activeResourceGroupIds;
+}

--- a/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceRelationsByIdRest.java
+++ b/AMW_rest/src/main/java/ch/mobi/itc/mobiliar/rest/resources/ResourceRelationsByIdRest.java
@@ -25,6 +25,8 @@ import ch.mobi.itc.mobiliar.rest.dtos.GroupedResourceRelationsDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.PropertyBulkUpdateDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.PropertyDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.PropertyExtendedDTO;
+import ch.mobi.itc.mobiliar.rest.dtos.ResourceActivationDTO;
+import ch.mobi.itc.mobiliar.rest.dtos.ResourceActivationsRequestDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.ResourceRelationDTO;
 import ch.mobi.itc.mobiliar.rest.dtos.UnresolvedRelationDTO;
 import ch.puzzle.itc.mobiliar.business.environment.boundary.ContextLocator;
@@ -34,7 +36,11 @@ import ch.puzzle.itc.mobiliar.business.property.boundary.UpdateRelationPropertie
 import ch.puzzle.itc.mobiliar.business.property.control.PropertyEditingService;
 import ch.puzzle.itc.mobiliar.business.property.entity.ResourceEditProperty;
 import ch.puzzle.itc.mobiliar.business.property.entity.ResourceEditRelation;
+import ch.puzzle.itc.mobiliar.business.resourceactivation.boundary.ResourceActivationService;
+import ch.puzzle.itc.mobiliar.business.resourceactivation.entity.ResourceActivationEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.boundary.AddResourceRelationCommand;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.boundary.ListApplicationsForAppServerUseCase;
+import ch.puzzle.itc.mobiliar.business.resourcerelation.entity.ConsumedResourceRelationEntity;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.boundary.AddResourceRelationUseCase;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.boundary.GetResourceRelationsUseCase;
 import ch.puzzle.itc.mobiliar.business.resourcerelation.boundary.GroupedRelations;
@@ -64,7 +70,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 
 @RequestScoped
@@ -86,6 +94,12 @@ public class ResourceRelationsByIdRest {
 
     @Inject
     RemoveResourceRelationUseCase removeResourceRelationUseCase;
+
+    @Inject
+    ResourceActivationService resourceActivationService;
+
+    @Inject
+    ListApplicationsForAppServerUseCase listApplicationsUseCase;
 
     @Inject
     ContextLocator contextLocator;
@@ -237,6 +251,75 @@ public class ResourceRelationsByIdRest {
         RemoveResourceRelationCommand command = new RemoveResourceRelationCommand(relationId);
 
         removeResourceRelationUseCase.removeRelation(command);
+
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
+    @GET
+    @Path("/{id : \\d+}/relations/{relationId : \\d+}/activations")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get resource activations for a relation (active applications)")
+    public Response getResourceActivations(
+            @Parameter(description = "Resource ID") @PathParam("id") Integer resourceId,
+            @Parameter(description = "Relation ID") @PathParam("relationId") Integer relationId,
+            @Parameter(description = "Context ID") @DefaultValue("1") @QueryParam("contextId") Integer contextId)
+            throws ResourceNotFoundException, ValidationException {
+
+        // Get all applications linked to this resource (the AppServer's applications)
+        List<ConsumedResourceRelationEntity> applications = listApplicationsUseCase.listApplications(resourceId);
+
+        // Get activation entities for this relation+context (contains deactivation info)
+        List<ResourceActivationEntity> activations = resourceActivationService.loadResourceActivations(relationId, contextId);
+
+        // Build a set of inactive application group IDs
+        Set<Integer> inactiveAppGroupIds = new HashSet<>();
+        for (ResourceActivationEntity activation : activations) {
+            if (!activation.isActive()) {
+                inactiveAppGroupIds.add(activation.getResourceGroup().getId());
+            }
+        }
+
+        // Build DTOs for all applications - default to active unless explicitly deactivated
+        List<ResourceActivationDTO> dtos = new ArrayList<>();
+        for (ConsumedResourceRelationEntity appRelation : applications) {
+            Integer appGroupId = appRelation.getSlaveResource().getResourceGroup().getId();
+            String appGroupName = appRelation.getSlaveResource().getResourceGroup().getName();
+            boolean isActive = !inactiveAppGroupIds.contains(appGroupId);
+            dtos.add(new ResourceActivationDTO(appGroupId, appGroupName, isActive));
+        }
+
+        return Response.ok(dtos).build();
+    }
+
+    @PUT
+    @Path("/{id : \\d+}/relations/{relationId : \\d+}/activations")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Update resource activations (activate/deactivate applications)")
+    public Response updateResourceActivations(
+            @Parameter(description = "Resource ID") @PathParam("id") Integer resourceId,
+            @Parameter(description = "Relation ID") @PathParam("relationId") Integer relationId,
+            ResourceActivationsRequestDTO request,
+            @Parameter(description = "Context ID") @DefaultValue("1") @QueryParam("contextId") Integer contextId)
+            throws ResourceNotFoundException, ValidationException {
+
+        if (request == null || request.getActiveResourceGroupIds() == null) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Active resource group IDs are required").build();
+        }
+
+        // Get all applications linked to this resource
+        List<ConsumedResourceRelationEntity> applications = listApplicationsUseCase.listApplications(resourceId);
+        List<Integer> allAppGroupIds = new ArrayList<>();
+        for (ConsumedResourceRelationEntity appRelation : applications) {
+            allAppGroupIds.add(appRelation.getSlaveResource().getResourceGroup().getId());
+        }
+
+        // Calculate which ones to deactivate (not in the active list)
+        List<Integer> activeIds = request.getActiveResourceGroupIds();
+        List<Integer> deactivationIds = new ArrayList<>(allAppGroupIds);
+        deactivationIds.removeAll(activeIds);
+
+        resourceActivationService.activateDeactivateResources(relationId, contextId, deactivationIds, activeIds);
 
         return Response.status(Response.Status.NO_CONTENT).build();
     }


### PR DESCRIPTION
Show active applications in related-resources tile for APPLICATIONSERVERS on Node relation.
Example:
http://localhost:8080/AMW_web/pages/editResourceView.xhtml?rel=360266&ctx=1&id=263978

Needs merge of https://github.com/liimaorg/liima/pull/1005 first