### PR TITLE
Fix/selected resource typte id url param

### DIFF
--- a/AMW_angular/io/src/app/resources/resources-page.component.html
+++ b/AMW_angular/io/src/app/resources/resources-page.component.html
@@ -10,7 +10,7 @@
             <li class="nav-item">
               <a
                 class="nav-link ps-0"
-                [ngClass]="{ active: selection === resourceType }"
+                [ngClass]="{ active: selectedResourceType() === resourceType }"
                 style="display: inline-block"
                 (click)="toggleChildrenAndOrLoadResourcesList(resourceType)"
                 (keydown.enter)="toggleChildrenAndOrLoadResourcesList(resourceType)"
@@ -34,7 +34,7 @@
           <li class="nav-item">
             <a
               class="nav-link ps-0"
-              [ngClass]="{ active: selection === resourceType }"
+              [ngClass]="{ active: selectedResourceType() === resourceType }"
               style="display: inline-block"
               (click)="toggleChildrenAndOrLoadResourcesList(resourceType)"
               (keydown.enter)="toggleChildrenAndOrLoadResourcesList(resourceType)"
@@ -57,7 +57,7 @@
                   <li class="nav-item">
                     <a
                       class="nav-link ps-0"
-                      [ngClass]="{ active: selection === child }"
+                      [ngClass]="{ active: selectedResourceType() === child }"
                       style="display: inline-block"
                       (click)="toggleChildrenAndOrLoadResourcesList(child)"
                       (keydown.enter)="toggleChildrenAndOrLoadResourcesList(child)"

--- a/AMW_angular/io/src/app/resources/resources-page.component.html
+++ b/AMW_angular/io/src/app/resources/resources-page.component.html
@@ -73,7 +73,7 @@
       </ul>
     </div>
     <div class="col-10">
