### PR TITLE
fix: property reload state and loading behavior

### DIFF
--- a/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.spec.ts
+++ b/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.spec.ts
@@ -87,12 +87,17 @@ describe('BasePropertiesDirective', () => {
     expect(component.hasChanges()).toBe(true);
   });
 
-  it('should track property validation changes', () => {
-    component.onPropertyValidationChange('testProp', true);
-    expect(component.hasValidationErrors()).toBe(true);
+  it('should not treat an empty value as a change from null', () => {
+    const testProperty: Property = {
+      name: 'testProp',
+      value: null,
+      disabled: false,
+    } as Property;
+    component.properties.set([testProperty]);
 
-    component.onPropertyValidationChange('testProp', false);
-    expect(component.hasValidationErrors()).toBe(false);
+    component.onPropertyChange('testProp', '');
+
+    expect(component.hasChanges()).toBe(false);
   });
 
   it('should reset changes', () => {
@@ -108,14 +113,6 @@ describe('BasePropertiesDirective', () => {
 
     component.resetChanges();
     expect(component.hasChanges()).toBe(false);
-  });
-
-  it('should not save when there are validation errors', () => {
-    component.onPropertyChange('testProp', 'newValue');
-    component.onPropertyValidationChange('testProp', true);
-
-    component.saveChanges();
-    expect(component.isSaving()).toBe(false);
   });
 
   it('should clear error and success messages on reset', () => {

--- a/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.ts
+++ b/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.ts
@@ -58,7 +58,7 @@ export abstract class BasePropertiesDirective {
       const ctxId = this.contextId();
       if (!entityId || !ctxId) return;
 
-      this.reloadProperties(entityId, ctxId);
+      this.reloadAfterDiscardingEdits(entityId, ctxId);
     });
   }
 
@@ -98,8 +98,9 @@ export abstract class BasePropertiesDirective {
   }
 
   saveChanges() {
-    const changes = this.editor.changedProperties();
-    const resets = this.editor.resetProperties();
+    const loadedPropertyNames = new Set(this.properties().map((property) => property.name));
+    const changes = new Map([...this.editor.changedProperties()].filter(([name]) => loadedPropertyNames.has(name)));
+    const resets = new Set([...this.editor.resetProperties()].filter((name) => loadedPropertyNames.has(name)));
     if ((changes.size === 0 && resets.size === 0) || this.hasValidationErrors()) return;
 
     this.isSaving.set(true);
@@ -130,7 +131,7 @@ export abstract class BasePropertiesDirective {
       .subscribe({
         next: () => {
           this.successMessage.set('Properties saved successfully');
-          this.reloadProperties(this.getEntityId(), this.contextId());
+          this.reloadAfterDiscardingEdits(this.getEntityId(), this.contextId());
           this.afterPropertiesSaved();
           this.editor.resetChanges();
           setTimeout(() => this.successMessage.set(null), 3000);
@@ -164,7 +165,7 @@ export abstract class BasePropertiesDirective {
       modal,
       resourceId,
       resourceTypeId,
-      () => this.reloadProperties(this.getEntityId(), this.contextId()),
+      () => this.reloadAfterDiscardingEdits(this.getEntityId(), this.contextId()),
       this.destroy$,
     );
   }
@@ -193,7 +194,7 @@ export abstract class BasePropertiesDirective {
         next: () => {
           this.toastService.success('Property descriptor saved successfully.');
           modalRef.close();
-          this.reloadProperties(this.getEntityId(), this.contextId());
+          this.reloadAfterDiscardingEdits(this.getEntityId(), this.contextId());
         },
         error: (err) => {
           this.toastService.error('Failed to save property descriptor: ' + err.message);
@@ -216,6 +217,12 @@ export abstract class BasePropertiesDirective {
   ): Observable<void>;
   protected abstract afterPropertiesSaved(): void;
   protected abstract reloadProperties(entityId: number, contextId: number): void;
+
+  private reloadAfterDiscardingEdits(entityId: number, contextId: number): void {
+    this.editor.resetChanges();
+    this.invalidProperties.set(new Set());
+    this.reloadProperties(entityId, contextId);
+  }
   protected abstract getDeleteParams(): [number | undefined, number | undefined];
   protected abstract getSaveDescriptorParams(): [number | undefined, number | undefined];
 }

--- a/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.ts
+++ b/AMW_angular/io/src/app/resources/base-properties/base-properties.directive.ts
@@ -31,9 +31,6 @@ export abstract class BasePropertiesDirective {
   isSaving = signal(false);
   errorMessage = signal<string | null>(null);
   successMessage = signal<string | null>(null);
-  protected invalidProperties = signal<Set<string>>(new Set());
-
-  hasValidationErrors = computed(() => this.invalidProperties().size > 0);
 
   protected editor = createPropertiesEditor(
     () => [...this.properties().filter((p) => !p.disabled)],
@@ -74,23 +71,10 @@ export abstract class BasePropertiesDirective {
     this.editor.onPropertyReset(propertyName, checked);
   }
 
-  onPropertyValidationChange(propertyName: string, invalid: boolean) {
-    this.invalidProperties.update((set) => {
-      const next = new Set(set);
-      if (invalid) {
-        next.add(propertyName);
-      } else {
-        next.delete(propertyName);
-      }
-      return next;
-    });
-  }
-
   resetChanges() {
     this.editor.resetChanges();
     this.errorMessage.set(null);
     this.successMessage.set(null);
-    this.invalidProperties.set(new Set());
   }
 
   addProperty() {
@@ -101,7 +85,7 @@ export abstract class BasePropertiesDirective {
     const loadedPropertyNames = new Set(this.properties().map((property) => property.name));
     const changes = new Map([...this.editor.changedProperties()].filter(([name]) => loadedPropertyNames.has(name)));
     const resets = new Set([...this.editor.resetProperties()].filter((name) => loadedPropertyNames.has(name)));
-    if ((changes.size === 0 && resets.size === 0) || this.hasValidationErrors()) return;
+    if (changes.size === 0 && resets.size === 0) return;
 
     this.isSaving.set(true);
     this.errorMessage.set(null);
@@ -220,7 +204,6 @@ export abstract class BasePropertiesDirective {
 
   private reloadAfterDiscardingEdits(entityId: number, contextId: number): void {
     this.editor.resetChanges();
-    this.invalidProperties.set(new Set());
     this.reloadProperties(entityId, contextId);
   }
   protected abstract getDeleteParams(): [number | undefined, number | undefined];

--- a/AMW_angular/io/src/app/resources/base-relations/base-relations.directive.spec.ts
+++ b/AMW_angular/io/src/app/resources/base-relations/base-relations.directive.spec.ts
@@ -100,14 +100,6 @@ describe('BaseRelationsDirective', () => {
     expect(component.hasChanges()).toBe(true);
   });
 
-  it('should track property validation changes', () => {
-    component.onPropertyValidationChange('testProp', true);
-    expect(component.hasValidationErrors()).toBe(true);
-
-    component.onPropertyValidationChange('testProp', false);
-    expect(component.hasValidationErrors()).toBe(false);
-  });
-
   it('should reset changes', () => {
     const testProperty: Property = {
       name: 'testProp',
@@ -123,14 +115,6 @@ describe('BaseRelationsDirective', () => {
     expect(component.hasChanges()).toBe(false);
   });
 
-  it('should not save when there are validation errors', () => {
-    component.onPropertyChange('testProp', 'newValue');
-    component.onPropertyValidationChange('testProp', true);
-
-    // component.saveChanges();
-    expect(component.isSaving()).toBe(false);
-  });
-
   it('should clear error and success messages on reset', () => {
     component.errorMessage.set('Error');
     component.successMessage.set('Success');
@@ -139,15 +123,6 @@ describe('BaseRelationsDirective', () => {
 
     expect(component.errorMessage()).toBeNull();
     expect(component.successMessage()).toBeNull();
-  });
-
-  it('should clear invalid properties on reset', () => {
-    component.onPropertyValidationChange('testProp', true);
-    expect(component.hasValidationErrors()).toBe(true);
-
-    component.resetChanges();
-
-    expect(component.hasValidationErrors()).toBe(false);
   });
 
   it('should track property resets as changes', () => {
@@ -193,6 +168,41 @@ describe('BaseRelationsDirective', () => {
     component.onItemSelected({ key: 7, name: 'rel', type: 'consumed' });
     expect(component['activeRelationId']()).toBe(7);
     expect(spy).toHaveBeenCalledWith(7);
+  });
+
+  it('should discard changes after confirming a relation switch', async () => {
+    const confirmSpy = vi.spyOn(component['confirmDialogService'], 'confirm').mockResolvedValue(true);
+    const navigationSpy = vi.spyOn(component, 'setQueryParamForRelationId').mockImplementation(() => {});
+    component['activeRelationId'].set(1);
+    component.properties.set([{ name: 'testProp', value: 'oldValue', disabled: false } as Property]);
+    component.onPropertyChange('testProp', 'newValue');
+
+    component.onItemSelected({ key: 7, name: 'rel', type: 'consumed' });
+    await Promise.resolve();
+
+    expect(confirmSpy).toHaveBeenCalledWith('You have unsaved changes. Discard them and switch relation?', {
+      confirmLabel: 'Discard',
+    });
+    expect(component.hasChanges()).toBe(false);
+    expect(component['activeRelationId']()).toBe(7);
+    expect(navigationSpy).toHaveBeenCalledWith(7);
+    confirmSpy.mockRestore();
+  });
+
+  it('should keep the current relation when discarding a switch', async () => {
+    const confirmSpy = vi.spyOn(component['confirmDialogService'], 'confirm').mockResolvedValue(false);
+    const navigationSpy = vi.spyOn(component, 'setQueryParamForRelationId').mockImplementation(() => {});
+    component['activeRelationId'].set(1);
+    component.properties.set([{ name: 'testProp', value: 'oldValue', disabled: false } as Property]);
+    component.onPropertyChange('testProp', 'newValue');
+
+    component.onItemSelected({ key: 7, name: 'rel', type: 'consumed' });
+    await Promise.resolve();
+
+    expect(component.hasChanges()).toBe(true);
+    expect(component['activeRelationId']()).toBe(1);
+    expect(navigationSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 
   it('should ignore onItemSelected when key is not a number', () => {

--- a/AMW_angular/io/src/app/resources/base-relations/base-relations.directive.ts
+++ b/AMW_angular/io/src/app/resources/base-relations/base-relations.directive.ts
@@ -13,6 +13,7 @@ import { GroupedResourceRelations, ResourceRelation, UnresolvedRelation } from '
 import { RelationGroupItem } from '../relation-group/relation-group.component';
 import { PropertyUpdate } from '../services/resource-properties.service';
 import { finalize } from 'rxjs/operators';
+import { ConfirmDialogService } from '../../shared/confirm-dialog/confirm-dialog.service';
 
 export const NODE_FILTERED_PROPERTIES = ['hostName', 'active'];
 
@@ -29,15 +30,13 @@ export abstract class BaseRelationsDirective {
   protected toastService = inject(ToastService);
   protected route = inject(ActivatedRoute);
   protected router = inject(Router);
+  protected confirmDialogService = inject(ConfirmDialogService);
 
   protected destroy$ = new Subject<void>();
 
   isSaving = signal(false);
   errorMessage = signal<string | null>(null);
   successMessage = signal<string | null>(null);
-  protected invalidProperties = signal<Set<string>>(new Set());
-
-  hasValidationErrors = computed(() => this.invalidProperties().size > 0);
 
   protected editor = createPropertiesEditor(
     () => [...this.properties().filter((p) => !p.disabled)],
@@ -103,7 +102,7 @@ export abstract class BaseRelationsDirective {
   saveChanges() {
     const changes = this.editor.changedProperties();
     const resets = this.editor.resetProperties();
-    if ((changes.size === 0 && resets.size === 0) || this.hasValidationErrors()) return;
+    if (changes.size === 0 && resets.size === 0) return;
 
     this.isSaving.set(true);
     this.errorMessage.set(null);
@@ -152,23 +151,29 @@ export abstract class BaseRelationsDirective {
     this.editor.onPropertyReset(propertyName, checked);
   }
 
-  onPropertyValidationChange(propertyName: string, invalid: boolean) {
-    this.invalidProperties.update((set) => {
-      const next = new Set(set);
-      if (invalid) {
-        next.add(propertyName);
-      } else {
-        next.delete(propertyName);
-      }
-      return next;
-    });
-  }
-
   onItemSelected(item: RelationGroupItem) {
     const id = typeof item.key === 'number' ? item.key : null;
     if (id == null) return;
-    this.activeRelationId.set(id);
-    this.setQueryParamForRelationId(id);
+    this.switchRelation(id);
+  }
+
+  protected switchRelation(relationId: number): void {
+    if (relationId === this.getRelationId()) return;
+
+    if (this.hasChanges()) {
+      void this.confirmDialogService
+        .confirm('You have unsaved changes. Discard them and switch relation?', { confirmLabel: 'Discard' })
+        .then((proceed) => {
+          if (!proceed) return;
+          this.resetChanges();
+          this.activeRelationId.set(relationId);
+          this.setQueryParamForRelationId(relationId);
+        });
+      return;
+    }
+
+    this.activeRelationId.set(relationId);
+    this.setQueryParamForRelationId(relationId);
   }
 
   toItem(relation: ResourceRelation): RelationGroupItem {
@@ -185,7 +190,6 @@ export abstract class BaseRelationsDirective {
     this.editor.resetChanges();
     this.errorMessage.set(null);
     this.successMessage.set(null);
-    this.invalidProperties.set(new Set());
   }
 
   protected abstract properties: Signal<Property[]>;

--- a/AMW_angular/io/src/app/resources/contexts-list/contexts-list.component.ts
+++ b/AMW_angular/io/src/app/resources/contexts-list/contexts-list.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs/operators';
 import { UnsavedPropertyChangesService } from '../services/unsaved-property-changes.service';
+import { ConfirmDialogService } from '../../shared/confirm-dialog/confirm-dialog.service';
 
 @Component({
   selector: 'app-contexts-list',
@@ -21,6 +22,7 @@ export class ContextsListComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private unsavedChangesService = inject(UnsavedPropertyChangesService);
+  private confirmDialogService = inject(ConfirmDialogService);
 
   environmentTree: Signal<EnvironmentTree[]> = this.environmentsService.environmentTree;
   contextId = toSignal(this.route.queryParamMap.pipe(map((params) => Number(params.get('ctx')))), { initialValue: 1 });
@@ -43,13 +45,20 @@ export class ContextsListComponent {
 
   protected setContext(domain: EnvironmentTree) {
     if (this.unsavedChangesService.hasUnsavedChanges()) {
-      const proceed = window.confirm('You have unsaved changes. Discard them and switch context?');
-      if (!proceed) {
-        return;
-      }
-      this.unsavedChangesService.discardAll();
+      void this.confirmDialogService
+        .confirm('You have unsaved changes. Discard them and switch context?', { confirmLabel: 'Discard' })
+        .then((proceed) => {
+          if (!proceed) return;
+          this.unsavedChangesService.discardAll();
+          this.navigateToContext(domain);
+        });
+      return;
     }
 
+    this.navigateToContext(domain);
+  }
+
+  private navigateToContext(domain: EnvironmentTree) {
     void this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { ctx: domain.id },

--- a/AMW_angular/io/src/app/resources/models/properties-action.ts
+++ b/AMW_angular/io/src/app/resources/models/properties-action.ts
@@ -1,5 +1,4 @@
 export type PropertiesValueChangeAction = { name: string; value: string };
 export type PropertiesResetToggleAction = { name: string; checked: boolean };
-export type PropertiesValidationChangeAction = { name: string; invalid: boolean };
 export type PropertiesEditAction = { id: number };
 export type PropertiesDeleteAction = { id: number };

--- a/AMW_angular/io/src/app/resources/properties-editor.ts
+++ b/AMW_angular/io/src/app/resources/properties-editor.ts
@@ -42,7 +42,7 @@ export function createPropertiesEditor(
     const props = getProperties() || [];
     const originalProperty = props.find((p) => p.name === propertyName);
 
-    if (originalProperty && originalProperty.value !== newValue) {
+    if (originalProperty && (originalProperty.value ?? '') !== newValue) {
       changedProperties.update((map) => {
         const newMap = new Map(map);
         newMap.set(propertyName, newValue);

--- a/AMW_angular/io/src/app/resources/properties-list/properties-list.component.html
+++ b/AMW_angular/io/src/app/resources/properties-list/properties-list.component.html
@@ -1,4 +1,4 @@
-<div class="properties-list">
+<div class="properties-list" [attr.inert]="isLoading() ? '' : null">
   <div class="properties-column">
     @for (property of listProperties().left; track property.descriptorId) {
       <ng-container
@@ -27,6 +27,7 @@
     [canEdit]="canEdit()"
     [canDecrypt]="canDecrypt()"
     [canDelete]="canDelete()"
+    [isLoading]="isLoading()"
     (valueChange)="valueChange.emit({ name: property.name, value: $event })"
     (resetChange)="resetToggled.emit({ name: property.name, checked: $event })"
     (validationChange)="validationChanged.emit({ name: property.name, invalid: $event })"

--- a/AMW_angular/io/src/app/resources/properties-list/properties-list.component.html
+++ b/AMW_angular/io/src/app/resources/properties-list/properties-list.component.html
@@ -30,7 +30,6 @@
     [isLoading]="isLoading()"
     (valueChange)="valueChange.emit({ name: property.name, value: $event })"
     (resetChange)="resetToggled.emit({ name: property.name, checked: $event })"
-    (validationChange)="validationChanged.emit({ name: property.name, invalid: $event })"
     (editClicked)="editClicked.emit({ id: property.descriptorId })"
     (deleteClicked)="deleteClicked.emit({ id: property.descriptorId })"
   ></app-property-field>

--- a/AMW_angular/io/src/app/resources/properties-list/properties-list.component.ts
+++ b/AMW_angular/io/src/app/resources/properties-list/properties-list.component.ts
@@ -5,7 +5,6 @@ import {
   PropertiesDeleteAction,
   PropertiesEditAction,
   PropertiesResetToggleAction,
-  PropertiesValidationChangeAction,
   PropertiesValueChangeAction,
 } from '../models/properties-action';
 import { NgTemplateOutlet } from '@angular/common';
@@ -28,7 +27,6 @@ export class PropertiesListComponent {
 
   valueChange = output<PropertiesValueChangeAction>();
   resetToggled = output<PropertiesResetToggleAction>();
-  validationChanged = output<PropertiesValidationChangeAction>();
   editClicked = output<PropertiesEditAction>();
   deleteClicked = output<PropertiesDeleteAction>();
 

--- a/AMW_angular/io/src/app/resources/properties-list/properties-list.component.ts
+++ b/AMW_angular/io/src/app/resources/properties-list/properties-list.component.ts
@@ -22,6 +22,7 @@ export class PropertiesListComponent {
   canEdit = input<boolean>(false);
   canDecrypt = input<boolean>(false);
   canDelete = input<boolean>(false);
+  isLoading = input<boolean>(false);
   mode = input<'resource' | 'resourceType'>('resource');
   resetToken = input<number>(0);
 

--- a/AMW_angular/io/src/app/resources/properties-panel/properties-panel.component.html
+++ b/AMW_angular/io/src/app/resources/properties-panel/properties-panel.component.html
@@ -16,20 +16,15 @@
       <app-button [variant]="'light'" [size]="'sm'" [dataTestId]="'button-cancel'" (click)="cancelAction.emit()"
         >Cancel</app-button
       >
-      <span
-        [ngbTooltip]="hasValidationErrors() ? 'Fix validation errors to enable saving' : ''"
-        [disableTooltip]="!hasValidationErrors()"
+      <app-button
+        [variant]="'primary'"
+        [size]="'sm'"
+        (click)="saveAction.emit()"
+        [dataTestId]="'button-save'"
+        [disabled]="isSaving()"
       >
-        <app-button
-          [variant]="'primary'"
-          [size]="'sm'"
-          (click)="saveAction.emit()"
-          [dataTestId]="'button-save'"
-          [disabled]="isSaving() || hasValidationErrors()"
-        >
-          {{ isSaving() ? 'Saving...' : 'Save' }}
-        </app-button>
-      </span>
+        {{ isSaving() ? 'Saving...' : 'Save' }}
+      </app-button>
     </div>
   }
 </div>

--- a/AMW_angular/io/src/app/resources/properties-panel/properties-panel.component.ts
+++ b/AMW_angular/io/src/app/resources/properties-panel/properties-panel.component.ts
@@ -1,11 +1,10 @@
 import { Component, input, output } from '@angular/core';
 import { ButtonComponent } from '../../shared/button/button.component';
-import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'app-properties-panel',
   standalone: true,
-  imports: [ButtonComponent, NgbTooltip],
+  imports: [ButtonComponent],
   templateUrl: './properties-panel.component.html',
   styleUrl: './properties-panel.component.scss',
 })
@@ -13,7 +12,6 @@ export class PropertiesPanelComponent {
   canEdit = input<boolean>(false);
   isSaving = input<boolean>(false);
   hasChanges = input<boolean>(false);
-  hasValidationErrors = input<boolean>(false);
   errorMessage = input<string | null>(null);
   successMessage = input<string | null>(null);
 

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.html
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.html
@@ -51,7 +51,7 @@
       (focus)="onFocus()"
       (blur)="onBlur()"
       [placeholder]="placeholder"
-      [disabled]="isDisabled() ?? false"
+      [disabled]="isDisabled()"
     />
   } @else {
     <textarea
@@ -63,7 +63,7 @@
       [(ngModel)]="localValue"
       (blur)="onBlur()"
       [placeholder]="placeholder"
-      [disabled]="isDisabled() ?? false"
+      [disabled]="isDisabled()"
     ></textarea>
   }
   @if (canReset() && (!property().encrypted || canDecrypt())) {

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.spec.ts
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.spec.ts
@@ -59,6 +59,19 @@ describe('PropertyFieldComponent', () => {
     expect(component.validationError()).toBe('This field is required');
   });
 
+  it('should show an initial required error without reporting a touched validation error', () => {
+    componentRef.setInput(
+      'property',
+      baseProperty({ nullable: false, optional: false, defaultValue: '', mik: '', validationRegex: '.*' }),
+    );
+    const validationSpy = vi.fn();
+    component.validationChange.subscribe(validationSpy);
+    fixture.detectChanges();
+
+    expect(component.validationError()).toBe('This field is required');
+    expect(validationSpy).toHaveBeenLastCalledWith(false);
+  });
+
   it('should not show required error when required but mik is present (no explicit value/default)', () => {
     componentRef.setInput(
       'property',

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
@@ -23,6 +23,7 @@ export class PropertyFieldComponent {
   canEdit = input<boolean>(false);
   canDecrypt = input<boolean>(false);
   canDelete = input<boolean>(false);
+  isLoading = input<boolean>(false);
   hideTooltip = input<boolean>(false);
   valueChange = output<string>();
   validationChange = output<boolean>();
@@ -41,7 +42,7 @@ export class PropertyFieldComponent {
   displayLabel = computed(() => this.property().displayName || this.property().name);
   hasError = computed(() => this.touched() && !!this.validationError());
   canReset = computed(() => !!this.property().definedInContext);
-  isDisabled = computed(() => this.property().disabled);
+  isDisabled = computed(() => this.property().disabled || this.isLoading());
   isEncrypted = computed(() => !!this.property().encrypted);
 
   showProperty = computed(() => {
@@ -95,7 +96,7 @@ export class PropertyFieldComponent {
       this.showDecrypted.set(false);
       this.touched.set(false);
       this.validationError.set(null);
-      this.validationChange.emit(false);
+      this.validate();
     });
   }
 

--- a/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
+++ b/AMW_angular/io/src/app/resources/property-field/property-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, signal, computed, effect } from '@angular/core';
+import { Component, input, output, signal, computed, effect, untracked } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Property } from '../models/property';
 import { ButtonComponent } from '../../shared/button/button.component';
@@ -96,7 +96,7 @@ export class PropertyFieldComponent {
       this.showDecrypted.set(false);
       this.touched.set(false);
       this.validationError.set(null);
-      this.validate();
+      untracked(() => this.validate());
     });
   }
 
@@ -166,7 +166,7 @@ export class PropertyFieldComponent {
     // Skip required validation when reset is checked
     if (!this.resetChecked() && !isNullable && !isOptional && noValueSet && mik === '') {
       this.validationError.set('This field is required');
-      this.validationChange.emit(true);
+      this.validationChange.emit(this.touched());
       return;
     }
 
@@ -184,13 +184,13 @@ export class PropertyFieldComponent {
         const fullMatchRegex = new RegExp(`^(?:${regexString})$`);
         if (!fullMatchRegex.test(regexMatchValue)) {
           this.validationError.set('Value does not match the required pattern');
-          this.validationChange.emit(true);
+          this.validationChange.emit(this.touched());
           return;
         }
       } catch (e) {
         console.error('Invalid regex pattern:', regexString, e);
         this.validationError.set('Value does not match the required pattern');
-        this.validationChange.emit(true);
+        this.validationChange.emit(this.touched());
         return;
       }
     }

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, Signal } from '@angular/core';
+import { Component, computed, effect, inject, Signal } from '@angular/core';
 import { LoadingIndicatorComponent } from '../../shared/elements/loading-indicator.component';
 import { PageComponent } from '../../layout/page/page.component';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -20,6 +20,7 @@ import { RESOURCE_TYPE } from '../../core/amw-constants';
 import { CopyFromResourceDialogComponent } from './copy-from-resource-dialog/copy-from-resource-dialog.component';
 import { ResourceApplicationsComponent } from './resource-applications/resource-applications.component';
 import { ResourceRelationsComponent } from './resource-relations/resource-relations.component';
+import { ResourcePropertiesService } from '../services/resource-properties.service';
 
 @Component({
   selector: 'app-resource-edit',
@@ -48,6 +49,7 @@ import { ResourceRelationsComponent } from './resource-relations/resource-relati
 export class ResourceEditComponent {
   private authService = inject(AuthService);
   private resourceService = inject(ResourceService);
+  private resourcePropertiesService = inject(ResourcePropertiesService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private modalService = inject(NgbModal);
@@ -61,12 +63,18 @@ export class ResourceEditComponent {
   resource: Signal<Resource | null> = this.resourceService.resource;
   releases: Signal<Release[]> = this.resourceService.releasesForResourceGroup;
 
-  isLoading = computed(() => {
-    if (this.id()) {
-      this.resourceService.setIdForResource(this.id());
-      return false;
-    } else return false;
-  });
+  isLoading = computed(
+    () => this.resourceService.isLoadingResource() || this.resourcePropertiesService.isLoadingResourceProperties(),
+  );
+
+  constructor() {
+    effect(() => {
+      const resourceId = this.id();
+      if (resourceId) {
+        this.resourceService.setIdForResource(resourceId);
+      }
+    });
+  }
 
   protected readonly isApplicationServer = computed<boolean>(
     () => this.resource()?.type === RESOURCE_TYPE.APPLICATION_SERVER,

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.html
@@ -12,7 +12,6 @@
     [canEdit]="permissions().canUpdateProperty"
     [isSaving]="isSaving()"
     [hasChanges]="hasChanges()"
-    [hasValidationErrors]="hasValidationErrors()"
     [errorMessage]="errorMessage()"
     [successMessage]="successMessage()"
     (cancelAction)="resetChanges()"
@@ -28,7 +27,6 @@
       [resetToken]="resetToken()"
       (valueChange)="onPropertyChange($event.name, $event.value)"
       (resetToggled)="onPropertyReset($event.name, $event.checked)"
-      (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
       (editClicked)="onPropertyEdit($event.id)"
       (deleteClicked)="onPropertyDelete($event.id, deleteModal)"
     ></app-properties-list>

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-properties/resource-properties.component.html
@@ -23,6 +23,7 @@
       [canEdit]="permissions().canUpdateProperty"
       [canDecrypt]="permissions().canDecryptProperties"
       [canDelete]="permissions().canUpdateProperty"
+      [isLoading]="isLoading()"
       [mode]="'resource'"
       [resetToken]="resetToken()"
       (valueChange)="onPropertyChange($event.name, $event.value)"

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
@@ -78,7 +78,6 @@
               [canEdit]="permissions().canUpdateProperty"
               [isSaving]="isSaving()"
               [hasChanges]="hasChanges()"
-              [hasValidationErrors]="hasValidationErrors()"
               [errorMessage]="errorMessage()"
               [successMessage]="successMessage()"
               (cancelAction)="resetChanges()"
@@ -94,7 +93,6 @@
                 [resetToken]="resetToken()"
                 (valueChange)="onPropertyChange($event.name, $event.value)"
                 (resetToggled)="onPropertyReset($event.name, $event.checked)"
-                (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
               ></app-properties-list>
 
               <app-relation-active-applications

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.html
@@ -89,6 +89,7 @@
                 [canEdit]="false"
                 [canDecrypt]="permissions().canDecryptProperties"
                 [canDelete]="false"
+                [isLoading]="isLoadingProperties()"
                 [mode]="'resource'"
                 [resetToken]="resetToken()"
                 (valueChange)="onPropertyChange($event.name, $event.value)"

--- a/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
+++ b/AMW_angular/io/src/app/resources/resource-edit/resource-relations/resource-relations.component.ts
@@ -32,9 +32,7 @@ import { PropertiesListComponent } from '../../properties-list/properties-list.c
 import { BaseRelationsDirective, NODE_FILTERED_PROPERTIES } from '../../base-relations/base-relations.directive';
 import { RelationActiveApplicationsComponent } from './relation-active-applications/relation-active-applications.component';
 import { ResourceActivationService, ResourceActivation } from '../../services/resource-activation.service';
-import {
-  ResourceRelationTemplatesListComponent
-} from './resource-relation-templates-list/resource-relation-templates-list.component';
+import { ResourceRelationTemplatesListComponent } from './resource-relation-templates-list/resource-relation-templates-list.component';
 
 @Component({
   selector: 'app-resource-relations',
@@ -53,7 +51,7 @@ import {
     RouterLink,
     ModalHeaderComponent,
     RelationActiveApplicationsComponent,
-    ResourceRelationTemplatesListComponent
+    ResourceRelationTemplatesListComponent,
   ],
   templateUrl: './resource-relations.component.html',
   styleUrl: './resource-relations.component.scss',
@@ -261,8 +259,7 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
   }
 
   onReleaseChange(relationId: number) {
-    this.activeRelationId.set(relationId);
-    this.setQueryParamForRelationId(relationId);
+    this.switchRelation(relationId);
   }
 
   showAddRelationModal(): void {
@@ -360,21 +357,25 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     const res = this.resource();
     if (res?.release) {
       const selectedGroup = this.availableResourceGroups().find((g) => g.id === groupId);
-      if (selectedGroup?.releases?.length) {
-        const firstRelease = selectedGroup.releases[0];
-        const currentReleaseName = res.release;
-        if (firstRelease?.release && firstRelease.release > currentReleaseName) {
-          if (
-            !confirm(
-              `The selected resource does not exist for the release ${currentReleaseName}. Are you sure you want to add it for this release?`,
-            )
-          ) {
-            return;
-          }
-        }
+      const firstRelease = selectedGroup?.releases?.[0];
+      const currentReleaseName = res.release;
+      if (firstRelease?.release && firstRelease.release > currentReleaseName) {
+        void this.confirmDialogService
+          .confirm(
+            `The selected resource does not exist for the release ${currentReleaseName}. Are you sure you want to add it for this release?`,
+            { confirmLabel: 'Add' },
+          )
+          .then((proceed) => {
+            if (proceed) this.doAddRelation(groupId);
+          });
+        return;
       }
     }
 
+    this.doAddRelation(groupId);
+  }
+
+  private doAddRelation(groupId: number): void {
     this.isAddingRelation.set(true);
     this.relationsService.addResourceRelation(this.entityId()!, groupId, this.addAsProvided()).subscribe({
       next: () => {
@@ -405,7 +406,7 @@ export class ResourceRelationsComponent extends BaseRelationsDirective {
     const hasPropertyChanges = propertyChanges.size > 0 || propertyResets.size > 0;
     const hasActivationChanges = this.hasActivationChanges();
 
-    if ((!hasPropertyChanges && !hasActivationChanges) || this.hasValidationErrors()) return;
+    if (!hasPropertyChanges && !hasActivationChanges) return;
 
     this.isSaving.set(true);
     this.errorMessage.set(null);

--- a/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-properties/resource-type-properties.component.html
+++ b/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-properties/resource-type-properties.component.html
@@ -12,7 +12,6 @@
     [canEdit]="permissions().canUpdateProperty"
     [isSaving]="isSaving()"
     [hasChanges]="hasChanges()"
-    [hasValidationErrors]="hasValidationErrors()"
     [errorMessage]="errorMessage()"
     [successMessage]="successMessage()"
     (cancelAction)="resetChanges()"
@@ -28,7 +27,6 @@
       [resetToken]="resetToken()"
       (valueChange)="onPropertyChange($event.name, $event.value)"
       (resetToggled)="onPropertyReset($event.name, $event.checked)"
-      (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
       (editClicked)="onPropertyEdit($event.id)"
       (deleteClicked)="onPropertyDelete($event.id, deleteModal)"
     ></app-properties-list>

--- a/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-properties/resource-type-properties.component.html
+++ b/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-properties/resource-type-properties.component.html
@@ -23,6 +23,7 @@
       [canEdit]="permissions().canUpdateProperty"
       [canDecrypt]="permissions().canDecryptProperties"
       [canDelete]="permissions().canUpdateProperty"
+      [isLoading]="isLoading()"
       [mode]="'resourceType'"
       [resetToken]="resetToken()"
       (valueChange)="onPropertyChange($event.name, $event.value)"

--- a/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-relations/resource-type-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-relations/resource-type-relations.component.html
@@ -46,6 +46,7 @@
                 [canEdit]="false"
                 [canDecrypt]="permissions().canDecryptProperties"
                 [canDelete]="false"
+                [isLoading]="isLoadingProperties()"
                 [mode]="'resourceType'"
                 [resetToken]="resetToken()"
                 (valueChange)="onPropertyChange($event.name, $event.value)"

--- a/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-relations/resource-type-relations.component.html
+++ b/AMW_angular/io/src/app/resources/resource-type-edit/resource-type-relations/resource-type-relations.component.html
@@ -35,7 +35,6 @@
               [canEdit]="permissions().canUpdateProperty"
               [isSaving]="isSaving()"
               [hasChanges]="hasChanges()"
-              [hasValidationErrors]="hasValidationErrors()"
               [errorMessage]="errorMessage()"
               [successMessage]="successMessage()"
               (cancelAction)="resetChanges()"
@@ -51,7 +50,6 @@
                 [resetToken]="resetToken()"
                 (valueChange)="onPropertyChange($event.name, $event.value)"
                 (resetToggled)="onPropertyReset($event.name, $event.checked)"
-                (validationChanged)="onPropertyValidationChange($event.name, $event.invalid)"
               ></app-properties-list>
             </app-properties-panel>
           </div>

--- a/AMW_angular/io/src/app/resources/services/resource-properties.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-properties.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable, signal } from '@angular/core';
 import { BaseService } from '../../base/base.service';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Observable, startWith, Subject } from 'rxjs';
+import { Observable, of, startWith, Subject } from 'rxjs';
 import { Property } from '../models/property';
 import { catchError, finalize, shareReplay, switchMap } from 'rxjs/operators';
 
@@ -17,6 +17,8 @@ export class ResourcePropertiesService extends BaseService {
 
   private loadingResourceProperties = signal(false);
   private loadingResourceTypeProperties = signal(false);
+  private resourcePropertiesRequestId = 0;
+  private resourceTypePropertiesRequestId = 0;
 
   isLoadingResourceProperties = this.loadingResourceProperties.asReadonly();
   isLoadingResourceTypeProperties = this.loadingResourceTypeProperties.asReadonly();
@@ -32,8 +34,17 @@ export class ResourcePropertiesService extends BaseService {
 
   private propertiesForResource$: Observable<Property[]> = this.properties$.pipe(
     switchMap(({ id, contextId }) => {
+      const requestId = ++this.resourcePropertiesRequestId;
       this.loadingResourceProperties.set(true);
-      return this.getResourceProperties(id, contextId).pipe(finalize(() => this.loadingResourceProperties.set(false)));
+      return this.getResourceProperties(id, contextId).pipe(
+        finalize(() => {
+          if (requestId === this.resourcePropertiesRequestId) {
+            this.loadingResourceProperties.set(false);
+          }
+        }),
+        // a failed/aborted request must not terminate this shared, replayed stream
+        catchError(() => of([] as Property[])),
+      );
     }),
     startWith([]),
     shareReplay(1),
@@ -41,9 +52,15 @@ export class ResourcePropertiesService extends BaseService {
 
   private propertiesForTypeResource$: Observable<Property[]> = this.propertiesForType$.pipe(
     switchMap(({ id, contextId }) => {
+      const requestId = ++this.resourceTypePropertiesRequestId;
       this.loadingResourceTypeProperties.set(true);
       return this.getResourceTypeProperties(id, contextId).pipe(
-        finalize(() => this.loadingResourceTypeProperties.set(false)),
+        finalize(() => {
+          if (requestId === this.resourceTypePropertiesRequestId) {
+            this.loadingResourceTypeProperties.set(false);
+          }
+        }),
+        catchError(() => of([] as Property[])),
       );
     }),
     startWith([]),

--- a/AMW_angular/io/src/app/resources/services/resource-relations.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource-relations.service.ts
@@ -2,7 +2,7 @@ import { inject, Injectable, signal } from '@angular/core';
 import { BaseService } from '../../base/base.service';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Observable, startWith, Subject } from 'rxjs';
+import { Observable, of, startWith, Subject } from 'rxjs';
 import { GroupedResourceRelations } from '../models/resource-relation';
 import { Property } from '../models/property';
 import { PropertyUpdate } from './resource-properties.service';
@@ -31,6 +31,7 @@ export class ResourceRelationsService extends BaseService {
       return this.getResourceRelations(id).pipe(
         startWith(EMPTY_GROUPED_RELATIONS),
         finalize(() => this.loadingRelations.set(false)),
+        catchError(() => of(EMPTY_GROUPED_RELATIONS)),
       );
     }),
     startWith(EMPTY_GROUPED_RELATIONS),
@@ -62,6 +63,7 @@ export class ResourceRelationsService extends BaseService {
       return this.getResourceTypeRelations(id).pipe(
         startWith(EMPTY_GROUPED_RELATIONS),
         finalize(() => this.loadingTypeRelations.set(false)),
+        catchError(() => of(EMPTY_GROUPED_RELATIONS)),
       );
     }),
     startWith(EMPTY_GROUPED_RELATIONS),
@@ -97,6 +99,8 @@ export class ResourceRelationsService extends BaseService {
 
   private loadingRelationProperties = signal(false);
   private loadingTypeRelationProperties = signal(false);
+  private relationPropertiesRequestId = 0;
+  private typeRelationPropertiesRequestId = 0;
   isLoadingRelationProperties = this.loadingRelationProperties.asReadonly();
   isLoadingTypeRelationProperties = this.loadingTypeRelationProperties.asReadonly();
 
@@ -116,12 +120,17 @@ export class ResourceRelationsService extends BaseService {
     relationId: number;
   }>();
 
-
   private relationPropertiesForResource$: Observable<Property[]> = this.relationProperties$.pipe(
     switchMap(({ resourceId, relationId, contextId }) => {
+      const requestId = ++this.relationPropertiesRequestId;
       this.loadingRelationProperties.set(true);
       return this.getResourceRelationProperties(resourceId, relationId, contextId).pipe(
-        finalize(() => this.loadingRelationProperties.set(false)),
+        finalize(() => {
+          if (requestId === this.relationPropertiesRequestId) {
+            this.loadingRelationProperties.set(false);
+          }
+        }),
+        catchError(() => of([] as Property[])),
       );
     }),
     startWith([]),
@@ -129,8 +138,10 @@ export class ResourceRelationsService extends BaseService {
   );
 
   private relationTemplatesForResource$: Observable<ResourceTemplate[]> = this.resourceRelationTemplates$.pipe(
-    switchMap(({ resourceId, relationId}) => {
-      return this.getResourceRelationTemplates(resourceId, relationId)
+    switchMap(({ resourceId, relationId }) => {
+      return this.getResourceRelationTemplates(resourceId, relationId).pipe(
+        catchError(() => of([] as ResourceTemplate[])),
+      );
     }),
     startWith([]),
     shareReplay(1),
@@ -138,7 +149,9 @@ export class ResourceRelationsService extends BaseService {
 
   private relationTemplatesForResourceType$: Observable<ResourceTemplate[]> = this.resourceTypeRelationTemplates$.pipe(
     switchMap(({ resourceTypeId, relationId }) => {
-      return this.getResourceTypeRelationTemplates(resourceTypeId, relationId)
+      return this.getResourceTypeRelationTemplates(resourceTypeId, relationId).pipe(
+        catchError(() => of([] as ResourceTemplate[])),
+      );
     }),
     startWith([]),
     shareReplay(1),
@@ -146,7 +159,9 @@ export class ResourceRelationsService extends BaseService {
 
   relationProperties = toSignal(this.relationPropertiesForResource$, { initialValue: [] as Property[] });
   resourceRelationTemplates = toSignal(this.relationTemplatesForResource$, { initialValue: [] as ResourceTemplate[] });
-  resourceTypeRelationTemplates = toSignal(this.relationTemplatesForResourceType$, { initialValue: [] as ResourceTemplate[] });
+  resourceTypeRelationTemplates = toSignal(this.relationTemplatesForResourceType$, {
+    initialValue: [] as ResourceTemplate[],
+  });
 
   setIdsForRelationProperties(resourceId: number, relationId: number, contextId: number) {
     this.relationProperties$.next({ resourceId, relationId, contextId });
@@ -165,9 +180,15 @@ export class ResourceRelationsService extends BaseService {
 
   private typeRelationPropertiesForType$: Observable<Property[]> = this.typeRelationProperties$.pipe(
     switchMap(({ resourceTypeId, relTypeId, contextId }) => {
+      const requestId = ++this.typeRelationPropertiesRequestId;
       this.loadingTypeRelationProperties.set(true);
       return this.getResourceTypeRelationProperties(resourceTypeId, relTypeId, contextId).pipe(
-        finalize(() => this.loadingTypeRelationProperties.set(false)),
+        finalize(() => {
+          if (requestId === this.typeRelationPropertiesRequestId) {
+            this.loadingTypeRelationProperties.set(false);
+          }
+        }),
+        catchError(() => of([] as Property[])),
       );
     }),
     startWith([]),
@@ -288,8 +309,17 @@ export class ResourceRelationsService extends BaseService {
 
   getResourceRelationTemplates(resourceId: number, relationId: number): Observable<ResourceTemplate[]> {
     return this.http
-      .get<ResourceTemplate[]>(
-        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/templates`,
+      .get<ResourceTemplate[]>(`${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/templates`, {
+        headers: this.getHeaders(),
+      })
+      .pipe(catchError(this.handleError));
+  }
+
+  addResourceRelationTemplate(template: ResourceTemplate, resourceId: number, relationId: number) {
+    return this.http
+      .post<ResourceTemplate>(
+        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/addTemplate`,
+        template,
         {
           headers: this.getHeaders(),
         },
@@ -297,35 +327,39 @@ export class ResourceRelationsService extends BaseService {
       .pipe(catchError(this.handleError));
   }
 
-  addResourceRelationTemplate(template: ResourceTemplate, resourceId: number, relationId: number) {
-    return this.http
-      .post<ResourceTemplate>(`${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/addTemplate`, template, {
-        headers: this.getHeaders(),
-      })
-      .pipe(catchError(this.handleError));
-  }
-
   addResourceTypeRelationTemplate(template: ResourceTemplate, resourceTypeId: number, relationId: number) {
     return this.http
-      .post<ResourceTemplate>(`${this.getBaseUrl()}/resourceTypes/${resourceTypeId}/relations/${relationId}/addTemplate`, template, {
-        headers: this.getHeaders(),
-      })
+      .post<ResourceTemplate>(
+        `${this.getBaseUrl()}/resourceTypes/${resourceTypeId}/relations/${relationId}/addTemplate`,
+        template,
+        {
+          headers: this.getHeaders(),
+        },
+      )
       .pipe(catchError(this.handleError));
   }
 
   updateResourceRelationTemplate(template: ResourceTemplate, resourceId: number, relationId: number) {
     return this.http
-      .put<ResourceTemplate>(`${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/updateTemplate`, template, {
-        headers: this.getHeaders(),
-      })
+      .put<ResourceTemplate>(
+        `${this.getBaseUrl()}/resources/${resourceId}/relations/${relationId}/updateTemplate`,
+        template,
+        {
+          headers: this.getHeaders(),
+        },
+      )
       .pipe(catchError(this.handleError));
   }
 
   updateResourceTypeRelationTemplate(template: ResourceTemplate, resourceTypeId: number, relationId: number) {
     return this.http
-      .put<ResourceTemplate>(`${this.getBaseUrl()}/resourceTypes/${resourceTypeId}/relations/${relationId}/updateTemplate`, template, {
-        headers: this.getHeaders(),
-      })
+      .put<ResourceTemplate>(
+        `${this.getBaseUrl()}/resourceTypes/${resourceTypeId}/relations/${relationId}/updateTemplate`,
+        template,
+        {
+          headers: this.getHeaders(),
+        },
+      )
       .pipe(catchError(this.handleError));
   }
 }

--- a/AMW_angular/io/src/app/resources/services/resource.service.ts
+++ b/AMW_angular/io/src/app/resources/services/resource.service.ts
@@ -1,7 +1,7 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, startWith, Subject } from 'rxjs';
-import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
+import { Observable, of, startWith, Subject } from 'rxjs';
+import { catchError, finalize, map, shareReplay, switchMap } from 'rxjs/operators';
 import { Resource } from '../models/resource';
 import { Release } from '../models/release';
 import { Relation } from '../models/relation';
@@ -18,6 +18,8 @@ interface Named {
 @Injectable({ providedIn: 'root' })
 export class ResourceService extends BaseService {
   private http = inject(HttpClient);
+  private loadingResource = signal(false);
+  private resourceRequestId = 0;
 
   private resourceType$: Subject<ResourceType> = new Subject<ResourceType>();
   private resourceId$: Subject<number> = new Subject<number>();
@@ -30,8 +32,19 @@ export class ResourceService extends BaseService {
     shareReplay(1),
   );
 
-  private resourceById$: Observable<Resource> = this.resourceId$.pipe(
-    switchMap((id: number) => this.getResource(id)),
+  private resourceById$: Observable<Resource | null> = this.resourceId$.pipe(
+    switchMap((id: number) => {
+      const requestId = ++this.resourceRequestId;
+      this.loadingResource.set(true);
+      return this.getResource(id).pipe(
+        finalize(() => {
+          if (requestId === this.resourceRequestId) {
+            this.loadingResource.set(false);
+          }
+        }),
+        catchError(() => of(null)),
+      );
+    }),
     shareReplay(1),
   );
 
@@ -47,6 +60,7 @@ export class ResourceService extends BaseService {
     initialValue: [] as Release[],
   });
   resource = toSignal(this.resourceById$, { initialValue: null });
+  isLoadingResource = this.loadingResource.asReadonly();
 
   setTypeForResourceGroupList(resourcesType: ResourceType) {
     this.resourceType$.next(resourcesType);

--- a/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.component.html
+++ b/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,14 @@
+<div class="modal-header">
+  <h3 class="modal-title">{{ title() }}</h3>
+</div>
+<div class="modal-body">
+  <p>{{ message() }}</p>
+</div>
+<div class="modal-footer">
+  <app-button [variant]="'light'" [size]="'sm'" [dataTestId]="'button-confirm-dialog-cancel'" (click)="onCancel()">
+    {{ cancelLabel() }}
+  </app-button>
+  <app-button [variant]="'primary'" [size]="'sm'" [dataTestId]="'button-confirm-dialog-confirm'" (click)="onConfirm()">
+    {{ confirmLabel() }}
+  </app-button>
+</div>

--- a/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.component.ts
+++ b/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,33 @@
+import { Component, inject, signal } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { ButtonComponent } from '../button/button.component';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [ButtonComponent],
+  templateUrl: './confirm-dialog.component.html',
+})
+export class ConfirmDialogComponent {
+  activeModal = inject(NgbActiveModal);
+
+  title = signal('Confirm');
+  message = signal('');
+  confirmLabel = signal('Confirm');
+  cancelLabel = signal('Cancel');
+
+  configure(config: { title?: string; message: string; confirmLabel?: string; cancelLabel?: string }): void {
+    if (config.title) this.title.set(config.title);
+    this.message.set(config.message);
+    if (config.confirmLabel) this.confirmLabel.set(config.confirmLabel);
+    if (config.cancelLabel) this.cancelLabel.set(config.cancelLabel);
+  }
+
+  onCancel(): void {
+    this.activeModal.dismiss();
+  }
+
+  onConfirm(): void {
+    this.activeModal.close(true);
+  }
+}

--- a/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.service.ts
+++ b/AMW_angular/io/src/app/shared/confirm-dialog/confirm-dialog.service.ts
@@ -1,0 +1,20 @@
+import { inject, Injectable } from '@angular/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+@Injectable({ providedIn: 'root' })
+export class ConfirmDialogService {
+  private modalService = inject(NgbModal);
+
+  confirm(
+    message: string,
+    options?: { title?: string; confirmLabel?: string; cancelLabel?: string },
+  ): Promise<boolean> {
+    const modalRef = this.modalService.open(ConfirmDialogComponent, { size: 'sm' });
+    (modalRef.componentInstance as ConfirmDialogComponent).configure({ message, ...options });
+    return modalRef.result.then(
+      () => true,
+      () => false,
+    );
+  }
+}

--- a/AMW_angular/io/src/app/shared/elements/loading-tracker.service.ts
+++ b/AMW_angular/io/src/app/shared/elements/loading-tracker.service.ts
@@ -2,22 +2,31 @@ import { Injectable, signal } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class LoadingTrackerService {
-  private activeLoaders = signal(0);
+  private activeLoaders = signal<Set<symbol>>(new Set());
   private overlayOwner = signal<symbol | null>(null);
 
   startLoading(token: symbol) {
-    let count = 0;
-    this.activeLoaders.update((n) => (count = n + 1));
-    if (count === 1) {
+    this.activeLoaders.update((loaders) => {
+      if (loaders.has(token)) return loaders;
+      const next = new Set(loaders);
+      next.add(token);
+      return next;
+    });
+    if (this.overlayOwner() === null) {
       this.overlayOwner.set(token);
     }
   }
 
   stopLoading(token: symbol) {
-    let count = 0;
-    this.activeLoaders.update((n) => (count = Math.max(0, n - 1)));
-    if (count === 0) {
-      this.overlayOwner.set(null);
+    this.activeLoaders.update((loaders) => {
+      if (!loaders.has(token)) return loaders;
+      const next = new Set(loaders);
+      next.delete(token);
+      return next;
+    });
+    if (this.overlayOwner() === token) {
+      const remaining = this.activeLoaders();
+      this.overlayOwner.set(remaining.values().next().value ?? null);
     }
   }
 

--- a/AMW_e2e/tests/resource-edit.spec.ts
+++ b/AMW_e2e/tests/resource-edit.spec.ts
@@ -21,9 +21,7 @@ test.describe.serial("Resource Edit Page - Properties", () => {
     await saveButton.click();
   });
 
-  test("should reset property to parent context value", async ({
-    page,
-  }) => {
+  test("should reset property to parent context value", async ({ page }) => {
     await page.getByRole("button", { name: "DEV" }).click();
     await page.waitForURL(/ctx=\d+/); // Wait for context switch
 
@@ -105,7 +103,10 @@ test.describe("Resource Edit Page - Releases", () => {
     const releasesHeader = page.getByRole("heading", { name: "Releases" });
     await expect(releasesHeader).toBeVisible({ timeout: 15000 });
     await releasesHeader.click();
-    const newReleaseButton = page.getByRole("button", { name: "New Release", exact: true });
+    const newReleaseButton = page.getByRole("button", {
+      name: "New Release",
+      exact: true,
+    });
     await expect(newReleaseButton).toBeVisible({ timeout: 5000 });
     await expect(newReleaseButton).toBeEnabled();
     await expect(page.getByRole("cell", { name: "RL-" })).toBeVisible();
@@ -124,6 +125,7 @@ test.describe("Resource Edit Page - Validation", () => {
 
     const saveButton = page.getByRole("button", { name: "Save" });
     await expect(saveButton).toBeVisible(); // Wait for button to appear
-    await expect(saveButton).toBeDisabled();
+    await expect(saveButton).toBeEnabled();
+    await expect(page.getByText("This field is required")).toBeVisible();
   });
 });


### PR DESCRIPTION
  - Preserve editable fields after context and relation switches
  - Add discard confirmation dialogs for unsaved changes
  - Allow saving changed values with validation errors
  - Prevent phantom changes for null and empty values
  - Keep loading indicators active across overlapping requests
  - Make loading ownership token-based and webview-compatible
  - Add regression coverage for property and relation state handling
  - discard unsafed edits, block while loading