### PR TITLE
fix: restrict relation types for non-default resources

### DIFF
--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
@@ -1,122 +1,124 @@
-<app-loading-indicator [isLoading]="isLoadingRelations()"></app-loading-indicator>
-<app-tile-component
-  [title]="'Related Resources'"
-  [actionName]="'Add Relation'"
-  [canAction]="permissions().canUpdateProperty && this.contextId() === 1"
-  [isCollapsed]="false"
-  [noContent]="!hasRelations()"
-  [notAllowed]="false"
-  (tileAction)="showAddRelationModal()"
->
-  @if (hasRelations()) {
-    <div class="relations-layout">
-      <div class="relations-container">
-        @if (canSetRuntime()) {
-          <div class="set-runtime-container">
-            <app-button [variant]="'secondary'" [size]="'sm'" (click)="showSetRuntimeModal()">
-              <app-icon icon="plus"></app-icon>
-              Set Runtime
-            </app-button>
-          </div>
-        }
-        <app-relation-group
-          [title]="'Runtime'"
-          [items]="runtimeItems()"
-          [selectedKey]="selectedItemKey()"
-          (itemSelected)="onItemSelected($event)"
-        />
-        <app-relation-group
-          [title]="'Unresolved'"
-          [items]="unresolvedItems()"
-          [selectedKey]="selectedItemKey()"
-          (itemSelected)="onItemSelected($event)"
-        />
-        <app-relation-group
-          [title]="'Consumed Resources'"
-          [items]="consumedItems()"
-          [selectedKey]="selectedItemKey()"
-          (itemSelected)="onItemSelected($event)"
-        />
-        <app-relation-group
-          [title]="'Provided Resources'"
-          [items]="providedItems()"
-          [selectedKey]="selectedItemKey()"
-          (itemSelected)="onItemSelected($event)"
-        />
-      </div>
-      @if (selectedRelation(); as rel) {
-        <div class="relation-detail-panel">
-          <div class="relation-detail-header">
-            <a class="nav-link" [routerLink]="['/resource/edit']" [queryParams]="{ ctx: 1, id: rel.slaveId }">
-              <h3 class="relation-detail-title">{{ rel.relatedResourceName }}</h3>
-            </a>
-            @if (rel.availableReleases && rel.availableReleases.length > 1) {
-              <ng-select
-                id="selectRelease"
-                [clearable]="false"
-                [ngModel]="selectedRelationIdForRelease()"
-                (ngModelChange)="onReleaseChange($event)"
-                name="release"
-              >
-                @for (release of rel.availableReleases; track release.relationId) {
-                  <ng-option [value]="release.relationId">{{ release.releaseName }}</ng-option>
-                }
-              </ng-select>
-            } @else {
-              <span class="relation-release-value">{{ rel.relatedResourceRelease }}</span>
-            }
-            @if (permissions().canUpdateProperty && contextId() === 1) {
-              <app-button [variant]="'secondary'" [size]="'sm'" (click)="showRemoveRelationConfirmation()">
-                <app-icon icon="trash"></app-icon>
-                Remove Relation
+@if (!isNode()) {
+  <app-loading-indicator [isLoading]="isLoadingRelations()"></app-loading-indicator>
+  <app-tile-component
+    [title]="'Related Resources'"
+    [actionName]="'Add Relation'"
+    [canAction]="permissions().canUpdateProperty && this.contextId() === 1"
+    [isCollapsed]="false"
+    [noContent]="!hasRelations()"
+    [notAllowed]="false"
+    (tileAction)="showAddRelationModal()"
+  >
+    @if (hasRelations()) {
+      <div class="relations-layout">
+        <div class="relations-container">
+          @if (canSetRuntime()) {
+            <div class="set-runtime-container">
+              <app-button [variant]="'secondary'" [size]="'sm'" (click)="showSetRuntimeModal()">
+                <app-icon icon="plus"></app-icon>
+                Set Runtime
               </app-button>
-            }
-          </div>
-          <div class="relation-detail-body">
-            <app-loading-indicator [isLoading]="isLoadingProperties()"></app-loading-indicator>
-            <app-properties-panel
-              [canEdit]="permissions().canUpdateProperty"
-              [isSaving]="isSaving()"
-              [hasChanges]="hasChanges()"
-              [hasValidationErrors]="hasValidationErrors()"
-              [errorMessage]="errorMessage()"
-              [successMessage]="successMessage()"
-              (cancelAction)="resetChanges()"
-              (saveAction)="saveChanges()"
-            >
-              <app-properties-list
-                [properties]="properties()"
-                [canEdit]="false"
-                [canDecrypt]="permissions().canDecryptProperties"
-                [canDelete]="false"
-                [mode]="'resource'"
-                [resetToken]="resetToken()"
-                (valueChange)="onPropertyChange($event.name, $event.value)"
-                (resetToggled)="onPropertyReset($event.name, $event.checked)"
-                (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
-              ></app-properties-list>
-
-              <app-relation-active-applications
-                [resourceId]="resource()?.id!"
-                [relationId]="selectedRelation()?.id!"
-                [contextId]="contextId()"
-                [isApplicationServerToNode]="isApplicationServerToNodeRelation()"
-                [canEdit]="permissions().canUpdateProperty"
-                [activeApplicationIds]="currentActiveAppIds()"
-                (activationChange)="onActivationChange($event)"
-              ></app-relation-active-applications>
-            </app-properties-panel>
-          </div>
+            </div>
+          }
+          <app-relation-group
+            [title]="'Runtime'"
+            [items]="runtimeItems()"
+            [selectedKey]="selectedItemKey()"
+            (itemSelected)="onItemSelected($event)"
+          />
+          <app-relation-group
+            [title]="'Unresolved'"
+            [items]="unresolvedItems()"
+            [selectedKey]="selectedItemKey()"
+            (itemSelected)="onItemSelected($event)"
+          />
+          <app-relation-group
+            [title]="'Consumed Resources'"
+            [items]="consumedItems()"
+            [selectedKey]="selectedItemKey()"
+            (itemSelected)="onItemSelected($event)"
+          />
+          <app-relation-group
+            [title]="'Provided Resources'"
+            [items]="providedItems()"
+            [selectedKey]="selectedItemKey()"
+            (itemSelected)="onItemSelected($event)"
+          />
         </div>
-        <app-resource-relation-templates-list
-          [resource]="resource()!"
-          [relation]="rel"
-          [contextId]="contextId()"
-        ></app-resource-relation-templates-list>
-      }
-    </div>
-  }
-</app-tile-component>
+        @if (selectedRelation(); as rel) {
+          <div class="relation-detail-panel">
+            <div class="relation-detail-header">
+              <a class="nav-link" [routerLink]="['/resource/edit']" [queryParams]="{ ctx: 1, id: rel.slaveId }">
+                <h3 class="relation-detail-title">{{ rel.relatedResourceName }}</h3>
+              </a>
+              @if (rel.availableReleases && rel.availableReleases.length > 1) {
+                <ng-select
+                  id="selectRelease"
+                  [clearable]="false"
+                  [ngModel]="selectedRelationIdForRelease()"
+                  (ngModelChange)="onReleaseChange($event)"
+                  name="release"
+                >
+                  @for (release of rel.availableReleases; track release.relationId) {
+                    <ng-option [value]="release.relationId">{{ release.releaseName }}</ng-option>
+                  }
+                </ng-select>
+              } @else {
+                <span class="relation-release-value">{{ rel.relatedResourceRelease }}</span>
+              }
+              @if (permissions().canUpdateProperty && contextId() === 1) {
+                <app-button [variant]="'secondary'" [size]="'sm'" (click)="showRemoveRelationConfirmation()">
+                  <app-icon icon="trash"></app-icon>
+                  Remove Relation
+                </app-button>
+              }
+            </div>
+            <div class="relation-detail-body">
+              <app-loading-indicator [isLoading]="isLoadingProperties()"></app-loading-indicator>
+              <app-properties-panel
+                [canEdit]="permissions().canUpdateProperty"
+                [isSaving]="isSaving()"
+                [hasChanges]="hasChanges()"
+                [hasValidationErrors]="hasValidationErrors()"
+                [errorMessage]="errorMessage()"
+                [successMessage]="successMessage()"
+                (cancelAction)="resetChanges()"
+                (saveAction)="saveChanges()"
+              >
+                <app-properties-list
+                  [properties]="properties()"
+                  [canEdit]="false"
+                  [canDecrypt]="permissions().canDecryptProperties"
+                  [canDelete]="false"
+                  [mode]="'resource'"
+                  [resetToken]="resetToken()"
+                  (valueChange)="onPropertyChange($event.name, $event.value)"
+                  (resetToggled)="onPropertyReset($event.name, $event.checked)"
+                  (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
+                ></app-properties-list>
+
+                <app-relation-active-applications
+                  [resourceId]="resource()?.id!"
+                  [relationId]="selectedRelation()?.id!"
+                  [contextId]="contextId()"
+                  [isApplicationServerToNode]="isApplicationServerToNodeRelation()"
+                  [canEdit]="permissions().canUpdateProperty"
+                  [activeApplicationIds]="currentActiveAppIds()"
+                  (activationChange)="onActivationChange($event)"
+                ></app-relation-active-applications>
+              </app-properties-panel>
+            </div>
+          </div>
+          <app-resource-relation-templates-list
+            [resource]="resource()!"
+            [relation]="rel"
+            [contextId]="contextId()"
+          ></app-resource-relation-templates-list>
+        }
+      </div>
+    }
+  </app-tile-component>
+}
 
 <ng-template #addRelationModal let-modal>
   <app-modal-header [title]="'Add Related Resource'" (cancelAction)="modal.dismiss('Cross click')"></app-modal-header>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
@@ -80,7 +80,7 @@ describe('ResourceRelationsComponent', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('should load resource types for default resource type (NODE)', () => {
+  it('isNode should return true for NODE resource type', () => {
     component['resource'] = signal({
       id: 1,
       name: 'Test',
@@ -89,11 +89,34 @@ describe('ResourceRelationsComponent', () => {
       defaultRelease: {} as any,
       releases: [],
     });
-    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
 
-    component.showAddRelationModal();
+    expect(component['isNode']()).toBe(true);
+  });
 
-    expect(spy).toHaveBeenCalled();
+  it('isNode should return true for quoted NODE resource type', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: '"NODE"',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+
+    expect(component['isNode']()).toBe(true);
+  });
+
+  it('isNode should return false for non-NODE resource type', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'APPLICATION',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+
+    expect(component['isNode']()).toBe(false);
   });
 
   it('should load resource types for default resource type (RUNTIME)', () => {

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
@@ -1,0 +1,152 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { signal } from '@angular/core';
+import { ResourceRelationsComponent } from './resource-relations.component';
+import { ResourceService } from '../../services/resource.service';
+import { ResourceTypesService } from '../../services/resource-types.service';
+import { ResourceRelationsService } from '../../services/resource-relations.service';
+import { AuthService } from 'src/app/auth/auth.service';
+import { ToastService } from 'src/app/shared/elements/toast/toast.service';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+
+describe('ResourceRelationsComponent', () => {
+  let component: ResourceRelationsComponent;
+  let fixture: ComponentFixture<ResourceRelationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ResourceRelationsComponent],
+      providers: [
+        ResourceService,
+        ResourceTypesService,
+        ResourceRelationsService,
+        AuthService,
+        ToastService,
+        NgbModal,
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: Router,
+          useValue: { navigate: vi.fn() },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: { queryParams: of({}) },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ResourceRelationsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load resource types for default resource type (APPLICATION)', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'APPLICATION',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should load resource types for default resource type (APPLICATIONSERVER)', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'APPLICATIONSERVER',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should load resource types for default resource type (NODE)', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'NODE',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should load resource types for default resource type (RUNTIME)', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'RUNTIME',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should load related resource types for non-default resource type', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: 'Webservice',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    component['groupedRelations'] = signal({
+      runtime: [],
+      consumed: [],
+      provided: [],
+      unresolved: [{ type: 'FeatureTeam', name: 'Team A' }],
+    } as any);
+    const spy = vi.spyOn(component, 'loadRelatedResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should handle quoted type names (e.g., "APPLICATION")', () => {
+    component['resource'] = signal({
+      id: 1,
+      name: 'Test',
+      type: '"APPLICATION"',
+      version: '1.0',
+      defaultRelease: {} as any,
+      releases: [],
+    });
+    const spy = vi.spyOn(component, 'loadAllResourceTypes' as any).mockImplementation(() => {});
+
+    component.showAddRelationModal();
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.spec.ts
@@ -172,4 +172,22 @@ describe('ResourceRelationsComponent', () => {
 
     expect(spy).toHaveBeenCalled();
   });
+
+  describe('getCleanType', () => {
+    it('should return the same string when no quotes are present', () => {
+      expect(component['getCleanType']('NODE')).toBe('NODE');
+    });
+
+    it('should remove quotes from quoted string', () => {
+      expect(component['getCleanType']('"NODE"')).toBe('NODE');
+    });
+
+    it('should return undefined when input is undefined', () => {
+      expect(component['getCleanType'](undefined)).toBeUndefined();
+    });
+
+    it('should handle empty string', () => {
+      expect(component['getCleanType']('')).toBe('');
+    });
+  });
 });

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
@@ -197,6 +197,12 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     return isAppServer && isNode;
   });
 
+  protected isNode = computed(() => {
+    const type = this.resource()?.type;
+    const cleanType = type?.replace(/"/g, '');
+    return cleanType === 'NODE';
+  });
+
   protected properties = computed<Property[]>(() => {
     const props = this.relationsService.relationProperties;
     const result: Property[] = [];

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
@@ -199,9 +199,17 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
 
   protected isNode = computed(() => {
     const type = this.resource()?.type;
-    const cleanType = type?.replace(/"/g, '');
-    return cleanType === 'NODE';
+    return this.getCleanType(type) === 'NODE';
   });
+
+  /**
+   * Cleans a resource type string by removing surrounding quotes and converting to uppercase.
+   * @param type - The resource type string, possibly undefined
+   * @returns The cleaned type string in uppercase, or undefined if input is undefined
+   */
+  protected getCleanType(type: string | undefined): string | undefined {
+    return type?.replace(/"/g, '').toUpperCase();
+  }
 
   protected properties = computed<Property[]>(() => {
     const props = this.relationsService.relationProperties;
@@ -543,7 +551,8 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
   private isDefaultResourceType(): boolean {
     const type = this.resource()?.type;
     const defaultTypes = ['APPLICATION', 'APPLICATIONSERVER', 'NODE', 'RUNTIME'];
-    const cleanType = type!.replace(/"/g, '');
+    const cleanType = this.getCleanType(type);
+    if (!cleanType) return false;
     return defaultTypes.includes(cleanType);
   }
 

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
@@ -14,11 +14,11 @@ import { RouterLink } from '@angular/router';
 import { Observable, of, forkJoin } from 'rxjs';
 import { NgOptionComponent, NgSelectComponent } from '@ng-select/ng-select';
 import { finalize } from 'rxjs/operators';
-import { TileComponent } from '../../../shared/tile/tile.component';
-import { LoadingIndicatorComponent } from '../../../shared/elements/loading-indicator.component';
-import { ButtonComponent } from '../../../shared/button/button.component';
-import { IconComponent } from '../../../shared/icon/icon.component';
-import { ModalHeaderComponent } from '../../../shared/modal-header/modal-header.component';
+import { TileComponent } from 'src/app/shared/tile/tile.component';
+import { LoadingIndicatorComponent } from 'src/app/shared/elements/loading-indicator.component';
+import { ButtonComponent } from 'src/app/shared/button/button.component';
+import { IconComponent } from 'src/app/shared/icon/icon.component';
+import { ModalHeaderComponent } from 'src/app/shared/modal-header/modal-header.component';
 import { ResourceService } from '../../services/resource.service';
 import { ResourceTypesService } from '../../services/resource-types.service';
 import { PropertyUpdate } from '../../services/resource-properties.service';
@@ -32,9 +32,7 @@ import { PropertiesListComponent } from '../../properties-list/properties-list.c
 import { BaseRelationsDirective, NODE_FILTERED_PROPERTIES } from '../../base-relations/base-relations.directive';
 import { RelationActiveApplicationsComponent } from './relation-active-applications/relation-active-applications.component';
 import { ResourceActivationService, ResourceActivation } from '../../services/resource-activation.service';
-import {
-  ResourceRelationTemplatesListComponent
-} from './resource-relation-templates-list/resource-relation-templates-list.component';
+import { ResourceRelationTemplatesListComponent } from './resource-relation-templates-list/resource-relation-templates-list.component';
 
 @Component({
   selector: 'app-resource-relations',
@@ -53,7 +51,7 @@ import {
     RouterLink,
     ModalHeaderComponent,
     RelationActiveApplicationsComponent,
-    ResourceRelationTemplatesListComponent
+    ResourceRelationTemplatesListComponent,
   ],
   templateUrl: './resource-relations.component.html',
   styleUrl: './resource-relations.component.scss',
@@ -272,13 +270,13 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     this.addAsProvided.set(false);
     this.childResourceTypes.set([]);
     this.availableResourceGroups.set([]);
-    this.resourceTypesService.getRootResourceTypes().subscribe({
-      next: (types) => this.resourceTypes.set(types),
-      error: (err) => {
-        console.error('Failed to load resource types:', err);
-        this.toastService.error('Failed to load resource types.');
-      },
-    });
+
+    if (this.isDefaultResourceType()) {
+      this.loadAllResourceTypes();
+    } else {
+      this.loadRelatedResourceTypes();
+    }
+
     this.modalService.open(this.addRelationModal, { size: 'lg' });
   }
 
@@ -532,6 +530,42 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
       error: (err) => {
         console.error('Failed to load resource groups:', err);
         this.toastService.error('Failed to load resource groups.');
+      },
+    });
+  }
+
+  private isDefaultResourceType(): boolean {
+    const type = this.resource()?.type;
+    const defaultTypes = ['APPLICATION', 'APPLICATIONSERVER', 'NODE', 'RUNTIME'];
+    const cleanType = type!.replace(/"/g, '');
+    return defaultTypes.includes(cleanType);
+  }
+
+  private loadRelatedResourceTypes(): void {
+    const unresolvedTypes = new Set(this.groupedRelations().unresolved.map((u) => u.type));
+
+    if (unresolvedTypes.size === 0) {
+      return;
+    }
+
+    this.resourceTypesService.getAllResourceTypes().subscribe({
+      next: (types) => {
+        const filteredTypes = types.filter((t) => unresolvedTypes.has(t.name));
+        this.resourceTypes.set(filteredTypes);
+      },
+      error: (err) => {
+        console.error('Failed to load resource types:', err);
+        this.toastService.error('Failed to load resource types.');
+      },
+    });
+  }
+
+  private loadAllResourceTypes(): void {
+    this.resourceTypesService.getRootResourceTypes().subscribe({
+      next: (types) => this.resourceTypes.set(types),
+      error: (err) => {
+        console.error('Failed to load resource types:', err);
+        this.toastService.error('Failed to load resource types.');
       },
     });
   }


### PR DESCRIPTION
Fixes unresolved related resources logic for non-default resource types. Non-default resource types can now only add relations to resource types defined at the type level (via unresolved relations). Default resource types (`APPLICATION`, `APPLICATIONSERVER`, `NODE`, `RUNTIME`) continue to allow adding any resource type.

**Note**: The JSF version hides all related resources for `NODE` resource types entirely (`rendered="${!resourceRelationModel.node}"`), and this PR now fixes this issue by adding an `isNode()` check to hide the relations component for `NODE` resource types.