### PR TITLE
fix: flaky e2e tests

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    timeout-minutes: 30
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Check out code
       uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   build_and_test:
     name: build and test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Check out code
       uses: actions/checkout@v7

--- a/AMW_angular/io/src/app/settings/property-types/property-type-edit.component.spec.ts
+++ b/AMW_angular/io/src/app/settings/property-types/property-type-edit.component.spec.ts
@@ -58,6 +58,18 @@ describe('PropertyTypeEditComponent', () => {
     expect(component.isValidRegex()).toBe(false);
   });
 
+  it('isValidForm returns false for an invalid regex', () => {
+    component.propertyType.name = 'NAME';
+    component.propertyType.validationRegex = '*';
+    expect(component.isValidForm()).toBe(false);
+  });
+
+  it('isValidForm returns true when name and regex are valid', () => {
+    component.propertyType.name = 'NAME';
+    component.propertyType.validationRegex = '.*';
+    expect(component.isValidForm()).toBe(true);
+  });
+
   it('onTagsChange updates propertyTags', () => {
     component.propertyType.propertyTags = [];
     const newTags = [{ name: 'tag1', type: 'LOCAL' }];

--- a/AMW_angular/io/src/app/settings/property-types/property-type-edit.component.ts
+++ b/AMW_angular/io/src/app/settings/property-types/property-type-edit.component.ts
@@ -53,7 +53,7 @@ export class PropertyTypeEditComponent {
   }
 
   isValidForm() {
-    return this.propertyType.name !== '' && this.propertyType.validationRegex !== '';
+    return this.propertyType.name !== '' && this.propertyType.validationRegex !== '' && this.isValidRegex();
   }
 
   save() {

--- a/AMW_e2e/tests/deployments.spec.ts
+++ b/AMW_e2e/tests/deployments.spec.ts
@@ -11,6 +11,8 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("create a deployment", () => {
   test("should create a deployment", async ({ page }) => {
+    test.setTimeout(60_000);
+
     await expect(page.locator(".page-title")).toHaveText("Deployments");
     await page.getByTestId("create-button").click();
     await expect(page.getByText(/Create new deployment/).first()).toBeVisible();
@@ -29,9 +31,9 @@ test.describe("create a deployment", () => {
       .locator('[data-cy="date-picker"]')
       .fill(tomorrow.toLocaleDateString("de-CH") + " 00:00");
     await page.getByRole("button", { name: "Deploy", exact: true }).click();
-    await page
-      .getByText(/Tracking Id/)
-      .first()
-      .click();
+    const trackingIdLink = page.getByRole("link", { name: /Tracking Id \d+/ });
+    await expect(trackingIdLink).toBeVisible({ timeout: 30_000 });
+    await trackingIdLink.click();
+    await expect(page).toHaveURL(/#\/deployments\?filters=/);
   });
 });

--- a/AMW_e2e/tests/deployments.spec.ts
+++ b/AMW_e2e/tests/deployments.spec.ts
@@ -30,9 +30,17 @@ test.describe("create a deployment", () => {
     await page
       .locator('[data-cy="date-picker"]')
       .fill(tomorrow.toLocaleDateString("de-CH") + " 00:00");
-    await page.getByRole("button", { name: "Deploy", exact: true }).click();
+    const deployButton = page.getByRole("button", {
+      name: "Deploy",
+      exact: true,
+    });
+    await expect(deployButton).toBeEnabled();
+    await deployButton.click();
+    await expect(page.locator(".alert-success")).toBeVisible({
+      timeout: 30_000,
+    });
     const trackingIdLink = page.getByRole("link", { name: /Tracking Id \d+/ });
-    await expect(trackingIdLink).toBeVisible({ timeout: 30_000 });
+    await expect(trackingIdLink).toBeVisible();
     await trackingIdLink.click();
     await expect(page).toHaveURL(/#\/deployments\?filters=/);
   });

--- a/AMW_e2e/tests/resource-edit.spec.ts
+++ b/AMW_e2e/tests/resource-edit.spec.ts
@@ -4,6 +4,8 @@ async function switchContext(page: Page, contextName: string) {
   const previousUrl = page.url();
   await page.getByRole("button", { name: contextName }).click();
   await page.waitForURL((url) => url.href !== previousUrl);
+  // properties reload asynchronously and discard pending edits, so wait for it to settle
+  await page.waitForLoadState("networkidle");
 }
 
 test.beforeEach(async ({ page }) => {

--- a/AMW_e2e/tests/resource-edit.spec.ts
+++ b/AMW_e2e/tests/resource-edit.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+async function switchContext(page: Page, contextName: string) {
+  const previousUrl = page.url();
+  await page.getByRole("button", { name: contextName }).click();
+  await page.waitForURL((url) => url.href !== previousUrl);
+}
 
 test.beforeEach(async ({ page }) => {
   await page.goto("./#/resource/edit?ctx=1&id=251811&selectedResourceTypeId=1");
@@ -6,8 +12,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe.serial("Resource Edit Page - Properties", () => {
   test("should edit and save a property value", async ({ page }) => {
-    await page.getByRole("button", { name: "D (TEST)" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+    await switchContext(page, "D (TEST)");
 
     const propertyInput = page.getByRole("textbox", {
       name: "Version",
@@ -21,16 +26,12 @@ test.describe.serial("Resource Edit Page - Properties", () => {
     await saveButton.click();
   });
 
-  test("should reset property to parent context value", async ({
-    page,
-  }) => {
-    await page.getByRole("button", { name: "DEV" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+  test("should reset property to parent context value", async ({ page }) => {
+    await switchContext(page, "DEV");
 
     const propertyInput = page.getByRole("textbox", { name: "Version" });
     const originalValue = await propertyInput.inputValue();
-    await page.getByRole("button", { name: "D (TEST)" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+    await switchContext(page, "D (TEST)");
 
     await propertyInput.fill("temporary-value");
     await page.keyboard.press("Tab");
@@ -49,8 +50,7 @@ test.describe.serial("Resource Edit Page - Properties", () => {
   });
 
   test("should cancel property changes", async ({ page }) => {
-    await page.getByRole("button", { name: "D (TEST)" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+    await switchContext(page, "D (TEST)");
 
     const propertyInput = page.getByRole("textbox", { name: "Version" });
     const originalValue = await propertyInput.inputValue();
@@ -66,18 +66,10 @@ test.describe.serial("Resource Edit Page - Properties", () => {
   });
 
   test("should switch between contexts", async ({ page }) => {
-    // Click on GLOBAL context
-    await page.getByRole("button", { name: "GLOBAL" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+    await switchContext(page, "D (TEST)");
+    await switchContext(page, "GLOBAL");
 
-    // Verify URL updated
     await expect(page).toHaveURL(/ctx=1/);
-
-    // Click on D (TEST) context
-    await page.getByRole("button", { name: "D (TEST)" }).click();
-
-    // Verify URL updated (ctx should change)
-    await page.waitForURL(/ctx=\d+/);
   });
 
   test("should disable save button when no changes", async ({ page }) => {
@@ -105,7 +97,10 @@ test.describe("Resource Edit Page - Releases", () => {
     const releasesHeader = page.getByRole("heading", { name: "Releases" });
     await expect(releasesHeader).toBeVisible({ timeout: 15000 });
     await releasesHeader.click();
-    const newReleaseButton = page.getByRole("button", { name: "New Release", exact: true });
+    const newReleaseButton = page.getByRole("button", {
+      name: "New Release",
+      exact: true,
+    });
     await expect(newReleaseButton).toBeVisible({ timeout: 5000 });
     await expect(newReleaseButton).toBeEnabled();
     await expect(page.getByRole("cell", { name: "RL-" })).toBeVisible();
@@ -116,8 +111,7 @@ test.describe("Resource Edit Page - Validation", () => {
   test("should show validation errors for invalid property values", async ({
     page,
   }) => {
-    await page.getByRole("button", { name: "D (TEST)" }).click();
-    await page.waitForURL(/ctx=\d+/); // Wait for context switch
+    await switchContext(page, "D (TEST)");
     const propertyInput = page.getByRole("textbox", { name: "Version" });
     await propertyInput.fill("");
     await page.keyboard.press("Tab");

--- a/AMW_e2e/tests/settings/property-types.spec.ts
+++ b/AMW_e2e/tests/settings/property-types.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 /**
  * Test scenario:
  * 1. add a propertyType called test-property-type with invalid regex should not be possible
- * 2. add a propertyType called test-property-type
+ * 2. correct and add the propertyType
  * 3. adding the same propertyType again should not be possible
  * 4. updating the propertyType
  * 5. delete propertyType
@@ -20,30 +20,23 @@ test.describe("PropertyTypes -CRUD", () => {
     await page.getByTestId("button-add").click();
     await page.locator("#name").fill(propertyTypeName);
     await page.locator("#regex").fill("*");
-    // TODO: save should not be enabled when regex is wrong?
-    await page.getByTestId("button-save").click();
     await expect(
-      page
-        .locator("ngb-toast")
-        .filter({ hasText: "Invalid property type validation pattern." }),
+      page.getByText("Invalid regular expression pattern."),
     ).toBeVisible();
-    // close ngb-toast explicitly to not overlap edit/delete buttons
-    await page.getByTestId("toast-close").last().click();
-    await expect(page.locator("ngb-toast")).toHaveCount(0, { timeout: 5000 });
+    await expect(page.getByTestId("button-save")).toBeDisabled();
     await expect(
       page.getByRole("row").filter({ hasText: propertyTypeName }),
     ).toHaveCount(0);
-    await expect(page.locator("body.modal-open")).toHaveCount(0);
 
-    await page.getByTestId("button-add").click();
-    await page.locator("#name").fill(propertyTypeName);
     await page.locator("#regex").fill("sd");
-    await page.locator("#regex").press("Tab"); // Trigger blur for form validation
     await expect(page.getByTestId("button-save")).toBeEnabled();
     await page.getByTestId("button-save").click();
     await expect(page.locator("body.modal-open")).toHaveCount(0);
     await expect(
-      page.locator("ngb-toast").filter({ hasText: "Property type saved." }).first(),
+      page
+        .locator("ngb-toast")
+        .filter({ hasText: "Property type saved." })
+        .first(),
     ).toBeVisible({ timeout: 5000 });
     await page.getByTestId("toast-close").last().click();
     await expect(page.locator("ngb-toast")).toHaveCount(0, { timeout: 5000 });
@@ -57,7 +50,8 @@ test.describe("PropertyTypes -CRUD", () => {
     await expect(
       page
         .locator("ngb-toast")
-        .filter({ hasText: "Property type already exists." }).first(),
+        .filter({ hasText: "Property type already exists." })
+        .first(),
     ).toBeVisible({ timeout: 5000 });
     await expect(page.locator("body.modal-open")).toHaveCount(0);
     await page.getByTestId("toast-close").last().click();
@@ -74,7 +68,12 @@ test.describe("PropertyTypes -CRUD", () => {
     await page.locator("#encrypted").click();
     await expect(page.getByTestId("button-save")).toBeEnabled();
     await page.getByTestId("button-save").click();
-    await expect(page.locator("ngb-toast").filter({ hasText: "Property type saved." }).first()).toBeVisible({ timeout: 5000 });
+    await expect(
+      page
+        .locator("ngb-toast")
+        .filter({ hasText: "Property type saved." })
+        .first(),
+    ).toBeVisible({ timeout: 5000 });
     await expect(page.locator("body.modal-open")).toHaveCount(0);
     await page.getByTestId("toast-close").last().click();
     await expect(page.locator("ngb-toast")).toHaveCount(0, { timeout: 5000 });
@@ -88,7 +87,10 @@ test.describe("PropertyTypes -CRUD", () => {
     await page.getByTestId("button-delete").click();
     await expect(page.locator("ngb-toast")).toHaveCount(1, { timeout: 5000 });
     await expect(
-      page.locator("ngb-toast").filter({ hasText: "Property type deleted." }).first(),
+      page
+        .locator("ngb-toast")
+        .filter({ hasText: "Property type deleted." })
+        .first(),
     ).toBeVisible({ timeout: 5000 });
     await page.getByTestId("toast-close").last().click();
     await expect(page.locator("ngb-toast")).toHaveCount(0, { timeout: 5000 });

--- a/AMW_e2e/tests/settings/property-types.spec.ts
+++ b/AMW_e2e/tests/settings/property-types.spec.ts
@@ -29,6 +29,10 @@ test.describe("PropertyTypes -CRUD", () => {
     ).toHaveCount(0);
 
     await page.locator("#regex").fill("sd");
+    await page.locator("#regex").press("Tab"); // Trigger blur for form validation
+    await expect(
+      page.getByText("Invalid regular expression pattern."),
+    ).toHaveCount(0);
     await expect(page.getByTestId("button-save")).toBeEnabled();
     await page.getByTestId("button-save").click();
     await expect(page.locator("body.modal-open")).toHaveCount(0);


### PR DESCRIPTION
* reject invalid property type regexes client-side
* test regex validation without backend error timing
* wait for actual resource context URL changes
* wait explicitly for deployment tracking links
* add focused unit coverage for property type validation