### PR TITLE
refactor: improve property reset toggle and tooltip behavior

### DIFF
--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.html
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.html
@@ -67,22 +67,21 @@
     ></textarea>
   }
   @if (canReset() && (!property().encrypted || canDecrypt())) {
-    <input
-      type="checkbox"
-      class="btn-check"
+    <button
+      type="button"
       [id]="resetId()"
-      autocomplete="off"
-      [checked]="resetChecked()"
-      (change)="toggleReset($event)"
-    />
-    <label
+      class="btn btn-outline-secondary reset-btn"
+      [class.active]="resetChecked()"
       aria-label="Reset property"
-      class="btn btn-outline-primary reset-btn"
+      [attr.aria-pressed]="resetChecked()"
       [ngbTooltip]="'Reset property'"
-      [for]="resetId()"
+      #resetTooltip="ngbTooltip"
+      triggers="mouseenter:mouseleave"
+      container="body"
+      (click)="toggleReset(resetTooltip)"
     >
       <app-icon icon="arrow-counterclockwise" data-testid="button-reset"></app-icon
-    ></label>
+    ></button>
   }
 </div>
 

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.spec.ts
@@ -136,26 +136,26 @@ describe('PropertyFieldComponent', () => {
     expect(input?.getAttribute('placeholder')).toBe('DEFAULT');
   });
 
-  it('should not render reset checkbox when property is not defined in current context', () => {
+  it('should not render reset button when property is not defined in current context', () => {
     componentRef.setInput('property', baseProperty({ definedInContext: false, value: 'X', replacedValue: '' }));
     fixture.detectChanges();
 
-    const reset = fixture.nativeElement.querySelector(`input[type="checkbox"]`);
+    const reset = fixture.nativeElement.querySelector('.reset-btn');
     expect(reset).toBeNull();
   });
 
-  it('should render reset checkbox when property is defined in current context even if value is null', () => {
+  it('should render reset button when property is defined in current context even if value is null', () => {
     componentRef.setInput(
       'property',
       baseProperty({ name: 'pNull', definedInContext: true, value: null, replacedValue: '' }),
     );
     fixture.detectChanges();
 
-    const reset: HTMLInputElement | null = fixture.nativeElement.querySelector(`#reset-pNull`);
+    const reset: HTMLButtonElement | null = fixture.nativeElement.querySelector(`#reset-pNull`);
     expect(reset).not.toBeNull();
   });
 
-  it('should render reset checkbox when replacedValue exists and toggle value + emit resetChange', () => {
+  it('should render reset button when replacedValue exists and toggle value + emit resetChange', () => {
     componentRef.setInput(
       'property',
       baseProperty({
@@ -172,29 +172,27 @@ describe('PropertyFieldComponent', () => {
     const resetSpy = vi.fn();
     component.resetChange.subscribe(resetSpy);
 
-    const reset: HTMLInputElement | null = fixture.nativeElement.querySelector(`#reset-p1`);
+    const reset: HTMLButtonElement | null = fixture.nativeElement.querySelector(`#reset-p1`);
     expect(reset).not.toBeNull();
 
     // check reset => value becomes replacedValue and input is disabled
-    reset!.checked = true;
-    const resetOnEvent = new Event('change');
-    Object.defineProperty(resetOnEvent, 'target', { value: reset });
-    (component as PropertyFieldComponent).toggleReset(resetOnEvent);
+    reset!.click();
     fixture.detectChanges();
 
     expect(component.localValue).toBe('PARENT');
     expect(component.resetChecked()).toBe(true);
+    expect(reset!.getAttribute('aria-pressed')).toBe('true');
+    expect(reset!.classList.contains('active')).toBe(true);
     expect(resetSpy).toHaveBeenCalledWith(true);
 
     // uncheck reset => value becomes original and input enabled again (if not otherwise disabled)
-    reset!.checked = false;
-    const resetOffEvent = new Event('change');
-    Object.defineProperty(resetOffEvent, 'target', { value: reset });
-    (component as PropertyFieldComponent).toggleReset(resetOffEvent);
+    reset!.click();
     fixture.detectChanges();
 
     expect(component.localValue).toBe('CURRENT');
     expect(component.resetChecked()).toBe(false);
+    expect(reset!.getAttribute('aria-pressed')).toBe('false');
+    expect(reset!.classList.contains('active')).toBe(false);
     expect(resetSpy).toHaveBeenCalledWith(false);
   });
 });

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
@@ -126,9 +126,9 @@ export class PropertyFieldComponent {
     this.valueChange.emit(this.localValue);
   }
 
-  toggleReset(event: Event) {
-    const target = event.target as HTMLInputElement | null;
-    const checked = !!target?.checked;
+  toggleReset(tooltip?: NgbTooltip) {
+    tooltip?.close();
+    const checked = !this.resetChecked();
     this.resetChecked.set(checked);
 
     if (checked) {


### PR DESCRIPTION
- Replace the hidden checkbox and label with an accessible toggle button
- Use Bootstrap's secondary button styling
- Keep tooltip outside the input group to preserve border radii
- Close the tooltip on click and dismiss it on mouse leave
- Update property-field tests for the new toggle behavior