### PR TITLE
style: change property input color

### DIFF
--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.scss
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.scss
@@ -33,7 +33,7 @@
   font-size: 14px;
   transition: border-color 0.2s;
   line-height: 21px;
-  color: #0e1687;
+  color: #065806;
 }
 
 .upper-context {


### PR DESCRIPTION
The requirement was to change the color of the property inputs.

**Previous**

<img width="1908" height="637" alt="previous" src="https://github.com/user-attachments/assets/2f656ea9-2018-4269-8106-cd22213a2e92" />

**Current implementation**

<img width="1908" height="637" alt="current" src="https://github.com/user-attachments/assets/6a20e70b-36f8-46c8-b3b6-66cb660a6f0a" />

**Alternative option**
<img width="1908" height="637" alt="alternative" src="https://github.com/user-attachments/assets/d684048a-bcfc-4735-a3ad-6260d05b40c7" />

Please review. If the current version looks good, please approve the MR. Otherwise, let me know if you prefer the alternative.