-      @if (selectedResourceTypeOrDefault(); as rt) {
+      @if (selectedResourceType(); as rt) {
         <app-resources-list
           [resourceType]="rt"
           [resourceGroupList]="resourceGroupListForType()"

--- a/AMW_angular/io/src/app/resources/resources-page.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-page.component.ts
@@ -108,7 +108,7 @@ export class ResourcesPageComponent implements OnDestroy {
       const isDirectChild = type.children?.some((c) => c.id === targetId);
       if (isDirectChild) {
         // Add this parent to expanded items
-        if (!this.expandedItems.find((e) => e.id === type.id)) {
+        if (!this.isExpanded(type)) {
           this.expandedItems.push(type);
         }
         return type;
@@ -118,7 +118,7 @@ export class ResourcesPageComponent implements OnDestroy {
         const foundParent = this.expandParents(type.children, targetId);
         if (foundParent) {
           // Add this ancestor to expanded items
-          if (!this.expandedItems.find((e) => e.id === type.id)) {
+          if (!this.isExpanded(type)) {
             this.expandedItems.push(type);
           }
           return foundParent; // Return the immediate parent (deepest level)
@@ -199,7 +199,7 @@ export class ResourcesPageComponent implements OnDestroy {
       });
   }
 
-  isExpanded(resourceType: ResourceType) {
+  isExpanded(resourceType: ResourceType): boolean {
     return this.expandedItems.some((element) => element.id === resourceType.id);
   }
 
@@ -262,7 +262,7 @@ export class ResourcesPageComponent implements OnDestroy {
   }
 
   private toggleExpandedItems(resourceType: ResourceType) {
-    const index = this.expandedItems?.findIndex((element: ResourceType) => element.id === resourceType.id);
+    const index = this.expandedItems.findIndex((element: ResourceType) => element.id === resourceType.id);
     if (index > -1) {
       this.expandedItems.splice(index, 1);
     } else {

--- a/AMW_angular/io/src/app/resources/resources-page.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-page.component.ts
@@ -70,19 +70,26 @@ export class ResourcesPageComponent implements OnDestroy {
     { initialValue: null },
   );
 
-  private autoSelectTrigger = computed(() => {
+  private autoSelectTrigger = effect(() => {
     const idFromUrl = this.selectedResourceTypeIdFromUrl();
-    if (idFromUrl === null) return;
-
     const allTypes = [...(this.predefinedResourceTypes() || []), ...(this.rootResourceTypes() || [])];
     if (allTypes.length === 0) return;
 
-    const resourceType = this.findTypeById(allTypes, idFromUrl);
-    if (resourceType) {
-      // Expand parent chain so child is visible in tree, get the immediate parent
-      const parentType = this.expandParents(allTypes, idFromUrl);
-      // Safely execute selection out-of-stack to avoid expression-changed bugs
-      setTimeout(() => this.selectFromUrl(resourceType, parentType));
+    // If URL parameter is provided, select that specific type
+    if (idFromUrl !== null) {
+      const resourceType = this.findTypeById(allTypes, idFromUrl);
+      if (resourceType) {
+        const parentType = this.expandParents(allTypes, idFromUrl);
+        setTimeout(() => this.selectFromUrl(resourceType, parentType));
+      }
+    }
+    // If no URL parameter and no selection yet, select first root type as default
+    else if (!this.selectedResourceType() && this.rootResourceTypes() && this.rootResourceTypes().length > 0) {
+      const firstRootType = this.rootResourceTypes()[0];
+      this.selection = firstRootType;
+      this.loadResourceGroups(firstRootType);
+      this.selectedResourceType.set(firstRootType);
+      this.updateUrlForResourceType(firstRootType);
     }
   });
 
@@ -138,9 +145,6 @@ export class ResourcesPageComponent implements OnDestroy {
   }
 
   constructor() {
-    // Simply reference the computed signal so it stays active and listens for changes
-    this.autoSelectTrigger();
-
     // Initial page load: hide loader once resource types are available
     effect(() => {
       if (this.predefinedResourceTypes().length > 0 || this.rootResourceTypes().length > 0) {
@@ -185,15 +189,7 @@ export class ResourcesPageComponent implements OnDestroy {
     this.selectedResourceType.set(resourceType);
 
     if (updateUrl) {
-      this.router
-        .navigate([], {
-          relativeTo: this.route,
-          queryParams: { selectedResourceTypeId: resourceType.id },
-          queryParamsHandling: 'merge',
-        })
-        .catch((error) => {
-          console.error('Navigation error:', error);
-        });
+      this.updateUrlForResourceType(resourceType);
     }
   }
 
@@ -201,6 +197,18 @@ export class ResourcesPageComponent implements OnDestroy {
     this.isLoading.set(true);
     this.pendingResourceListLoad = true;
     this.resourceService.setTypeForResourceGroupList(resourceType);
+  }
+
+  private updateUrlForResourceType(resourceType: ResourceType): void {
+    this.router
+      .navigate([], {
+        relativeTo: this.route,
+        queryParams: { selectedResourceTypeId: resourceType.id },
+        queryParamsHandling: 'merge',
+      })
+      .catch((error) => {
+        console.error('Navigation error:', error);
+      });
   }
 
   isExpanded(resourceType: ResourceType) {
@@ -215,7 +223,7 @@ export class ResourcesPageComponent implements OnDestroy {
         next: () => this.toastService.success('Resource saved successfully.'),
         error: (e) => console.error('Failed to create resource:', e),
         complete: () => {
-          const rt = this.selectedResourceTypeOrDefault();
+          const rt = this.selectedResourceType();
           if (rt) this.resourceService.setTypeForResourceGroupList(rt);
         },
       });

--- a/AMW_angular/io/src/app/resources/resources-page.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-page.component.ts
@@ -58,7 +58,6 @@ export class ResourcesPageComponent implements OnDestroy {
   expandedResourceTypeId: number | null = null;
   expandedItems: ResourceType[] = [];
   selectedResourceType: WritableSignal<ResourceType | null> = signal(null);
-  selection: any;
 
   private selectedResourceTypeIdFromUrl = toSignal(
     this.route.queryParamMap.pipe(
@@ -86,7 +85,6 @@ export class ResourcesPageComponent implements OnDestroy {
     // If no URL parameter and no selection yet, select first root type as default
     else if (!this.selectedResourceType() && this.rootResourceTypes() && this.rootResourceTypes().length > 0) {
       const firstRootType = this.rootResourceTypes()[0];
-      this.selection = firstRootType;
       this.loadResourceGroups(firstRootType);
       this.selectedResourceType.set(firstRootType);
       this.updateUrlForResourceType(firstRootType);
@@ -131,7 +129,6 @@ export class ResourcesPageComponent implements OnDestroy {
   }
 
   private selectFromUrl(resourceType: ResourceType, parentType: ResourceType | null): void {
-    this.selection = resourceType;
     this.loadResourceGroups(resourceType);
     // For parent with children: expand it and update expandedItems
     if (resourceType.hasChildren) {
@@ -182,7 +179,6 @@ export class ResourcesPageComponent implements OnDestroy {
   });
 
   toggleChildrenAndOrLoadResourcesList(resourceType: ResourceType, updateUrl: boolean = true): void {
-    this.selection = resourceType;
     this.loadResourceGroups(resourceType);
     if (resourceType && resourceType.hasChildren) this.toggleExpandedItems(resourceType);
     this.expandedResourceTypeId = this.expandedResourceTypeId === resourceType.id ? null : resourceType.id;

--- a/AMW_angular/io/src/app/resources/resources-page.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-page.component.ts
@@ -170,14 +170,6 @@ export class ResourcesPageComponent implements OnDestroy {
     }
   });
 
-  selectedResourceTypeOrDefault: Signal<ResourceType | null> = computed(() => {
-    if (!this.selectedResourceType() && this.rootResourceTypes() && this.rootResourceTypes().length > 0) {
-      this.resourceService.setTypeForResourceGroupList(this.rootResourceTypes()[0]);
-      return this.rootResourceTypes()[0];
-    }
-    return this.selectedResourceType() || null;
-  });
-
   toggleChildrenAndOrLoadResourcesList(resourceType: ResourceType, updateUrl: boolean = true): void {
     this.loadResourceGroups(resourceType);
     if (resourceType && resourceType.hasChildren) this.toggleExpandedItems(resourceType);

--- a/AMW_angular/io/src/app/resources/resources-page.component.ts
+++ b/AMW_angular/io/src/app/resources/resources-page.component.ts
@@ -135,7 +135,7 @@ export class ResourcesPageComponent implements OnDestroy {
     this.loadResourceGroups(resourceType);
     // For parent with children: expand it and update expandedItems
     if (resourceType.hasChildren) {
-      this.getUpdateExpandedItems(resourceType);
+      this.toggleExpandedItems(resourceType);
       this.expandedResourceTypeId = resourceType.id;
     } else {
       // For leaf: expand parent so child is visible
@@ -184,7 +184,7 @@ export class ResourcesPageComponent implements OnDestroy {
   toggleChildrenAndOrLoadResourcesList(resourceType: ResourceType, updateUrl: boolean = true): void {
     this.selection = resourceType;
     this.loadResourceGroups(resourceType);
-    if (resourceType && resourceType.hasChildren) this.getUpdateExpandedItems(resourceType);
+    if (resourceType && resourceType.hasChildren) this.toggleExpandedItems(resourceType);
     this.expandedResourceTypeId = this.expandedResourceTypeId === resourceType.id ? null : resourceType.id;
     this.selectedResourceType.set(resourceType);
 
@@ -212,7 +212,7 @@ export class ResourcesPageComponent implements OnDestroy {
   }
 
   isExpanded(resourceType: ResourceType) {
-    return this.expandedItems.find((element) => element.id === resourceType.id);
+    return this.expandedItems.some((element) => element.id === resourceType.id);
   }
 
   addResource(resource: any) {
@@ -261,7 +261,7 @@ export class ResourcesPageComponent implements OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => this.toastService.success('Resource type deleted successfully.'),
-        error: (e) => console.error('Failed to create resource:', e),
+        error: (e) => console.error('Failed to delete resource type:', e),
         complete: () => {
           this.resourceTypesService.refreshData();
           this.selectedResourceType.set(null);
@@ -273,7 +273,7 @@ export class ResourcesPageComponent implements OnDestroy {
     this.destroy$.next(undefined);
   }
 
-  private getUpdateExpandedItems(resourceType: ResourceType) {
+  private toggleExpandedItems(resourceType: ResourceType) {
     const index = this.expandedItems?.findIndex((element: ResourceType) => element.id === resourceType.id);
     if (index > -1) {
       this.expandedItems.splice(index, 1);


### PR DESCRIPTION
# Fix URL parameter selection bug and refactor resource selection logic

- Fixed URL parameter `selectedResourceTypeId` being ignored on resources page by changing `autoSelectTrigger` from computed to effect
- Added default selection to `autoSelectTrigger` to select first root type when no URL parameter is provided
- Removed `selectedResourceTypeOrDefault` and redundant `selection` property to eliminate race conditions
- Code quality improvements: renamed methods, simplified array checks, fixed error messages
- Updated template to use `selectedResourceType()` signal consistently
